### PR TITLE
Simplify `render_sequence()` implementation and invocations

### DIFF
--- a/public-api/src/render.rs
+++ b/public-api/src/render.rs
@@ -196,12 +196,11 @@ fn render_sequence<T>(
         return vec![];
     }
     let mut output = start;
-    for seq in sequence {
+    for (index, seq) in sequence.iter().enumerate() {
         output.extend(render(seq));
-        output.extend(between.clone());
-    }
-    if output.len() >= between.len() {
-        output.truncate(output.len() - between.len());
+        if index < sequence.len() - 1 {
+            output.extend(between.clone());
+        }
     }
     output.extend(end);
     output

--- a/public-api/src/render.rs
+++ b/public-api/src/render.rs
@@ -192,7 +192,9 @@ fn render_sequence<T>(
     sequence: &[T],
     render: impl Fn(&T) -> Vec<Token>,
 ) -> Vec<Token> {
-    let start_len = start.len();
+    if return_nothing_if_empty && sequence.is_empty() {
+        return vec![];
+    }
     let mut output = start;
     for seq in sequence {
         output.extend(render(seq));
@@ -200,11 +202,6 @@ fn render_sequence<T>(
     }
     if output.len() >= between.len() {
         output.truncate(output.len() - between.len());
-    } else if return_nothing_if_empty {
-        return vec![];
-    }
-    if output.len() == start_len && return_nothing_if_empty {
-        return vec![];
     }
     output.extend(end);
     output


### PR DESCRIPTION
I looked into if it would make sense for us to start depending on `itertools`, more specifically `intersperse()`. It was not a good fit as far as I could tell, but I ended up simplifying (at least to my eyes) the `render_sequence()` code as part of investigating this.

This PR contains those simplifications/clarifications.
