### PR TITLE
Remove `--only-build-rustdoc-json` which was a hack for tests

### DIFF
--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -83,10 +83,6 @@ pub struct Args {
     #[clap(long, default_value = "auto")]
     color: arg_types::Color,
 
-    /// Do nothing but build the rustdoc JSON. Primarily meant for self-testing.
-    #[clap(long, hide = true)]
-    only_build_rustdoc_json: bool,
-
     /// Allows you to build rustdoc JSON with a toolchain other than `+nightly`.
     /// Useful if you have built a toolchain from source for example.
     #[clap(long, hide = true, default_value = "+nightly")]
@@ -96,9 +92,7 @@ pub struct Args {
 fn main_() -> Result<()> {
     let args = get_args();
 
-    if args.only_build_rustdoc_json {
-        build_rustdoc_json(&args)
-    } else if let Some(commits) = &args.diff_git_checkouts {
+    if let Some(commits) = &args.diff_git_checkouts {
         print_public_items_diff_between_two_commits(&args, commits)
     } else if let Some(files) = &args.diff_rustdoc_json {
         print_public_items_diff_between_two_rustdoc_json_files(&args, files)

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -202,17 +202,11 @@ fn diff_public_items_markdown_no_changes() {
 
 #[serial]
 #[test]
-fn diff_public_items_from_files_no_changes() {
-    // Build ./target/doc/cargo_public_api.json
-    let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();
-    cmd.arg("--only-build-rustdoc-json");
-    cmd.assert().success();
-
-    // Just a sanity check that --diff-rustdoc-json works at all
+fn diff_public_items_from_files() {
     let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();
     cmd.arg("--diff-rustdoc-json");
-    cmd.arg("../target/doc/cargo_public_api.json");
-    cmd.arg("../target/doc/cargo_public_api.json");
+    cmd.arg("../public-api/tests/rustdoc-json/example_api-v0.1.0.json");
+    cmd.arg("../public-api/tests/rustdoc-json/example_api-v0.2.0.json");
     cmd.assert()
         .stdout(
             "Removed items from the public API
@@ -221,11 +215,16 @@ fn diff_public_items_from_files_no_changes() {
 
 Changed items in the public API
 ===============================
-(none)
+-pub fn example_api::function(v1_param: Struct)
++pub fn example_api::function(v1_param: Struct, v2_param: usize)
+-pub struct example_api::Struct
++#[non_exhaustive] pub struct example_api::Struct
 
 Added items to the public API
 =============================
-(none)
++pub struct example_api::StructV2
++pub struct field example_api::Struct::v2_field: usize
++pub struct field example_api::StructV2::field: usize
 
 ",
         )


### PR DESCRIPTION
Since https://github.com/Enselic/cargo-public-api/pull/34 we can use real JSON from `public-api` instead.

(CI will fail because of https://github.com/Enselic/cargo-public-api/issues/67 but all tests pass locally)