### PR TITLE
README: Mention MINIMUM_RUSTDOC_JSON_VERSION in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # cargo-public-api
 
-List and diff the public API of Rust library crates between releases and commits. Allows you to detect breaking API changes and semver violations. Relies on and automatically builds rustdoc JSON, for which a recent version of the Rust nighty toolchain must be installed. See [here](https://github.com/Enselic/public_items#compatibility-matrix) for information about exactly how recent.
+List and diff the public API of Rust library crates between releases and commits. Allows you to detect breaking API changes and semver violations. Relies on and automatically builds rustdoc JSON, for which a recent version of the Rust nighty toolchain must be installed.
 
 # Installation
 
 ```
-# Install cargo-public-api, which builds with stable Rust
+# Install cargo-public-api with the regular stable Rust toolchain
 cargo install cargo-public-api
 
-# Install a recent version of nightly so that rustdoc JSON can be built automatically by cargo-public-api
+# Install nightly-2022-03-14 or later so that rustdoc JSON can be built automatically by cargo-public-api
 rustup install nightly
 ```
 

--- a/tests/readme_tests.rs
+++ b/tests/readme_tests.rs
@@ -1,0 +1,9 @@
+use public_items::MINIMUM_RUSTDOC_JSON_VERSION;
+
+#[test]
+fn installation_instructions_mentions_minimum_rustdoc_json_version() {
+    let readme = include_str!("../README.md");
+    let expected_installation_instruction =
+        format!("# Install {} or later", MINIMUM_RUSTDOC_JSON_VERSION);
+    assert!(readme.contains(&expected_installation_instruction));
+}


### PR DESCRIPTION
And add a test so we don't forget to update the instruction when we bump MINIMUM_RUSTDOC_JSON_VERSION next time.
