### PR TITLE
Add `--rustdoc-json-toolchain +custom` to `cargo public-api`

### DIFF
--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -12,6 +12,14 @@ fn list_public_items() {
 
 #[serial]
 #[test]
+fn custom_toolchain() {
+    let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();
+    cmd.args(["--rustdoc-json-toolchain", "+nightly"]);
+    assert_presence_of_own_library_items(cmd);
+}
+
+#[serial]
+#[test]
 fn list_public_items_explicit_manifest_path() {
     let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();
     cmd.arg("--manifest-path");

--- a/doc/development.md
+++ b/doc/development.md
@@ -11,12 +11,12 @@ Note that the toolchain required to build this library is distinct from the tool
 There are two ways. You can either do:
 ```
 % cd ~/src/arbitrary-crate
-% cargo run --manifest-path ~/src/cargo-public-api/Cargo.toml
+% cargo run --manifest-path ~/src/cargo-public-api/cargo-public-api/Cargo.toml
 ```
 or you can do
 ```
 % cd ~/src/cargo-public-api
-% cargo run -- --manifest-path ~/src/arbitrary-crate/Cargo.toml
+% cargo run --bin cargo-public-api -- --manifest-path ~/src/arbitrary-crate/Cargo.toml
 ```
 In the first case `--manifest-path` is interpreted by `cargo` itself, and in the second case `--manifest-path` is interpreted by `cargo-public-api`.
 
@@ -25,7 +25,7 @@ NOTE: The second way does not work with `--diff-git-checkouts` yet.
 You can also combine both ways:
 ```
 % cd /does/not/matter
-% cargo run --manifest-path ~/src/cargo-public-api/Cargo.toml -- --manifest-path ~/src/arbitrary-crate/Cargo.toml
+% cargo run --manifest-path ~/src/cargo-public-api/cargo-public-api/Cargo.toml -- --manifest-path ~/src/arbitrary-crate/Cargo.toml
 ```
 
 ## Code coverage
@@ -33,7 +33,8 @@ You can also combine both ways:
 Exploring code coverage is a good way to ensure we have broad enough tests. This is the command I use personally to get started:
 
 ```bash
-cargo llvm-cov --html && open target/llvm-cov/html/index.html
+cd public-api
+cargo llvm-cov --html && open ../target/llvm-cov/html/index.html
 ```
 
 Which obviously requires you to have done `cargo install cargo-llvm-cov` first.

--- a/doc/development.md
+++ b/doc/development.md
@@ -28,6 +28,14 @@ You can also combine both ways:
 % cargo run --manifest-path ~/src/cargo-public-api/cargo-public-api/Cargo.toml -- --manifest-path ~/src/arbitrary-crate/Cargo.toml
 ```
 
+## Use custom rustdoc JSON toolchain
+
+If you have built rustdoc yourself to try some rustdoc JSON fix, you can run `cargo public-api` with your custom toolchain like this:
+
+```
+cargo public-api --rustdoc-json-toolchain +custom
+```
+
 ## Code coverage
 
 Exploring code coverage is a good way to ensure we have broad enough tests. This is the command I use personally to get started:


### PR DESCRIPTION
If you want to use some other toolchain than `+nightly` to build rustdoc
JSON. For example if you built rustdoc from source to try a fix.