### PR TITLE
README: Remove 'Output formats' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,6 @@ Use `--with-blanket-implementations` if you want to include items of blanket imp
 cargo public-api --with-blanket-implementations
 ```
 
-# Output formats
-
-Currently there are two output formats. You can choose between `--output-format plain` (default, supports syntax highlighting) and `--output-format markdown`.
-
 # Target audience
 
 Maintainers of Rust libraries that want to keep track of changes to their public API.


### PR DESCRIPTION
Because:
* I want the README to be as easy as possible to digest, which among
  other things means the signal-to-noise ratio shall be as high as
  possible
* I find myself never using `--output-format markdown` and I expect the
  same to be true for other users
* It is easy enough to find out about output formats with `cargo
  public-api --help` or by looking at the code