### PR TITLE
Support output formats "plain" (with and without colors) and "markdown"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,7 +62,9 @@ dependencies = [
 name = "cargo-public-items"
 version = "0.7.1"
 dependencies = [
+ "ansi_term",
  "anyhow",
+ "atty",
  "cargo_metadata",
  "cargo_toml",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,7 @@ dependencies = [
  "clap",
  "predicates",
  "public_items",
+ "serial_test",
 ]
 
 [[package]]
@@ -130,6 +131,12 @@ dependencies = [
  "serde_derive",
  "toml",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -220,6 +227,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +261,16 @@ name = "libc"
 version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+
+[[package]]
+name = "lock_api"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "memchr"
@@ -274,6 +300,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -361,6 +412,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,10 +453,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
@@ -437,6 +509,36 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "serial_test"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bcc41d18f7a1d50525d080fd3e953be87c4f9f1a974f3c21798ca00d54ec15"
+dependencies = [
+ "lazy_static",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2881bccd7d60fb32dfa3d7b3136385312f8ad75e2674aab2852867a09790cae8"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ version = "0.7.1"
 [dev-dependencies]
 assert_cmd = "2.0.4"
 predicates = "2.1.1"
+serial_test = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,9 @@ repository = "https://github.com/Enselic/cargo-public-items"
 version = "0.7.1"
 
 [dependencies]
+ansi_term = "0.12.1"
 anyhow = "1.0.53"
+atty = "0.2.14"
 cargo_metadata = "0.14.2"
 cargo_toml = "0.11.4"
 clap = { version = "3.1.2", features = ["derive"] }

--- a/scripts/test-invocation-variants.sh
+++ b/scripts/test-invocation-variants.sh
@@ -35,10 +35,16 @@ if [ -d "${HOME}/src/public_items" ]; then
     cargo public-items --diff-git-checkouts v0.0.4 v0.0.5
 
     git stash
+    cargo public-items --diff-git-checkouts v0.0.4 v0.0.5 --color=never
+
+    git stash
     cargo public-items --diff-git-checkouts v0.2.0 v0.3.0
 
     git stash
     cargo public-items --diff-git-checkouts v0.3.0 v0.4.0
+
+    git stash
+    cargo public-items --diff-git-checkouts v0.3.0 v0.4.0 --output-format markdown
 
     if [ -n "${original_branch}" ]; then
         git checkout "${original_branch}"

--- a/scripts/test-invocation-variants.sh
+++ b/scripts/test-invocation-variants.sh
@@ -21,29 +21,3 @@ cargo public-items
 
 # Make sure we can run the tool on an external directory as a cargo sub-command
 cargo public-items --manifest-path "$(pwd)"/Cargo.toml
-
-# Make sure diffing works
-if [ -d "${HOME}/src/public_items" ]; then
-    cd ~/src/public_items
-
-    original_branch=$(git branch --show-current)
-
-    git stash
-    cargo public-items --diff-git-checkouts v0.0.4 v0.0.5
-
-    git stash
-    cargo public-items --diff-git-checkouts v0.0.4 v0.0.5 --color=never
-
-    git stash
-    cargo public-items --diff-git-checkouts v0.2.0 v0.3.0
-
-    git stash
-    cargo public-items --diff-git-checkouts v0.3.0 v0.4.0
-
-    git stash
-    cargo public-items --diff-git-checkouts v0.3.0 v0.4.0 --output-format markdown
-
-    if [ -n "${original_branch}" ]; then
-        git checkout "${original_branch}"
-    fi
-fi

--- a/src/arg_types.rs
+++ b/src/arg_types.rs
@@ -1,0 +1,67 @@
+use anyhow::anyhow;
+
+use std::str::FromStr;
+
+use crate::{markdown::Markdown, output_formatter::OutputFormatter, plain::Plain};
+
+#[derive(Debug)]
+pub enum OutputFormat {
+    Plain,
+    Markdown,
+}
+
+impl FromStr for OutputFormat {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "plain" {
+            Ok(OutputFormat::Plain)
+        } else if s == "markdown" {
+            Ok(OutputFormat::Markdown)
+        } else {
+            Err(anyhow!("See --help"))
+        }
+    }
+}
+
+impl OutputFormat {
+    pub fn formatter(&self) -> Box<dyn OutputFormatter> {
+        match self {
+            OutputFormat::Plain => Box::new(Plain),
+            OutputFormat::Markdown => Box::new(Markdown),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Color {
+    Auto,
+    Never,
+    Always,
+}
+
+impl FromStr for Color {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "auto" {
+            Ok(Color::Auto)
+        } else if s == "never" {
+            Ok(Color::Never)
+        } else if s == "always" {
+            Ok(Color::Always)
+        } else {
+            Err(anyhow!("See --help"))
+        }
+    }
+}
+
+impl Color {
+    pub fn active(&self) -> bool {
+        match self {
+            Color::Auto => atty::is(atty::Stream::Stdout), // We should not assume Stdout here, but good enough for now
+            Color::Never => false,
+            Color::Always => true,
+        }
+    }
+}

--- a/src/arg_types.rs
+++ b/src/arg_types.rs
@@ -14,12 +14,10 @@ impl FromStr for OutputFormat {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == "plain" {
-            Ok(OutputFormat::Plain)
-        } else if s == "markdown" {
-            Ok(OutputFormat::Markdown)
-        } else {
-            Err(anyhow!("See --help"))
+        match s {
+            "plain" => Ok(OutputFormat::Plain),
+            "markdown" => Ok(OutputFormat::Markdown),
+            _ => Err(anyhow!("See --help")),
         }
     }
 }
@@ -44,14 +42,11 @@ impl FromStr for Color {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == "auto" {
-            Ok(Color::Auto)
-        } else if s == "never" {
-            Ok(Color::Never)
-        } else if s == "always" {
-            Ok(Color::Always)
-        } else {
-            Err(anyhow!("See --help"))
+        match s {
+            "auto" => Ok(Color::Auto),
+            "never" => Ok(Color::Never),
+            "always" => Ok(Color::Always),
+            _ => Err(anyhow!("See --help")),
         }
     }
 }

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -1,53 +1,48 @@
-use public_items::diff::PublicItemsDiff;
+use std::io::{Result, Write};
 
-pub fn print_diff(w: &mut impl std::io::Write, diff: &PublicItemsDiff) -> std::io::Result<()> {
-    if diff.removed.is_empty() && diff.changed.is_empty() && diff.added.is_empty() {
-        return writeln!(w, "(No changes to the public API)");
+use public_items::{diff::PublicItemsDiff, PublicItem};
+
+use crate::{output_formatter::print_items_with_header, Args, OutputFormatter};
+
+pub struct Markdown;
+
+impl OutputFormatter for Markdown {
+    fn print_items(&self, _w: &mut dyn Write, _args: &Args, _items: Vec<PublicItem>) -> Result<()> {
+        todo!("Not yet implemented because I'm not sure what the output should look like. Feel free to open a PR with a proposal.")
     }
 
-    print_items_with_header(
-        w,
-        "## Removed items from the public API",
-        &diff.removed,
-        |w, item| writeln!(w, "* `{}`", item),
-    )?;
-
-    print_items_with_header(
-        w,
-        "## Changed items in the public API",
-        &diff.changed,
-        |w, changed_item| {
-            writeln!(
-                w,
-                "* `{}` changed to\n  `{}`",
-                changed_item.old, changed_item.new
-            )
-        },
-    )?;
-
-    print_items_with_header(
-        w,
-        "## Added items to the public API",
-        &diff.added,
-        |w, item| writeln!(w, "* `{}`", item),
-    )?;
-
-    Ok(())
-}
-
-fn print_items_with_header<W: std::io::Write, T>(
-    w: &mut W,
-    header: &str,
-    items: &[T],
-    print_fn: impl Fn(&mut W, &T) -> std::io::Result<()>,
-) -> std::io::Result<()> {
-    writeln!(w, "{}", header)?;
-    if items.is_empty() {
-        writeln!(w, "(none)")?;
-    } else {
-        for item in items {
-            print_fn(w, item)?;
+    fn print_diff(&self, w: &mut dyn Write, _args: &Args, diff: &PublicItemsDiff) -> Result<()> {
+        if diff.removed.is_empty() && diff.changed.is_empty() && diff.added.is_empty() {
+            return writeln!(w, "(No changes to the public API)");
         }
+
+        print_items_with_header(
+            w,
+            "## Removed items from the public API",
+            &diff.removed,
+            |w, item| writeln!(w, "* `{}`", item),
+        )?;
+
+        print_items_with_header(
+            w,
+            "## Changed items in the public API",
+            &diff.changed,
+            |w, changed_item| {
+                writeln!(
+                    w,
+                    "* `{}` changed to\n  `{}`",
+                    changed_item.old, changed_item.new
+                )
+            },
+        )?;
+
+        print_items_with_header(
+            w,
+            "## Added items to the public API",
+            &diff.added,
+            |w, item| writeln!(w, "* `{}`", item),
+        )?;
+
+        Ok(())
     }
-    writeln!(w)
 }

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -7,8 +7,10 @@ use crate::{output_formatter::print_items_with_header, Args, OutputFormatter};
 pub struct Markdown;
 
 impl OutputFormatter for Markdown {
-    fn print_items(&self, _w: &mut dyn Write, _args: &Args, _items: Vec<PublicItem>) -> Result<()> {
-        todo!("Not yet implemented because I'm not sure what the output should look like. Feel free to open a PR with a proposal.")
+    fn print_items(&self, w: &mut dyn Write, _args: &Args, items: Vec<PublicItem>) -> Result<()> {
+        print_items_with_header(w, "## Public API", &items, |w, item| {
+            writeln!(w, "* `{}`", item)
+        })
     }
 
     fn print_diff(&self, w: &mut dyn Write, _args: &Args, diff: &PublicItemsDiff) -> Result<()> {

--- a/src/output_formatter.rs
+++ b/src/output_formatter.rs
@@ -1,0 +1,27 @@
+use std::io::{Result, Write};
+
+use public_items::{diff::PublicItemsDiff, PublicItem};
+
+use crate::Args;
+
+pub trait OutputFormatter {
+    fn print_items(&self, w: &mut dyn Write, args: &Args, items: Vec<PublicItem>) -> Result<()>;
+    fn print_diff(&self, w: &mut dyn Write, args: &Args, diff: &PublicItemsDiff) -> Result<()>;
+}
+
+pub fn print_items_with_header<T>(
+    w: &mut dyn Write,
+    header: &str,
+    items: &[T],
+    print_fn: impl Fn(&mut dyn Write, &T) -> Result<()>,
+) -> Result<()> {
+    writeln!(w, "{}", header)?;
+    if items.is_empty() {
+        writeln!(w, "(none)")?;
+    } else {
+        for item in items {
+            print_fn(w, item)?;
+        }
+    }
+    writeln!(w)
+}

--- a/src/plain.rs
+++ b/src/plain.rs
@@ -1,0 +1,75 @@
+use std::io::{Result, Write};
+
+use public_items::{diff::PublicItemsDiff, PublicItem};
+
+use ansi_term::Color;
+
+use crate::{
+    output_formatter::{print_items_with_header, OutputFormatter},
+    Args,
+};
+
+pub struct Plain;
+
+impl OutputFormatter for Plain {
+    fn print_items(&self, w: &mut dyn Write, _args: &Args, items: Vec<PublicItem>) -> Result<()> {
+        for item in items {
+            writeln!(w, "{}", item)?;
+        }
+
+        Ok(())
+    }
+
+    fn print_diff(&self, w: &mut dyn Write, args: &Args, diff: &PublicItemsDiff) -> Result<()> {
+        let use_color = args.color.active();
+
+        print_items_with_header(
+            w,
+            "Removed items from the public API\n\
+             =================================",
+            &diff.removed,
+            |w, item| {
+                if use_color {
+                    writeln!(w, "{}", Color::Red.paint(item.to_string()))
+                } else {
+                    writeln!(w, "-{}", item)
+                }
+            },
+        )?;
+
+        print_items_with_header(
+            w,
+            "Changed items in the public API\n\
+             ===============================",
+            &diff.changed,
+            |w, changed_item| {
+                if use_color {
+                    writeln!(
+                        w,
+                        "{}\n{}",
+                        Color::Red.paint(changed_item.old.to_string()),
+                        Color::Green.paint(changed_item.new.to_string())
+                    )
+                } else {
+                    writeln!(w, "-{}\n+{}", changed_item.old, changed_item.new)
+                }
+            },
+        )?;
+
+        print_items_with_header(
+            w,
+            "Added items to the public API\n\
+             =============================",
+            &diff.added,
+            |w, item| {
+                if use_color {
+                    writeln!(w, "{}", Color::Green.paint(item.to_string()))
+                } else {
+                    writeln!(w, "+{}", item)
+                }
+            },
+        )?;
+
+        Ok(())
+    }
+}

--- a/tests/bin_tests.rs
+++ b/tests/bin_tests.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use assert_cmd::Command;
+use serial_test::serial;
 
 #[test]
 fn list_public_items() {
@@ -14,6 +15,143 @@ fn list_public_items_explicit_manifest_path() {
     cmd.arg("--manifest-path");
     cmd.arg(current_dir_and("Cargo.toml"));
     assert_presence_of_own_library_items(cmd);
+}
+
+// We must serially run tests that touch the test crate git repo to prevent
+// ".git/index.lock: File exists"-errors.
+#[serial]
+#[test]
+fn diff_public_items() {
+    ensure_test_crate_is_cloned();
+
+    let mut cmd = Command::cargo_bin("cargo-public-items").unwrap();
+    cmd.current_dir(test_crate_path());
+    cmd.arg("--color=never");
+    cmd.arg("--diff-git-checkouts");
+    cmd.arg("v0.0.4");
+    cmd.arg("v0.0.5");
+    cmd.assert()
+        .stdout(
+            "Removed items from the public API\n\
+             =================================\n\
+             -pub fn public_items::from_rustdoc_json_str(rustdoc_json_str: &str) -> Result<HashSet<String>>\n\
+             \n\
+             Changed items in the public API\n\
+             ===============================\n\
+             (none)\n\
+             \n\
+             Added items to the public API\n\
+             =============================\n\
+             +pub fn public_items::sorted_public_items_from_rustdoc_json_str(rustdoc_json_str: &str) -> Result<Vec<String>>\n\
+             \n\
+            ",
+        )
+        .success();
+}
+
+#[serial]
+#[test]
+fn diff_public_items_with_color() {
+    ensure_test_crate_is_cloned();
+
+    let mut cmd = Command::cargo_bin("cargo-public-items").unwrap();
+    cmd.current_dir(test_crate_path());
+    cmd.arg("--color=always");
+    cmd.arg("--diff-git-checkouts");
+    cmd.arg("v0.6.0");
+    cmd.arg("v0.7.1");
+    cmd.assert()
+        .stdout(
+            "Removed items from the public API\n\
+             =================================\n\
+             \x1b[31mpub fn public_items::PublicItem::hash<__H: $crate::hash::Hasher>(&self, state: &mut __H) -> ()\x1b[0m\n\
+             \x1b[31mpub fn public_items::diff::PublicItemsDiff::print_with_headers(&self, w: &mut impl std::io::Write, header_removed: &str, header_changed: &str, header_added: &str) -> std::io::Result<()>\x1b[0m\n\
+             \n\
+             Changed items in the public API\n\
+             ===============================\n\
+             \x1b[31mpub fn public_items::PublicItem::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result\x1b[0m\n\
+             \x1b[32mpub fn public_items::PublicItem::fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result\x1b[0m\n\
+             \x1b[31mpub fn public_items::diff::PublicItemsDiff::between(old: Vec<PublicItem>, new: Vec<PublicItem>) -> Self\x1b[0m\n\
+             \x1b[32mpub fn public_items::diff::PublicItemsDiff::between(old_items: Vec<PublicItem>, new_items: Vec<PublicItem>) -> Self\x1b[0m\n\
+             \n\
+             Added items to the public API\n\
+             =============================\n\
+             \x1b[32mpub fn public_items::diff::ChangedPublicItem::cmp(&self, other: &ChangedPublicItem) -> $crate::cmp::Ordering\x1b[0m\n\
+             \x1b[32mpub fn public_items::diff::ChangedPublicItem::eq(&self, other: &ChangedPublicItem) -> bool\x1b[0m\n\
+             \x1b[32mpub fn public_items::diff::ChangedPublicItem::ne(&self, other: &ChangedPublicItem) -> bool\x1b[0m\n\
+             \x1b[32mpub fn public_items::diff::ChangedPublicItem::partial_cmp(&self, other: &ChangedPublicItem) -> $crate::option::Option<$crate::cmp::Ordering>\x1b[0m\n\
+             \x1b[32mpub fn public_items::diff::PublicItemsDiff::eq(&self, other: &PublicItemsDiff) -> bool\x1b[0m\n\
+             \x1b[32mpub fn public_items::diff::PublicItemsDiff::ne(&self, other: &PublicItemsDiff) -> bool\x1b[0m\n\
+            \n\
+            ",
+        )
+        .success();
+}
+
+#[serial]
+#[test]
+fn diff_public_items_markdown() {
+    ensure_test_crate_is_cloned();
+
+    let mut cmd = Command::cargo_bin("cargo-public-items").unwrap();
+    cmd.current_dir(test_crate_path());
+    cmd.arg("--output-format=markdown");
+    cmd.arg("--diff-git-checkouts");
+    cmd.arg("v0.6.0");
+    cmd.arg("v0.7.1");
+    cmd.assert()
+        .stdout(r"## Removed items from the public API
+* `pub fn public_items::PublicItem::hash<__H: $crate::hash::Hasher>(&self, state: &mut __H) -> ()`
+* `pub fn public_items::diff::PublicItemsDiff::print_with_headers(&self, w: &mut impl std::io::Write, header_removed: &str, header_changed: &str, header_added: &str) -> std::io::Result<()>`
+
+## Changed items in the public API
+* `pub fn public_items::PublicItem::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result` changed to
+  `pub fn public_items::PublicItem::fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result`
+* `pub fn public_items::diff::PublicItemsDiff::between(old: Vec<PublicItem>, new: Vec<PublicItem>) -> Self` changed to
+  `pub fn public_items::diff::PublicItemsDiff::between(old_items: Vec<PublicItem>, new_items: Vec<PublicItem>) -> Self`
+
+## Added items to the public API
+* `pub fn public_items::diff::ChangedPublicItem::cmp(&self, other: &ChangedPublicItem) -> $crate::cmp::Ordering`
+* `pub fn public_items::diff::ChangedPublicItem::eq(&self, other: &ChangedPublicItem) -> bool`
+* `pub fn public_items::diff::ChangedPublicItem::ne(&self, other: &ChangedPublicItem) -> bool`
+* `pub fn public_items::diff::ChangedPublicItem::partial_cmp(&self, other: &ChangedPublicItem) -> $crate::option::Option<$crate::cmp::Ordering>`
+* `pub fn public_items::diff::PublicItemsDiff::eq(&self, other: &PublicItemsDiff) -> bool`
+* `pub fn public_items::diff::PublicItemsDiff::ne(&self, other: &PublicItemsDiff) -> bool`
+
+",
+        )
+        .success();
+}
+
+#[serial]
+#[test]
+fn diff_public_items_markdown_no_changes() {
+    ensure_test_crate_is_cloned();
+
+    let mut cmd = Command::cargo_bin("cargo-public-items").unwrap();
+    cmd.current_dir(test_crate_path());
+    cmd.arg("--output-format=markdown");
+    cmd.arg("--diff-git-checkouts");
+    cmd.arg("v0.2.0");
+    cmd.arg("v0.3.0");
+    cmd.assert()
+        .stdout("(No changes to the public API)\n")
+        .success();
+}
+
+#[test]
+fn list_public_items_markdown() {
+    let mut cmd = Command::cargo_bin("cargo-public-items").unwrap();
+    cmd.arg("--output-format=markdown");
+    cmd.assert()
+        .stdout(
+            "## Public API\n\
+             * `pub fn cargo_public_items::for_self_testing_purposes_please_ignore()`\n\
+             * `pub mod cargo_public_items`\n\
+             \n\
+             ",
+        )
+        .success();
 }
 
 #[test]
@@ -48,8 +186,50 @@ fn assert_presence_of_args_in_help(mut cmd: Command) {
         .success();
 }
 
+fn ensure_test_crate_is_cloned() {
+    let path = test_crate_path();
+    if path.exists() {
+        print!("INFO: using ");
+    } else {
+        print!("INFO: cloning into ");
+        clone_test_crate(&path);
+    }
+    // Print info about repo when running like this: cargo test -- --nocapture
+    println!("'{}'", &path.to_string_lossy());
+}
+
+/// Helper to get the absolute path to a given path, relative to the current
+/// path
 fn current_dir_and<P: AsRef<Path>>(path: P) -> PathBuf {
     let mut cur_dir = std::env::current_dir().unwrap();
     cur_dir.push(path);
     cur_dir
+}
+
+/// Helper to clone the test crate git repo to the proper place
+fn clone_test_crate(dest: &Path) {
+    let mut git = std::process::Command::new("git");
+    git.arg("clone");
+    git.arg("https://github.com/Enselic/public_items.git");
+    git.arg("-b");
+    git.arg("v0.7.1");
+    git.arg("--single-branch");
+    git.arg(dest);
+    assert!(git.spawn().unwrap().wait().unwrap().success());
+}
+
+/// Path to the git cloned test crate we use to test the diffing functionality
+fn test_crate_path() -> PathBuf {
+    let mut path = get_cache_dir();
+    path.push("cargo-public-items-test-repo");
+    path
+}
+
+/// Where to put things that survives across test runs. For example a git cloned
+/// test crate. We don't want to clone it every time we run tests.
+fn get_cache_dir() -> PathBuf {
+    // See https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
+    option_env!("CARGO_TARGET_TMPDIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir)
 }


### PR DESCRIPTION
This PR makes diffing use colors by default:
<img width="812" alt="Skärmavbild 2022-04-01 kl  17 09 04" src="https://user-images.githubusercontent.com/115040/161291288-bc7e8aed-e6f6-4c5e-8d8b-d92a627fdf22.png">

But if you pipe to a file (or pass `--color=never`) then the tool will use + and - instead of red and green:
<img width="844" alt="Skärmavbild 2022-04-01 kl  17 09 22" src="https://user-images.githubusercontent.com/115040/161291389-c3d7222d-377f-4395-a430-f9c2792eb41f.png">

