### PR TITLE
Enforce clippy lints only in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,11 +33,11 @@ jobs:
       - run: RUSTDOCFLAGS='--deny warnings' cargo doc --locked --no-deps
 
   cargo-clippy:
-    name: cargo clippy -- --deny clippy::all --deny clippy::pedantic
+    name: cargo clippy -- --deny clippy::all --deny clippy::pedantic ...
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: cargo clippy --locked --all-targets --all-features -- --deny clippy::all --deny clippy::pedantic
+      - run: cargo clippy --locked --all-targets --all-features -- --deny clippy::all --deny clippy::pedantic --deny dead_code
 
   cargo-test:
     name: cargo test

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -35,10 +35,12 @@
 				"--all-targets",
 				"--all-features",
 				"--",
-				"-D",
+				"--deny",
 				"clippy::all",
-				"-D",
-				"clippy::pedantic"
+				"--deny",
+				"clippy::pedantic",
+				"--deny",
+				"dead_code"
 			],
 			"problemMatcher": [
 				"$rustc"

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -1,3 +1,6 @@
+//! Simple wrapper around the library. For a much more sophisticated CLI, see
+//! <https://github.com/Enselic/cargo-public-api/blob/main/cargo-public-api/src/main.rs>.
+
 use std::io::stdout;
 use std::path::{Path, PathBuf};
 

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(clippy::all, clippy::pedantic)]
-
 use std::io::stdout;
 use std::path::{Path, PathBuf};
 

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -1,6 +1,9 @@
 //! This library gives you a the public API of a library crate, in the form of a
 //! list of public items in the crate. Public items are items that other crates
-//! can use.
+//! can use. Diffing is also supported.
+//!
+//! If you want a convenient CLI for this library, you should use [cargo
+//! public-api](https://github.com/Enselic/cargo-public-api).
 //!
 //! As input to the library, a special output format from `cargo doc` is used,
 //! which goes by the name **rustdoc JSON**. Currently, only `cargo doc` from
@@ -31,7 +34,7 @@
 //!
 //! The most comprehensive example code on how to use the library can be found
 //! in the thin binary wrapper around the library, see
-//! <https://github.com/Enselic/public-api/blob/main/src/main.rs>.
+//! <https://github.com/Enselic/cargo-public-api/blob/main/public-api/src/main.rs>.
 
 #![deny(missing_docs)]
 

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -33,8 +33,7 @@
 //! in the thin binary wrapper around the library, see
 //! <https://github.com/Enselic/public-api/blob/main/src/main.rs>.
 
-#![deny(missing_docs, dead_code)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(missing_docs)]
 
 mod error;
 mod intermediate_public_item;

--- a/scripts/run-ci-locally.sh
+++ b/scripts/run-ci-locally.sh
@@ -9,7 +9,7 @@ cargo fmt -- --check
 
 RUSTDOCFLAGS='--deny warnings' cargo doc --locked --no-deps
 
-cargo clippy --locked --all-targets --all-features -- --deny clippy::all --deny clippy::pedantic
+cargo clippy --locked --all-targets --all-features -- --deny clippy::all --deny clippy::pedantic --deny dead_code
 
 cargo test --locked
 


### PR DESCRIPTION
Otherwise it becomes unnecessarily tricky to compile older versions of the project with newer versions of the Rust toolchain (for example when doing `git bisect` in the future), because new lints are constantly added.

Keep `#![deny(missing_docs)]` though because
* We only want to do that for the lib
* It seems very unlikely that future version of the compiler will find
    more undocumented public items
