### PR TITLE
Also move `#![deny(missing_docs)]` outside of the code

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: cargo clippy --locked --all-targets --all-features -- --deny clippy::all --deny clippy::pedantic --deny warnings
+      - run: scripts/cargo-clippy.sh
 
   cargo-test:
     name: cargo test

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -29,19 +29,8 @@
 			"label": "rust: cargo check"
 		},
 		{
-			"type": "cargo",
-			"command": "clippy",
-			"args": [
-				"--all-targets",
-				"--all-features",
-				"--",
-				"--deny",
-				"clippy::all",
-				"--deny",
-				"clippy::pedantic",
-				"--deny",
-				"warnings"
-			],
+			"type": "shell",
+			"command": "./scripts/cargo-clippy.sh",
 			"problemMatcher": [
 				"$rustc"
 			],

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -36,8 +36,6 @@
 //! in the thin binary wrapper around the library, see
 //! <https://github.com/Enselic/cargo-public-api/blob/main/public-api/src/main.rs>.
 
-#![deny(missing_docs)]
-
 mod error;
 mod intermediate_public_item;
 mod item_iterator;

--- a/rustdoc-json/src/lib.rs
+++ b/rustdoc-json/src/lib.rs
@@ -3,8 +3,6 @@
 //! Currently only [`build()`] and [`build_quietly()`]. Please see their docs
 //! for more info.
 
-#![deny(missing_docs)]
-
 mod build;
 
 use std::{

--- a/scripts/cargo-clippy.sh
+++ b/scripts/cargo-clippy.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Applies to all packages
+cargo clippy --locked --all-targets --all-features -- --deny clippy::all --deny clippy::pedantic --deny warnings
+
+# Only --deny missing_docs for our libs because it does not matter for bins
+cargo clippy --locked --lib --package rustdoc-json --package public-api --all-features -- --deny missing_docs

--- a/scripts/run-ci-locally.sh
+++ b/scripts/run-ci-locally.sh
@@ -9,7 +9,7 @@ cargo fmt -- --check
 
 RUSTDOCFLAGS='--deny warnings' cargo doc --locked --no-deps
 
-cargo clippy --locked --all-targets --all-features -- --deny clippy::all --deny clippy::pedantic --deny warnings
+scripts/cargo-clippy.sh
 
 cargo test --locked
 

--- a/test-apis/lint_error/src/lib.rs
+++ b/test-apis/lint_error/src/lib.rs
@@ -1,9 +1,10 @@
-#![no_std] // Reduces rustdoc JSON size by 70%
+//! Deliberately missing docs to trigger `#![deny(missing_docs)]`. We still want
+//! to be able to build rustdoc JSON in this case. In reality we do this for
+//! `#![deny(warnings)]` when newer compiler versions comes up with new
+//! warnings. But for testing purposes it is fine to use
+//! `#![deny(missing_docs)]`.
 #![deny(missing_docs)]
 
-/// Deliberately missing docs to trigger `#![deny(missing_docs)]`. We still want
-/// to be able to build rustdoc JSON in this case. In reality we do this for
-/// `#![deny(warnings)]` when newer compiler versions comes up with new
-/// warnings. But for testing purposes it is fine to use
-/// `#![deny(missing_docs)]`.
+#![no_std] // Reduces rustdoc JSON size by 70%
+
 pub struct MissingDocs;


### PR DESCRIPTION
Same reason as in [84ea393](https://github.com/Enselic/cargo-public-api/pull/65) but extended to also include `#![deny(missing_docs)]` just to be safe. There is after all a risk that due to some rustc bug some items deep down can miss docs without the lint trigger now, but it will trigger later in newer toolchain versions.
