### PR TITLE
Add helper script to diff multiple versions serially

### DIFF
--- a/scripts/multi-diff.sh
+++ b/scripts/multi-diff.sh
@@ -1,0 +1,16 @@
+#/usr/bin/env bash
+set -o nounset
+
+# Run like this:
+#
+#   cd ~/src/some-lib
+#   ~/src/cargo-public-api/scripts/multi-diff.sh $(git tag | grep '^v\?[0-9]\+\.[0-9]\+\.[0-9]\+$')
+
+base_version="$1"
+shift
+
+for new_version in $@; do
+    echo "$base_version -> $new_version"
+    cargo public-api --diff-git-checkouts $base_version $new_version 2>/dev/null || echo "(Failed)"
+    base_version=$new_version
+done


### PR DESCRIPTION
Example usage:

```
# In ~/src/regex
% ~/src/cargo-public-api/scripts/multi-diff.sh $(git tag | grep '^v\?[0-9]\+\.[0-9]\+\.[0-9]\+$')
0.1.53 -> 0.1.54
Removed items from the public API
=================================
(none)

Changed items in the public API
===============================
(none)

Added items to the public API
=============================
(none)

0.1.54 -> 0.1.55
Removed items from the public API
=================================
(none)

Changed items in the public API
===============================
-pub fn regex::Captures::index<'a>(&'a self, name: &str) -> &'a str
+pub fn regex::Captures::index<'a>(&'a self, name: &'i str) -> &'a str

Added items to the public API
=============================
(none)

[....]
```

At some point this might make sense to support officially by `cargo public-api` itself, but until then this casual helper script is useful enough to include in the git repo I think.
