### PR TITLE
Support `--git-diff-checkouts` together with `--manifest-path`

### DIFF
--- a/cargo-public-api/src/git_utils.rs
+++ b/cargo-public-api/src/git_utils.rs
@@ -1,0 +1,37 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Context, Result};
+
+/// Synchronously do a `git checkout` of `commit`. Maybe we should use `git2`
+/// crate instead at some point?
+pub(crate) fn git_checkout(commit: &str, git_root: &Path) -> Result<()> {
+    let mut command = std::process::Command::new("git");
+    command.current_dir(git_root);
+    command.args(["checkout", commit]);
+    if command.spawn()?.wait()?.success() {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "Failed to git checkout {}, see error message on stdout/stderr.",
+            commit,
+        ))
+    }
+}
+
+/// Goes up the chain of parents and looks for a `.git` dir.
+pub(crate) fn git_root_from_manifest_path(manifest_path: &Path) -> Result<PathBuf> {
+    let err_fn = || anyhow!("No `.git` dir when starting from `{:?}`.", &manifest_path);
+    let start = std::fs::canonicalize(manifest_path).with_context(err_fn)?;
+    let mut candidate_opt = start.parent();
+    while let Some(candidate) = candidate_opt {
+        if [candidate, Path::new(".git")]
+            .iter()
+            .collect::<PathBuf>()
+            .exists()
+        {
+            return Ok(candidate.to_owned());
+        }
+        candidate_opt = candidate.parent();
+    }
+    Err(err_fn())
+}

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -13,6 +13,7 @@ use public_api::{
 use clap::Parser;
 
 mod arg_types;
+mod git_utils;
 mod markdown;
 mod output_formatter;
 mod plain;
@@ -226,22 +227,6 @@ fn get_options(args: &Args) -> Options {
     options
 }
 
-/// Synchronously do a `git checkout` of `commit`. Maybe we should use `git2`
-/// crate instead at some point?
-fn git_checkout(commit: &str, git_root: &Path) -> Result<()> {
-    let mut command = std::process::Command::new("git");
-    command.current_dir(git_root);
-    command.args(["checkout", commit]);
-    if command.spawn()?.wait()?.success() {
-        Ok(())
-    } else {
-        Err(anyhow!(
-            "Failed to git checkout {}, see error message on stdout/stderr.",
-            commit,
-        ))
-    }
-}
-
 /// Returns `./target/doc/crate_name.json`. Also takes care of transforming
 /// `crate-name` to `crate_name`.
 fn rustdoc_json_path_for_name(target_directory: &Path, lib_name: &str) -> PathBuf {
@@ -259,8 +244,8 @@ fn collect_public_items_from_commit(commit: Option<&str>) -> Result<Vec<PublicIt
     // Do a git checkout of a specific commit unless we are supposed to simply
     // use the current commit
     if let Some(commit) = commit {
-        let git_root = git_root_from_manifest_path(args.manifest_path.as_path())?;
-        git_checkout(commit, &git_root)?;
+        let git_root = git_utils::git_root_from_manifest_path(args.manifest_path.as_path())?;
+        git_utils::git_checkout(commit, &git_root)?;
     }
 
     // Invoke `cargo doc` to build rustdoc JSON
@@ -272,24 +257,6 @@ fn collect_public_items_from_commit(commit: Option<&str>) -> Result<Vec<PublicIt
     let options = get_options(&args);
 
     public_api_from_rustdoc_json_path(json_path, options)
-}
-
-/// Goes up the chain of parents and looks for a `.git` dir.
-fn git_root_from_manifest_path(manifest_path: &Path) -> Result<PathBuf> {
-    let err_fn = || anyhow!("No `.git` dir when starting from `{:?}`.", &manifest_path);
-    let start = std::fs::canonicalize(manifest_path).with_context(err_fn)?;
-    let mut candidate_opt = start.parent();
-    while let Some(candidate) = candidate_opt {
-        if [candidate, Path::new(".git")]
-            .iter()
-            .collect::<PathBuf>()
-            .exists()
-        {
-            return Ok(candidate.to_owned());
-        }
-        candidate_opt = candidate.parent();
-    }
-    Err(err_fn())
 }
 
 fn public_api_from_rustdoc_json_path<T: AsRef<Path>>(

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -89,6 +89,56 @@ fn diff_public_items() {
 
 #[serial]
 #[test]
+fn diff_public_items_with_manifest_path() {
+    ensure_test_crate_is_cloned();
+
+    let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();
+    cmd.arg("--manifest-path");
+    cmd.arg(format!(
+        "{}/Cargo.toml",
+        &test_crate_path().to_string_lossy()
+    ));
+    cmd.arg("--color=never");
+    cmd.arg("--diff-git-checkouts");
+    cmd.arg("v0.0.4");
+    cmd.arg("v0.0.5");
+    cmd.assert()
+        .stdout(
+            "Removed items from the public API\n\
+             =================================\n\
+             -pub fn public_items::from_rustdoc_json_str(rustdoc_json_str: &str) -> Result<HashSet<String>>\n\
+             \n\
+             Changed items in the public API\n\
+             ===============================\n\
+             (none)\n\
+             \n\
+             Added items to the public API\n\
+             =============================\n\
+             +pub fn public_items::sorted_public_items_from_rustdoc_json_str(rustdoc_json_str: &str) -> Result<Vec<String>>\n\
+             \n\
+            ",
+        )
+        .success();
+}
+
+#[test]
+fn diff_public_items_without_git_root() {
+    let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();
+    cmd.arg("--manifest-path");
+    cmd.arg("/does/not/exist/Cargo.toml");
+    cmd.arg("--color=never");
+    cmd.arg("--diff-git-checkouts");
+    cmd.arg("v0.0.4");
+    cmd.arg("v0.0.5");
+    cmd.assert()
+        .stderr(predicates::str::starts_with(
+            "Error: No `.git` dir when starting from `",
+        ))
+        .failure();
+}
+
+#[serial]
+#[test]
 fn diff_public_items_with_color() {
     ensure_test_crate_is_cloned();
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -20,8 +20,6 @@ or you can do
 ```
 In the first case `--manifest-path` is interpreted by `cargo` itself, and in the second case `--manifest-path` is interpreted by `cargo-public-api`.
 
-NOTE: The second way does not work with `--diff-git-checkouts` yet.
-
 You can also combine both ways:
 ```
 % cd /does/not/matter


### PR DESCRIPTION
So that you can do this:

```
cargo run -- --diff-git-checkouts  v0.20.0 v0.21.0 --manifest-path ~/src/bat/Cargo.toml
```