### PR TITLE
Rewrite diff algo with `hashbag` to fix off-by-one skewing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbag"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "021a178f0e7e9ff6f9312759b849f0fbadf22ee8666ac163d502a8496691c01a"
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,6 +441,8 @@ dependencies = [
  "assert_cmd",
  "cargo_metadata",
  "cargo_toml",
+ "hashbag",
+ "itertools",
  "pretty_assertions",
  "rustdoc-types",
  "serde",

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/Enselic/public-api"
 version = "0.11.4"
 
 [dependencies]
+hashbag = { version = "0.1.5", default-features = false }
 thiserror = "1.0.29"
 
 [dependencies.serde]
@@ -28,4 +29,5 @@ assert_cmd = "2.0.4"
 cargo_metadata = "0.14.2"
 cargo_toml = "0.11.5"
 pretty_assertions = "1.1.0"
+itertools = { version = "0.10.3", default-features = false }
 serial_test = "0.6.0"

--- a/public-api/src/diff/hashbag_utils.rs
+++ b/public-api/src/diff/hashbag_utils.rs
@@ -1,0 +1,148 @@
+//! This entire module is a vendoring/backport of [Implement
+//! `HashBag::difference(&self, other:
+//! &HashBag`](https://github.com/jonhoo/hashbag/pull/6)
+//!
+//! Once/if that PR is merged and made available through a new release of
+//! [`hashbag`](https://crates.io/crates/hashbag) we can remove all of this
+//! code.
+
+use hashbag::{HashBag, Iter};
+use std::{
+    collections::{hash_map::RandomState, HashMap},
+    hash::{BuildHasher, Hash},
+};
+
+pub trait DifferenceAddon<'a, T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher,
+{
+    fn difference(&'a self, other: &'a HashBag<T, S>) -> Difference<'a, T, S>;
+}
+
+impl<'a, T, S> DifferenceAddon<'a, T, S> for HashBag<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher,
+{
+    fn difference(&'a self, other: &'a HashBag<T, S>) -> Difference<'a, T, S> {
+        Difference {
+            base_iter: self.iter(),
+            other,
+            removed_from_other: HashMap::new(),
+        }
+    }
+}
+
+/// This `struct` is created by [`HashBag::difference`].
+/// See its documentation for more info.
+pub struct Difference<'a, T, S = RandomState> {
+    /// An iterator over "self"
+    base_iter: Iter<'a, T>,
+
+    /// The bag with entries we DO NOT want to return
+    other: &'a HashBag<T, S>,
+
+    /// Keeps track of many times we have conceptually "consumed" an entry from
+    /// `other`.
+    removed_from_other: HashMap<&'a T, usize>,
+}
+
+impl<'a, T, S> Iterator for Difference<'a, T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher,
+{
+    type Item = &'a T;
+
+    #[inline]
+    fn next(&mut self) -> Option<&'a T> {
+        loop {
+            let next = self.base_iter.next()?;
+            let removal_count = self.removed_from_other.entry(next).or_insert(0);
+
+            // Keep track of how many times we have removed the current entry.
+            // We don't actually remove anything, we just pretend we do.
+            *removal_count += 1;
+
+            // If we removed MORE entries from `other`, THEN we may start
+            // returning entries from the base iterator.
+            if *removal_count > self.other.contains(next) {
+                return Some(next);
+            }
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper_bound) = self.base_iter.size_hint();
+        (0, upper_bound)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_difference_from_empty() {
+        do_test_difference(&[], &[], &[]);
+        do_test_difference(&[], &[1], &[]);
+        do_test_difference(&[], &[1, 1], &[]);
+        do_test_difference(&[], &[1, 1, 2], &[]);
+    }
+
+    #[test]
+    fn test_difference_from_one() {
+        do_test_difference(&[1], &[], &[1]);
+        do_test_difference(&[1], &[1], &[]);
+        do_test_difference(&[1], &[1, 1], &[]);
+        do_test_difference(&[1], &[2], &[1]);
+        do_test_difference(&[1], &[1, 2], &[]);
+        do_test_difference(&[1], &[2, 2], &[1]);
+    }
+
+    #[test]
+    fn test_difference_from_duplicate_ones() {
+        do_test_difference(&[1, 1], &[], &[1, 1]);
+        do_test_difference(&[1, 1], &[1], &[1]);
+        do_test_difference(&[1, 1], &[1, 1], &[]);
+        do_test_difference(&[1, 1], &[2], &[1, 1]);
+        do_test_difference(&[1, 1], &[1, 2], &[1]);
+        do_test_difference(&[1, 1], &[2, 2], &[1, 1]);
+    }
+
+    #[test]
+    fn test_difference_from_one_one_two() {
+        do_test_difference(&[1, 1, 2], &[], &[1, 1, 2]);
+        do_test_difference(&[1, 1, 2], &[1], &[1, 2]);
+        do_test_difference(&[1, 1, 2], &[1, 1], &[2]);
+        do_test_difference(&[1, 1, 2], &[2], &[1, 1]);
+        do_test_difference(&[1, 1, 2], &[1, 2], &[1]);
+        do_test_difference(&[1, 1, 2], &[2, 2], &[1, 1]);
+    }
+
+    #[test]
+    fn test_difference_from_larger_bags() {
+        do_test_difference(&[1, 2, 2, 3], &[3], &[1, 2, 2]);
+        do_test_difference(&[1, 2, 2, 3], &[4], &[1, 2, 2, 3]);
+        do_test_difference(&[2, 2, 2, 2], &[2, 2], &[2, 2]);
+        do_test_difference(&[2, 2, 2, 2], &[], &[2, 2, 2, 2]);
+    }
+
+    fn do_test_difference(
+        self_entries: &[isize],
+        other_entries: &[isize],
+        expected_entries: &[isize],
+    ) {
+        let this = self_entries.iter().collect::<HashBag<_>>();
+        let other = other_entries.iter().collect::<HashBag<_>>();
+        let expected = expected_entries.iter().collect::<HashBag<_>>();
+        assert_eq!(
+            this.difference(&other)
+                .copied()
+                .collect::<HashBag<&isize>>(),
+            expected
+        );
+    }
+}

