### PR TITLE
Auto-derive `Eq` and `PartialEq` for `PublicItem`

### DIFF
--- a/public-api/src/item_iterator.rs
+++ b/public-api/src/item_iterator.rs
@@ -177,7 +177,7 @@ fn intermediate_public_item_to_public_item(
 /// of the public API of a crate. Implements [`Display`] so it can be printed. It
 /// also implements [`Ord`], but how items are ordered are not stable yet, and
 /// will change in later versions.
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct PublicItem {
     /// The "your_crate::mod_a::mod_b" part of an item. Split by "::"
     pub(crate) path: Vec<String>,
@@ -212,14 +212,6 @@ impl Display for PublicItem {
 pub(crate) fn tokens_to_string(tokens: &[Token]) -> String {
     tokens.iter().map(Token::text).collect()
 }
-
-impl PartialEq for PublicItem {
-    fn eq(&self, other: &Self) -> bool {
-        self.path == other.path && self.tokens == other.tokens
-    }
-}
-
-impl Eq for PublicItem {}
 
 impl PartialOrd for PublicItem {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {


### PR DESCRIPTION
The explicit implementation is identical to the derived one, and by
switching to a derived impl for these we can later make `PublicItem`
derive `Hash` without triggering
https://rust-lang.github.io/rust-clippy/master/index.html#derive_hash_xor_eq.

I'm playing around with fixing #50 with [`hashbag`](https://docs.rs/hashbag/latest/hashbag/) which requires `Hash`. Even if we end up not needing `Hash` later, I think this is a sensible simplifcation.