### PR TITLE
Bump to v0.11.2 so we can later try to release from the new repo structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-public-api"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "public-api"
-version = "0.11.0"
+version = "0.11.2"
 dependencies = [
  "assert_cmd",
  "cargo_metadata",

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "cargo-public-api"
 readme = "../README.md"
 repository = "https://github.com/Enselic/cargo-public-api"
-version = "0.11.1"
+version = "0.11.2"
 
 [dependencies]
 ansi_term = "0.12.1"
@@ -19,7 +19,7 @@ clap = { version = "3.1.2", features = ["derive"] }
 
 [dependencies.public-api]
 path = "../public-api"
-version = "0.11.0"
+version = "0.11.2"
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -6,9 +6,7 @@ homepage = "https://github.com/Enselic/public-api"
 license = "MIT"
 name = "public-api"
 repository = "https://github.com/Enselic/public-api"
-
-# Also update https://github.com/Enselic/public-api#compatibility-matrix
-version = "0.11.0"
+version = "0.11.2"
 
 [dependencies]
 serde = { version = "1.0.135", features = ["derive"] }


### PR DESCRIPTION
To see if we can make releases from the new repo structure.