### PR TITLE
Use `clap` and `cargo_metadata` to solve many problems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,12 +9,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "camino"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f3132262930b0522068049f5870a856ab8affc80c70d08b6ecb785771a6fc23"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cargo-public-items"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "cargo_metadata",
  "cargo_toml",
+ "clap",
  "public_items",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -29,10 +85,122 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f8c0e2a6b902acc18214e24a6935cdaf8a8e34231913d4404dcaee659f65a1"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d42c94ce7c2252681b5fed4d3627cc807b13dfc033246bd05d5b252399000e"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+
+[[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -80,6 +248,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
+name = "semver"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,6 +288,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +303,21 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thiserror"
@@ -155,3 +353,40 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,9 @@ version = "0.4.0"
 
 [dependencies]
 anyhow = "1.0.53"
+cargo_metadata = "0.14.2"
 cargo_toml = "0.10.3"
+clap = { version = "3.1.2", features = ["derive"] }
 
 [dependencies.public_items]
 # path = "/Users/martin/src/public_items"

--- a/scripts/test-invocation-variants.sh
+++ b/scripts/test-invocation-variants.sh
@@ -5,7 +5,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cargo run
 
 # Make sure we can conveniently run the tool from the source dir on an external crate
-cargo run "$(pwd)"
+cargo run -- --manifest-path "$(pwd)"/Cargo.toml
 
 # Install the tool
 cargo install --debug --path .
@@ -14,10 +14,10 @@ cargo install --debug --path .
 cargo-public-items
 
 # Make sure we can run the tool on an external directory stand-alone
-cargo-public-items "$(pwd)"
+cargo-public-items --manifest-path "$(pwd)"/Cargo.toml
 
 # Make sure we can run the tool on the current directory as a cargo sub-command
 cargo public-items
 
 # Make sure we can run the tool on an external directory as a cargo sub-command
-cargo public-items "$(pwd)"
+cargo public-items --manifest-path "$(pwd)"/Cargo.toml

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,28 +4,57 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use public_items::Options;
 
+use clap::Parser;
+
+const MIN_NIGHTLY: &str = "nightly-2022-02-23";
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+pub struct Args {
+    /// Raise this flag to make items part of blanket implementations such as
+    /// `impl<T> Any for T`, `impl<T> Borrow<T> for T`, and `impl<T, U> Into<U>
+    /// for T where U: From<T>` be included in the list of public items of a
+    /// crate.
+    ///
+    /// Blanket implementations are not included by default since the the vast
+    /// majority of users will find the presence of these items to just
+    /// constitute noise, even if they formally are part of the public API of a
+    /// crate.
+    #[clap(long)]
+    with_blanket_implementations: bool,
+
+    /// Path to `Cargo.toml`.
+    #[clap(long, default_value = "Cargo.toml")]
+    manifest_path: PathBuf,
+}
+
 fn main() -> Result<()> {
-    let crate_root = crate_root()?;
-    let mut manifest_path = crate_root.clone();
-    manifest_path.push("Cargo.toml");
+    let args = get_args();
 
     // Invoke `cargo doc` to build rustdoc JSON
-    build_rustdoc_json(&manifest_path)?;
+    build_rustdoc_json(&args.manifest_path)?;
 
     // Use the `public_items` crate to list all public items (the public API)
-    let lib_name = package_name(&manifest_path)?;
-    print_public_api_items(&rustdoc_json_path_for_name(&crate_root, &lib_name))?;
+    // after settings things up a bit
+    let target_directory = get_target_directory(&args.manifest_path)?;
+    let lib_name = package_name(&args.manifest_path)?;
+    let json_path = rustdoc_json_path_for_name(&target_directory, &lib_name);
+    let options = get_options(&args);
+    print_public_api_items(&json_path, options)?;
 
     Ok(())
 }
 
-/// Returns the root of the crate to analyze. Defaults to current dir. Otherwise
-/// uses the path of the first argument to the program.
-fn crate_root() -> Result<PathBuf> {
-    Ok(match std::env::args_os().nth(1) {
-        Some(crate_root) if crate_root != "public-items" => PathBuf::from(crate_root),
-        _ => std::env::current_dir().with_context(|| "Failed to get current dir")?,
-    })
+/// Get CLI args via `clap` while also handling when we are invoked as a cargo
+/// subcommand
+fn get_args() -> Args {
+    // If we are invoked by cargo as `cargo public-items`, the second arg will
+    // be "public-items". Remove it before passing args on to clap. If we are
+    // not invoked as a cargo subcommand, it will not be part of args at all, so
+    // it is safe to filter it out also in that case.
+    let args = std::env::args_os().filter(|x| x != "public-items");
+
+    Args::parse_from(args)
 }
 
 /// Synchronously generate the rustdoc JSON for the library crate in the current
@@ -52,24 +81,48 @@ fn package_name(path: impl AsRef<Path>) -> Result<String> {
         .name)
 }
 
+/// Typically returns the absolute path to the regular cargo `./target` directory.
+fn get_target_directory(manifest_path: &Path) -> Result<PathBuf> {
+    let mut metadata_cmd = cargo_metadata::MetadataCommand::new();
+    metadata_cmd.manifest_path(&manifest_path);
+    let metadata = metadata_cmd.exec()?;
+
+    Ok(metadata.target_directory.as_std_path().to_owned())
+}
+
+/// Figure out what [`Options`] to pass to
+/// [`public_items::sorted_public_items_from_rustdoc_json_str`] based on our
+/// [`Args`]
+fn get_options(args: &Args) -> Options {
+    let mut options = Options::default();
+    options.with_blanket_implementations = args.with_blanket_implementations;
+    options
+}
+
 /// Returns `./target/doc/crate_name.json`. Also takes care of transforming
 /// `crate-name` to `crate_name`.
-fn rustdoc_json_path_for_name(crate_root: &Path, lib_name: &str) -> PathBuf {
-    let mut rustdoc_json_path = crate_root.to_owned();
-    rustdoc_json_path.push("target");
+fn rustdoc_json_path_for_name(target_directory: &Path, lib_name: &str) -> PathBuf {
+    let mut rustdoc_json_path = target_directory.to_owned();
     rustdoc_json_path.push("doc");
     rustdoc_json_path.push(lib_name.replace('-', "_"));
     rustdoc_json_path.set_extension("json");
     rustdoc_json_path
 }
 
-/// Prints all public API items. Sorted.
-fn print_public_api_items(path: &Path) -> Result<()> {
-    let rustdoc_json = &std::fs::read_to_string(path)
-        .with_context(|| format!("Failed to read rustdoc JSON at {:?}", path))?;
+/// Prints all public API items.
+fn print_public_api_items(path: &Path, options: Options) -> Result<()> {
+    let rustdoc_json = &std::fs::read_to_string(path).with_context(|| {
+        format!(
+            "Failed to read rustdoc JSON at {:?}.\n\
+             This version of `cargo public-items` requires at least:\n\n    {}.\n\n\
+             If you have that, it might be `cargo public-items` that is out of date. Try\n\
+             to install the latest versions with `cargo install cargo-public-items`,",
+            path, MIN_NIGHTLY
+        )
+    })?;
 
     let public_items =
-        public_items::sorted_public_items_from_rustdoc_json_str(rustdoc_json, Options::default())
+        public_items::sorted_public_items_from_rustdoc_json_str(rustdoc_json, options)
             .with_context(|| format!("Failed to parse rustdoc JSON at {:?}", path))?;
 
     for public_item in public_items {


### PR DESCRIPTION
Some problems that are now solved
* Workspaced crates are now supported
* Users can get `--help`
* Support `--with-blanket-implementations`