--- a/public-api/src/item_iterator.rs
+++ b/public-api/src/item_iterator.rs
@@ -7,6 +7,12 @@ use crate::{tokens::Token, Options};
 
 type Impls<'a> = HashMap<&'a Id, Vec<&'a Impl>>;
 
+/// Each public item has a path that is displayed like `first::second::third`.
+/// Internally we represent that with a `vec!["first", "second", "third"]`. This
+/// is a type alias for that internal representation to make the code easier to
+/// read.
+pub(crate) type PublicItemPath = Vec<String>;
+
 /// Iterates over all items in a crate. Iterating over items has the benefit of
 /// behaving properly when:
 /// 1. A single item is imported several times.
@@ -168,7 +174,7 @@ fn intermediate_public_item_to_public_item(
             .path()
             .iter()
             .map(|i| i.get_effective_name())
-            .collect::<Vec<String>>(),
+            .collect::<PublicItemPath>(),
         tokens: public_item.render_token_stream(),
     }
 }
@@ -180,7 +186,7 @@ fn intermediate_public_item_to_public_item(
 #[derive(Clone, Eq, PartialEq)]
 pub struct PublicItem {
     /// The "your_crate::mod_a::mod_b" part of an item. Split by "::"
-    pub(crate) path: Vec<String>,
+    pub(crate) path: PublicItemPath,
 
     /// The rendered item as a stream of [`Token`]s
     pub(crate) tokens: Vec<Token>,

--- a/public-api/src/item_iterator.rs
+++ b/public-api/src/item_iterator.rs
@@ -183,7 +183,7 @@ fn intermediate_public_item_to_public_item(
 /// of the public API of a crate. Implements [`Display`] so it can be printed. It
 /// also implements [`Ord`], but how items are ordered are not stable yet, and
 /// will change in later versions.
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Hash)]
 pub struct PublicItem {
     /// The "your_crate::mod_a::mod_b" part of an item. Split by "::"
     pub(crate) path: PublicItemPath,

--- a/public-api/src/tokens.rs
+++ b/public-api/src/tokens.rs
@@ -3,7 +3,7 @@
 use crate::item_iterator::PublicItem;
 
 /// A token in a rendered [`PublicItem`], used to apply syntax colouring in downstream applications.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Token {
     /// A symbol, like `=` or `::<`
     Symbol(String),


### PR DESCRIPTION
And add regression test called `no_off_by_one_diff_skewing()` that the old algo does not pass.

This commit relies on a pending contribution to `hashbag`: https://github.com/jonhoo/hashbag/pull/6

To not be blocked on that contribution, I ported that code into our own repo. We can remove that code when/if that contribution is made available in a new `hashbag` release.

I also added `itertools` as a dev dependency. Maybe in the future we will promote it for use it in the regular lib.

For reference, the impact on the public API of `public-api` is:

```
% cargo public-api --diff-git-checkouts origin/main hashbag
Removed items from the public API
=================================
(none)

Changed items in the public API
===============================
(none)

Added items to the public API
=============================
+pub fn public_api::PublicItem::hash<__H: $crate::hash::Hasher>(&self, state: &mut __H) -> ()
+pub fn public_api::tokens::Token::hash<__H: $crate::hash::Hasher>(&self, state: &mut __H) -> ()
```

Closes #50
