### PR TITLE
`--cap-lints warn` when building rustdoc JSON

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ exclude = [
     "test-apis/example_api-v0.1.0",
     "test-apis/example_api-v0.2.0",
 
+    # To test that we pass --cap-lints when building rustdoc JSON
+    "test-apis/lint_error",
+
     # git repo used in tests.
     "target/tmp/cargo-public-api-test-repo",
 ]

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -168,7 +168,10 @@ fn build_rustdoc_json(args: &Args) -> Result<()> {
     command.args([&args.rustdoc_json_toolchain, "doc", "--lib", "--no-deps"]);
     command.arg("--manifest-path");
     command.arg(&args.manifest_path);
-    command.env("RUSTDOCFLAGS", "-Z unstable-options --output-format json");
+    command.env(
+        "RUSTDOCFLAGS",
+        "-Z unstable-options --output-format json --cap-lints warn",
+    );
     if command.spawn()?.wait()?.success() {
         Ok(())
     } else {

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -12,6 +12,20 @@ fn list_public_items() {
 
 #[serial]
 #[test]
+fn list_public_items_with_lint_error() {
+    let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();
+    cmd.args(["--manifest-path", "../test-apis/lint_error/Cargo.toml"]);
+    cmd.assert()
+        .stdout(
+            "pub mod lint_error\n\
+            pub struct lint_error::MissingDocs\n\
+            ",
+        )
+        .success();
+}
+
+#[serial]
+#[test]
 fn custom_toolchain() {
     let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();
     cmd.args(["--rustdoc-json-toolchain", "+nightly"]);

--- a/test-apis/lint_error/Cargo.toml
+++ b/test-apis/lint_error/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+description = "To test that we pass --cap-lints when building rustdoc JSON"
+name = "lint_error"
+version = "0.1.0"
+edition = "2021"

--- a/test-apis/lint_error/src/lib.rs
+++ b/test-apis/lint_error/src/lib.rs
@@ -1,0 +1,9 @@
+#![no_std] // Reduces rustdoc JSON size by 70%
+#![deny(missing_docs)]
+
+/// Deliberately missing docs to trigger `#![deny(missing_docs)]`. We still want
+/// to be able to build rustdoc JSON in this case. In reality we do this for
+/// `#![deny(warnings)]` when newer compiler versions comes up with new
+/// warnings. But for testing purposes it is fine to use
+/// `#![deny(missing_docs)]`.
+pub struct MissingDocs;


### PR DESCRIPTION
### Step-by-step:
1. In https://github.com/diesel-rs/diesel/tree/master/diesel
2. `cargo public-api --diff-git-checkouts v0.2.0 v0.3.0`

### Expected result:
Diff is printed

### Actual result:
```
error: unnecessary parentheses around type
  --> src/expression/functions/mod.rs:31:22
...
note: the lint level is defined here
  --> src/lib.rs:4:9
   |
4  | #![deny(warnings)]
   |         ^^^^^^^^
   = note: `#[deny(unused_parens)]` implied by `#[deny(warnings)]`
   = note: this error originates in the macro `sql_function_body` (in Nightly builds, run with -Z macro-backtrace for more info)
```

There is no reason we should not be allowed to bulid rustdoc JSON even though there are compiler warnings (that has been introduced in the compiler after the code was written). So pass `--cap-lints warn` to rustdoc JSON. Also add a regression test.
