### PR TITLE
Run `cargo install public-api && cargo install cargo-public-api` nightly

### DIFF
--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -1,0 +1,18 @@
+name: Nightly
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '44 4 * * *'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # The purpose of this job is to detect problems like
+  # https://github.com/Enselic/cargo-public-api/issues/61 ourselves
+  cargo-install:
+    runs-on: ubuntu-latest
+    steps:
+    - run: cargo install public-api
+    - run: cargo install cargo-public-api


### PR DESCRIPTION
So that we can detect problems such as #61 ourselves.

I contemplated adding `--locked` to the installation instructions, but I want to ensure that installation works even for people that don't copy-paste the install command from the README.