### PR TITLE
De-duplicate code into a new generic `rustdoc-json` crate

### DIFF
--- a/.github/workflows/Release-rustdoc-json.yml
+++ b/.github/workflows/Release-rustdoc-json.yml
@@ -1,0 +1,42 @@
+name: Release rustdoc-json
+
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  ci:
+    uses: ./.github/workflows/CI.yml
+
+  release:
+    needs: ci
+    environment: crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # Figure out what tag to use
+      - name: calculate version
+        id: version
+        run: |
+          version=$(cargo read-manifest --manifest-path rustdoc-json/Cargo.toml | jq --raw-output .version)
+          echo ::set-output name=VERSION::${version}
+          echo ::set-output name=GIT_TAG::rustdoc-json-v${version}
+
+      # Try to cargo publish rustdoc-json. If this succeeds we will tag the
+      # release. This is because we don't want to have a situation where a
+      # version exists at crates.io but not as a git tag.
+      - run: cargo publish -p rustdoc-json
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      # Push the tag to git.
+      - name: push tag
+        run: |
+          git tag ${{ steps.version.outputs.GIT_TAG }}
+          git push origin ${{ steps.version.outputs.GIT_TAG }}
+
+      # Do not create a GitHub release. That is only done for public-api and
+      # cargo-public-api. A git tag is sufficient for rustdoc-json.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,12 +100,11 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "atty",
- "cargo_metadata",
- "cargo_toml",
  "clap",
  "diff",
  "predicates",
  "public-api",
+ "rustdoc-json",
  "serial_test",
 ]
 
