### PR TITLE
Disable `serde_json` recursion limit

### DIFF
--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -9,9 +9,15 @@ repository = "https://github.com/Enselic/public-api"
 version = "0.11.3"
 
 [dependencies]
-serde = { version = "1.0.135", features = ["derive"] }
-serde_json = "1.0.77"
 thiserror = "1.0.29"
+
+[dependencies.serde]
+version = "1.0.135"
+features = ["derive"]
+
+[dependencies.serde_json]
+version = "1.0.77"
+features = ["unbounded_depth"]
 
 [dependencies.rustdoc-types]
 # path = "/Users/martin/src/rustdoc-types"


### PR DESCRIPTION
Otherwise we get this problem:

```
% cargo public-api # https://github.com/diesel-rs/diesel/tree/master/diesel with https://github.com/diesel-rs/diesel/pull/3190/files
Error: Failed to parse rustdoc JSON at "/Users/martin/src/diesel/target/doc/diesel.json".
Caused by:
    recursion limit exceeded at line 1 column 583841
```

Note that in order to generate rustdoc JSON for diesel, you currently need https://github.com/diesel-rs/diesel/pull/3190/files until https://github.com/rust-lang/rust/issues/93588 is fixed.

But nothing prevents us from taking care of this problem already now. I'm sure there are other crates out in the wild that suffers from the problem too.