### PR TITLE
Use public-api which is new name of public_items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ dependencies = [
  "cargo_toml",
  "clap",
  "predicates",
- "public_items",
+ "public-api",
  "serial_test",
 ]
 
@@ -391,10 +391,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "public_items"
-version = "0.8.0"
+name = "public-api"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f8935068fb52bba0bd678a73785de62844c9b40cac8bcd681b9d285b2a3fe3"
+checksum = "0b20da6988dcc6a078d15fe9c21307fb54619a7e7961a6cdd38c25cfea8c983b"
 dependencies = [
  "rustdoc-types",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ cargo_metadata = "0.14.2"
 cargo_toml = "0.11.4"
 clap = { version = "3.1.2", features = ["derive"] }
 
-[dependencies.public_items]
-# path = "/Users/martin/src/public_items"
-version = "0.8.0"
+[dependencies.public-api]
+# path = "/Users/martin/src/public-api"
+version = "0.9.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ rustup install nightly
 
 # Usage
 
-## List public items
+## List public API
 
-This example lists the public items of the library that this cargo subcommand is implemented with. The example assumes that the git repository for the library is checked out to `~/src/public_items`. To print all items that make up the public API of your Rust library crate, simply do this:
+This example lists the public API of the library that this cargo subcommand is implemented with (before it was renamed to `public-api`). The example assumes that the git repository for the library is checked out to `~/src/public_items`. To print all items that make up the public API of your Rust library crate, simply do this:
 
 ```
 % cd ~/src/public_items
@@ -43,7 +43,7 @@ pub struct public_items::PublicItem
 pub type public_items::Result<T> = std::result::Result<T, Error>
 ```
 
-## Diff public items between commits
+## Diff public API between commits
 
 To diff two different versions of your API, use `--diff-git-checkouts` while standing in the git repo of your project.
 
@@ -79,4 +79,4 @@ See [development.md](./doc/development.md).
 
 # Implementation details
 
-This utility is implemented with and adds conveniences on top of the [public_items](https://crates.io/crates/public_items) library (https://github.com/Enselic/public_items).
+This utility is implemented with and adds conveniences on top of the [public-api](https://crates.io/crates/public-api) library (https://github.com/Enselic/public-api).

--- a/doc/development.md
+++ b/doc/development.md
@@ -1,12 +1,12 @@
 ## Tips to work on this tool
 
-This project has kinship with [`public_items`](https://github.com/Enselic/public_items). Here follows some tips on how to make it easier to work with both projects. This guides assumes you have cloned `public_items` to `~/src/public_items` and [`cargo-public-api`](https://github.com/Enselic/cargo-public-api) to `~/src/cargo-public-api`.
+This project shares kinship with [`public-api`](https://github.com/Enselic/public-api). Here follows some tips on how to make it easier to work with both projects. This guides assumes you have cloned `public-api` to `~/src/public-api` and [`cargo-public-api`](https://github.com/Enselic/cargo-public-api) to `~/src/cargo-public-api`.
 
-### Make `cargo public-api` use local changes of `public_items`
+### Make `cargo public-api` use local changes of `public-api`
 
 Uncomment
 ```toml
-# path = "/Users/martin/src/public_items"
+# path = "/Users/martin/src/public-api"
 ```
 in `~/src/cargo-public-api/Cargo.toml` and update the path so it fits your system.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
 /// For self-testing purposes. Please ignore.
 pub fn for_self_testing_purposes_please_ignore() {
-    println!("If you are looking for the library this tool uses, it can be found at https://github.com/Enselic/public_items");
+    println!("If you are looking for the library this tool uses, it can be found at https://github.com/Enselic/public-api");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context, Result};
 use output_formatter::OutputFormatter;
-use public_items::{
-    public_items_from_rustdoc_json_str, Options, PublicItem, MINIMUM_RUSTDOC_JSON_VERSION,
+use public_api::{
+    public_api_from_rustdoc_json_str, Options, PublicItem, MINIMUM_RUSTDOC_JSON_VERSION,
 };
 
 use clap::Parser;
@@ -40,13 +40,13 @@ pub struct Args {
     ///
     /// 1. Do a literal in-tree, in-place `git checkout` of the first commit
     ///
-    /// 2. Collect public items
+    /// 2. Collect public API
     ///
     /// 3. Do a literal in-tree, in-place `git checkout` of the second commit
     ///
-    /// 4. Collect public items
+    /// 4. Collect public API
     ///
-    /// 5. Print the diff between public items in step 2 and step 4
+    /// 5. Print the diff between public API in step 2 and step 4
     ///
     /// Do not use non-fixed commit references such as `HEAD^` since the meaning
     /// of `HEAD^` is different depending on what commit is the current commit.
@@ -101,7 +101,7 @@ fn print_public_items_diff_between_two_commits(args: &Args, commits: &[String]) 
     let new_commit = commits.get(1).expect("clap makes sure second commit exist");
     let new = collect_public_items(Some(new_commit))?;
 
-    let diff = public_items::diff::PublicItemsDiff::between(old, new);
+    let diff = public_api::diff::PublicItemsDiff::between(old, new);
     args.output_format
         .formatter()
         .print_diff(&mut stdout(), args, &diff)?;
@@ -213,7 +213,7 @@ fn collect_public_items(commit: Option<&str>) -> Result<Vec<PublicItem>> {
     let rustdoc_json = &std::fs::read_to_string(&json_path)
         .with_context(|| format!("Failed to read rustdoc JSON at {:?}", json_path))?;
 
-    public_items_from_rustdoc_json_str(rustdoc_json, options).with_context(|| {
+    public_api_from_rustdoc_json_str(rustdoc_json, options).with_context(|| {
         format!(
             "Failed to parse rustdoc JSON at {:?}.\n\
             This version of `cargo public-api` requires at least:\n\n    {}\n\n\

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -1,6 +1,6 @@
 use std::io::{Result, Write};
 
-use public_items::{diff::PublicItemsDiff, PublicItem};
+use public_api::{diff::PublicItemsDiff, PublicItem};
 
 use crate::{output_formatter::print_items_with_header, Args, OutputFormatter};
 

--- a/src/output_formatter.rs
+++ b/src/output_formatter.rs
@@ -1,6 +1,6 @@
 use std::io::{Result, Write};
 
-use public_items::{diff::PublicItemsDiff, PublicItem};
+use public_api::{diff::PublicItemsDiff, PublicItem};
 
 use crate::Args;
 

--- a/src/plain.rs
+++ b/src/plain.rs
@@ -1,6 +1,6 @@
 use std::io::{Result, Write};
 
-use public_items::{diff::PublicItemsDiff, PublicItem};
+use public_api::{diff::PublicItemsDiff, PublicItem};
 
 use ansi_term::Color;
 

--- a/tests/bin_tests.rs
+++ b/tests/bin_tests.rs
@@ -224,7 +224,7 @@ fn current_dir_and<P: AsRef<Path>>(path: P) -> PathBuf {
 fn clone_test_crate(dest: &Path) {
     let mut git = std::process::Command::new("git");
     git.arg("clone");
-    git.arg("https://github.com/Enselic/public_items.git");
+    git.arg("https://github.com/Enselic/public-api.git"); // Tests still use ld name `public_items`
     git.arg("-b");
     git.arg("v0.7.1");
     git.arg("--single-branch");

--- a/tests/readme_tests.rs
+++ b/tests/readme_tests.rs
@@ -1,4 +1,4 @@
-use public_items::MINIMUM_RUSTDOC_JSON_VERSION;
+use public_api::MINIMUM_RUSTDOC_JSON_VERSION;
 
 #[test]
 fn installation_instructions_mentions_minimum_rustdoc_json_version() {


### PR DESCRIPTION
Tests still use `public_items`. Would be nice to change that some day.