@@ -439,11 +438,10 @@ name = "public-api"
 version = "0.12.1"
 dependencies = [
  "assert_cmd",
- "cargo_metadata",
- "cargo_toml",
  "hashbag",
  "itertools",
  "pretty_assertions",
+ "rustdoc-json",
  "rustdoc-types",
  "serde",
  "serde_json",
@@ -491,6 +489,15 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "rustdoc-json"
+version = "0.2.0"
+dependencies = [
+ "cargo_metadata",
+ "cargo_toml",
+ "thiserror",
+]
 
 [[package]]
 name = "rustdoc-types"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [workspace]
 members = [
+    "rustdoc-json",
+    "public-api",
     "cargo-public-api",
-    "public-api"
 ]
 
 # Test APIs can't be part of the workspace because some test API crates use

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -14,10 +14,12 @@ default-run = "cargo-public-api"
 ansi_term = "0.12.1"
 anyhow = "1.0.53"
 atty = "0.2.14"
-cargo_metadata = "0.14.2"
-cargo_toml = "0.11.4"
 clap = { version = "3.1.2", features = ["derive"] }
 diff = "0.1.12"
+
+[dependencies.rustdoc-json]
+path = "../rustdoc-json"
+version = "0.2.0"
 
 [dependencies.public-api]
 path = "../public-api"

--- a/doc/development.md
+++ b/doc/development.md
@@ -61,6 +61,8 @@ Here are some guidelines if you are a maintainer:
 
 ## How to release
 
+### `public-api` and `cargo-public-api`
+
 1. Bump to the same `version` in **public-api/Cargo.toml** and **cargo-public-api/Cargo.toml** (including the dependency on `public-api`), and push to `main`. If you bump 0.x.0 version, also update the [compatibility matrix](https://github.com/Enselic/cargo-public-api#compatibility-matrix).
 2. If `MINIMUM_RUSTDOC_JSON_VERSION` must be bumped, bump it. If you bump it, also bump it in [installation instruction](https://github.com/Enselic/cargo-public-api#installation) and the [compatibility matrix](https://github.com/Enselic/cargo-public-api#compatibility-matrix).
 3. Label PRs that should not be mentioned in the release notes with `[exclude-from-release-notes]`
@@ -72,3 +74,14 @@ Here are some guidelines if you are a maintainer:
 9. Double-check that the release ended up at https://crates.io/crates/public-api/versions and https://crates.io/crates/cargo-public-api/versions
 10. Double-check that the auto-generated release notes for the release at https://github.com/Enselic/cargo-public-api/releases is not horribly inaccurate. If so, please edit.
 11. Done!
+
+### `rustdoc-json`
+
+1. Bump the `version` in **rustdoc-json/Cargo.toml** and the dependencies declared in **public-api/Cargo.toml** and **cargo-public-api/Cargo.toml**.
+2. Go to https://github.com/Enselic/cargo-public-api/actions/workflows/Release-rustdoc-json.yml
+3. Click the **Run workflow ▼** button to the right
+4. Make sure the `main` branch is selected
+5. Click **Run workflow**
+6. Wait for the workflow to complete
+7. Double-check that the release ended up at https://crates.io/crates/rustdoc-json/versions
+8. Done!

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -26,8 +26,10 @@ version = "0.11.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.4"
-cargo_metadata = "0.14.2"
-cargo_toml = "0.11.5"
 pretty_assertions = "1.1.0"
 itertools = { version = "0.10.3", default-features = false }
 serial_test = "0.6.0"
+
+[dev-dependencies.rustdoc-json]
+path = "../rustdoc-json"
+version = "0.2.0"

--- a/public-api/tests/utils/mod.rs
+++ b/public-api/tests/utils/mod.rs
@@ -1,9 +1,12 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 /// Helper to get the path to a freshly built rustdoc JSON file for the given
 /// test-crate.
 pub fn rustdoc_json_path_for_crate(test_crate: &str) -> PathBuf {
-    build_rustdoc_json(format!("{}/Cargo.toml", test_crate))
+    // The test framework is unable to capture output from child processes (see
+    // https://users.rust-lang.org/t/cargo-doesnt-capture-stderr-in-tests/67045/4),
+    // so build quietly to make running tests much less noisy
+    rustdoc_json::build_quietly("+nightly", &format!("{}/Cargo.toml", test_crate)).unwrap()
 }
 
 /// Helper to get a String of freshly built rustdoc JSON for the given
@@ -11,48 +14,4 @@ pub fn rustdoc_json_path_for_crate(test_crate: &str) -> PathBuf {
 #[allow(unused)] // It IS used
 pub fn rustdoc_json_str_for_crate(test_crate: &str) -> String {
     std::fs::read_to_string(rustdoc_json_path_for_crate(test_crate)).unwrap()
-}
-
-/// Synchronously generate the rustdoc JSON for a library crate. Returns the
-/// path to the freshly built rustdoc JSON file.
-fn build_rustdoc_json<P: AsRef<Path>>(manifest_path: P) -> PathBuf {
-    // Synchronously invoke cargo doc
-    let mut command = std::process::Command::new("cargo");
-    command.args(["+nightly", "doc", "--lib", "--no-deps"]);
-
-    command.arg("--manifest-path");
-    command.arg(manifest_path.as_ref());
-
-    // The test framework is unable to capture output from child processes (see
-    // https://users.rust-lang.org/t/cargo-doesnt-capture-stderr-in-tests/67045/4),
-    // so be quiet to make running tests much less noisy
-    command.arg("--quiet");
-
-    command.env("RUSTDOCFLAGS", "-Z unstable-options --output-format json");
-
-    assert!(command.spawn().unwrap().wait().unwrap().success());
-
-    let mut rustdoc_json_path = get_target_directory(manifest_path.as_ref());
-    rustdoc_json_path.push("doc");
-    rustdoc_json_path.push(format!("{}.json", package_name(manifest_path)));
-    rustdoc_json_path
-}
-
-/// Figures out the name of the library crate in the current directory by
-/// looking inside `Cargo.toml`
-fn package_name(path: impl AsRef<Path>) -> String {
-    let manifest = cargo_toml::Manifest::from_path(&path).expect("valid manifest");
-    manifest
-        .package
-        .expect("[package] is declared in Cargo.toml")
-        .name
-}
-
-/// Typically returns the absolute path to the regular cargo `./target` directory.
-fn get_target_directory(manifest_path: &Path) -> PathBuf {
-    let mut metadata_cmd = cargo_metadata::MetadataCommand::new();
-    metadata_cmd.manifest_path(&manifest_path);
-    let metadata = metadata_cmd.exec().unwrap();
-
-    metadata.target_directory.as_std_path().to_owned()
 }

--- a/rustdoc-json/Cargo.toml
+++ b/rustdoc-json/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+description = "Utilities for working with rustdoc JSON."
+documentation = "https://docs.rs/rustdoc-json"
+edition = "2021"
+homepage = "https://github.com/Enselic/cargo-public-api/tree/main/rustdoc-json"
+license = "MIT"
+name = "rustdoc-json"
+readme = "README.md"
+repository = "https://github.com/Enselic/cargo-public-api/tree/main/rustdoc-json"
+version = "0.2.0"
+
+[dependencies]
+cargo_metadata = "0.14.2"
+cargo_toml = "0.11.4"
+thiserror = "1.0.29"

--- a/rustdoc-json/README.md
+++ b/rustdoc-json/README.md
@@ -1,0 +1,11 @@
+# rustdoc-json
+
+Utilities for working with [rustdoc JSON](https://github.com/rust-lang/rust/issues/76578).
+
+Right now there are only helper functions to build rustdoc JSON. Please refer to the [`docs`](https://docs.rs/rustdoc-json).
+
+Originally developed for use by [`public-api`](https://crates.io/crates/public-api) and [`cargo-public-api`](https://crates.io/crates/cargo-public-api), but should be useful for any Rust code that wants to build rustdoc JSON.
+
+## Testing
+
+This library is indirectly tested through the [`public-api`](https://crates.io/crates/public-api) and [`cargo-public-api`](https://crates.io/crates/cargo-public-api) test suites. Their tests heavily depend on this library, so if all of their tests pass, then this library works as it should.

--- a/rustdoc-json/src/build.rs
+++ b/rustdoc-json/src/build.rs
@@ -1,0 +1,89 @@
+use super::BuildError;
+
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+/// Run `cargo rustdoc` to produce rustdoc JSON and return the path to the built
+/// file.
+pub(crate) fn run_cargo_rustdoc(
+    toolchain: impl AsRef<OsStr>,
+    manifest_path: impl AsRef<Path>,
+    quiet: bool,
+) -> Result<PathBuf, BuildError> {
+    let output = cargo_rustdoc_command(toolchain, &manifest_path, quiet).output()?;
+    if output.status.success() {
+        rustdoc_json_path_for_manifest_path(manifest_path)
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        if stderr.contains("is a virtual manifest, but this command requires running against an actual package in this workspace") {
+            Err(BuildError::VirtualManifest(
+                manifest_path.as_ref().to_owned(),
+            ))
+        } else {
+            Err(BuildError::General(stderr))
+        }
+    }
+}
+
+/// Construct the `cargo rustdoc` command to use for building rustdoc JSON. The
+/// command typically ends up looks something like this:
+/// ```bash
+/// cargo +nightly rustdoc --lib --manifest-path Cargo.toml -- -Z unstable-options --output-format json --cap-lints warn
+/// ```
+fn cargo_rustdoc_command(
+    toolchain: impl AsRef<OsStr>,
+    manifest_path: impl AsRef<Path>,
+    quiet: bool,
+) -> Command {
+    let mut command = Command::new("cargo");
+    command.arg(toolchain.as_ref());
+    command.arg("rustdoc");
+    command.arg("--lib");
+    if quiet {
+        command.arg("--quiet");
+    }
+    command.arg("--manifest-path");
+    command.arg(manifest_path.as_ref());
+    command.arg("--");
+    command.args(["-Z", "unstable-options"]);
+    command.args(["--output-format", "json"]);
+    command.args(["--cap-lints", "warn"]);
+    command
+}
+
+/// Returns `./target/doc/crate_name.json`. Also takes care of transforming
+/// `crate-name` to `crate_name`.
+fn rustdoc_json_path_for_manifest_path(
+    manifest_path: impl AsRef<Path>,
+) -> Result<PathBuf, BuildError> {
+    let target_dir = target_directory(&manifest_path)?;
+    let lib_name = package_name(&manifest_path)?;
+
+    let mut rustdoc_json_path = target_dir;
+    rustdoc_json_path.push("doc");
+    rustdoc_json_path.push(lib_name.replace('-', "_"));
+    rustdoc_json_path.set_extension("json");
+    Ok(rustdoc_json_path)
+}
+
+/// Typically returns the absolute path to the regular cargo `./target`
+/// directory. But also handles packages part of workspaces.
+fn target_directory(manifest_path: impl AsRef<Path>) -> Result<PathBuf, BuildError> {
+    let mut metadata_cmd = cargo_metadata::MetadataCommand::new();
+    metadata_cmd.manifest_path(manifest_path.as_ref());
+    let metadata = metadata_cmd.exec()?;
+    Ok(metadata.target_directory.as_std_path().to_owned())
+}
+
+/// Figures out the name of the library crate in the current directory by
+/// looking inside `Cargo.toml`
+fn package_name(manifest_path: impl AsRef<Path>) -> Result<String, BuildError> {
+    let manifest = cargo_toml::Manifest::from_path(&manifest_path)?;
+    Ok(manifest
+        .package
+        .ok_or_else(|| BuildError::VirtualManifest(manifest_path.as_ref().to_owned()))?
+        .name)
+}

--- a/rustdoc-json/src/build.rs
+++ b/rustdoc-json/src/build.rs
@@ -78,8 +78,8 @@ fn target_directory(manifest_path: impl AsRef<Path>) -> Result<PathBuf, BuildErr
     Ok(metadata.target_directory.as_std_path().to_owned())
 }
 
-/// Figures out the name of the library crate in the current directory by
-/// looking inside `Cargo.toml`
+/// Figures out the name of the library crate corresponding to the given
+/// `Cargo.toml` manifest path.
 fn package_name(manifest_path: impl AsRef<Path>) -> Result<String, BuildError> {
     let manifest = cargo_toml::Manifest::from_path(&manifest_path)?;
     Ok(manifest

--- a/rustdoc-json/src/lib.rs
+++ b/rustdoc-json/src/lib.rs
@@ -1,0 +1,63 @@
+//! Utilities for working with rustdoc JSON.
+//!
+//! Currently only [`build()`] and [`build_quietly()`]. Please see their docs
+//! for more info.
+
+#![deny(missing_docs)]
+
+mod build;
+
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
+
+/// Represent all errors that can occur when using [`build()`] and
+/// [`build_quietly()`].
+#[derive(thiserror::Error, Debug)]
+pub enum BuildError {
+    /// You tried to generate rustdoc JSON for a virtual manifest. That does not
+    /// work. You need to point to the manifest of a real package.
+    #[error("Manifest must be for an actual package. `{0:?}` is a virtual manifest")]
+    VirtualManifest(PathBuf),
+
+    /// A general error. Refer to the attached error message for more info.
+    #[error("Failed to build rustdoc JSON. Stderr: {0}")]
+    General(String),
+
+    /// An error originating from `cargo_toml`.
+    #[error(transparent)]
+    CargoTomlError(#[from] cargo_toml::Error),
+
+    /// An error originating from `cargo_metadata`.
+    #[error(transparent)]
+    CargoMetadataError(#[from] cargo_metadata::Error),
+
+    /// Some kind of IO error occurred.
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+}
+
+/// Generate rustdoc JSON for a library crate. Returns the path to the freshly
+/// built rustdoc JSON file. `toolchain` is the toolchain, e.g. `"+nightly"`.
+/// `manifest_path` is the relative or absolute path to `Cargo.toml`.
+///
+/// # Errors
+///
+/// E.g. if building the JSON fails or of the manifest path does not exist or is
+/// invalid.
+pub fn build(
+    toolchain: impl AsRef<OsStr>,
+    manifest_path: impl AsRef<Path>,
+) -> Result<PathBuf, BuildError> {
+    build::run_cargo_rustdoc(toolchain, manifest_path, false)
+}
+
+/// Same as [`build()`] but also passes `--quiet` to `cargo`.
+#[allow(clippy::missing_errors_doc)]
+pub fn build_quietly(
+    toolchain: impl AsRef<OsStr>,
+    manifest_path: impl AsRef<Path>,
+) -> Result<PathBuf, BuildError> {
+    build::run_cargo_rustdoc(toolchain, manifest_path, true)
+}


### PR DESCRIPTION
Which should be usable by any Rust code that wants to build rustdoc JSON; not only by us.