### PR TITLE
Add `--deny=all` option to exit with failure if there is an API diff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,7 @@ dependencies = [
  "public-api",
  "rustdoc-json",
  "serial_test",
+ "thiserror",
 ]
 
 [[package]]

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0.53"
 atty = "0.2.14"
 clap = { version = "3.1.2", features = ["derive"] }
 diff = "0.1.12"
+thiserror = "1.0.29"
 
 [dependencies.rustdoc-json]
 path = "../rustdoc-json"

--- a/cargo-public-api/src/arg_types.rs
+++ b/cargo-public-api/src/arg_types.rs
@@ -4,6 +4,13 @@ use std::str::FromStr;
 
 use crate::{markdown::Markdown, output_formatter::OutputFormatter, plain::Plain};
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq, clap::ArgEnum)]
+#[clap(rename_all = "lower")]
+pub enum DenyMethod {
+    /// All forms of API diffs are denied: additions, changes, deletions.
+    All,
+}
+
 #[derive(Debug)]
 pub enum OutputFormat {
     Plain,

--- a/cargo-public-api/src/error.rs
+++ b/cargo-public-api/src/error.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("The API diff is not allowed as per --deny")]
+    DiffDenied,
+}

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -6,6 +6,7 @@
 use std::path::{Path, PathBuf};
 
 use assert_cmd::Command;
+use predicates::str::contains;
 use serial_test::serial;
 
 #[serial]
@@ -54,7 +55,7 @@ fn virtual_manifest_error() {
     cmd.arg(current_dir_and("tests/virtual-manifest/Cargo.toml"));
     cmd.assert()
         .stdout("")
-        .stderr(predicates::str::contains(
+        .stderr(contains(
             "Listing or diffing the public API of an entire workspace is not supported.",
         ))
         .failure();
@@ -88,10 +89,7 @@ fn deny_when_not_diffing() {
     let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();
     cmd.arg("--deny=all");
     cmd.assert()
-        .stdout("")
-        .stderr(predicates::str::contains(
-            "`--deny` can only be used with `--diff-git-checkouts`",
-        ))
+        .stderr(contains("`--deny` can only be used when diffing"))
         .failure();
 }
 
@@ -120,7 +118,9 @@ fn deny_with_diff() {
     cmd.arg("v0.0.4");
     cmd.arg("v0.0.5");
     cmd.arg("--deny=all");
-    cmd.assert().stderr("").failure();
+    cmd.assert()
+        .stderr(contains("The API diff is not allowed as per --deny"))
+        .failure();
 }
 
 #[serial]
@@ -281,7 +281,7 @@ fn diff_public_items_missing_one_arg() {
     cmd.arg("--diff-git-checkouts");
     cmd.arg("v0.2.0");
     cmd.assert()
-        .stderr(predicates::str::contains(
+        .stderr(contains(
             "requires at least 2 values but only 1 was provided",
         ))
         .failure();
@@ -308,9 +308,7 @@ fn list_public_items_markdown() {
 fn verbose() {
     let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();
     cmd.arg("--verbose");
-    cmd.assert()
-        .stdout(predicates::str::contains("Processing \""))
-        .success();
+    cmd.assert().stdout(contains("Processing \"")).success();
 }
 
 #[test]
@@ -339,9 +337,9 @@ fn assert_presence_of_own_library_items(mut cmd: Command) {
 
 fn assert_presence_of_args_in_help(mut cmd: Command) {
     cmd.assert()
-        .stdout(predicates::str::contains("--with-blanket-implementations"))
-        .stdout(predicates::str::contains("--manifest-path"))
-        .stdout(predicates::str::contains("--diff-git-checkouts"))
+        .stdout(contains("--with-blanket-implementations"))
+        .stdout(contains("--manifest-path"))
+        .stdout(contains("--diff-git-checkouts"))
         .success();
 }
 

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -82,6 +82,21 @@ fn diff_public_items() {
 
 #[serial]
 #[test]
+fn deny_when_not_diffing() {
+    ensure_test_crate_is_cloned(); // Because we still list the API
+
+    let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();
+    cmd.arg("--deny=all");
+    cmd.assert()
+        .stdout("")
+        .stderr(predicates::str::contains(
+            "`--deny` can only be used with `--diff-git-checkouts`",
+        ))
+        .failure();
+}
+
+#[serial]
+#[test]
 fn diff_public_items_with_manifest_path() {
     ensure_test_crate_is_cloned();
 

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -125,6 +125,22 @@ fn deny_with_diff() {
 
 #[serial]
 #[test]
+fn deny_with_invalid_arg() {
+    ensure_test_crate_is_cloned();
+
+    let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();
+    cmd.current_dir(test_crate_path());
+    cmd.arg("--diff-git-checkouts");
+    cmd.arg("v0.0.4");
+    cmd.arg("v0.0.5");
+    cmd.arg("--deny=invalid");
+    cmd.assert()
+        .stderr(contains("\"invalid\" isn't a valid value"))
+        .failure();
+}
+
+#[serial]
+#[test]
 fn diff_public_items_with_manifest_path() {
     ensure_test_crate_is_cloned();
 

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -111,6 +111,20 @@ fn deny_without_diff() {
 
 #[serial]
 #[test]
+fn deny_with_diff() {
+    ensure_test_crate_is_cloned();
+
+    let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();
+    cmd.current_dir(test_crate_path());
+    cmd.arg("--diff-git-checkouts");
+    cmd.arg("v0.0.4");
+    cmd.arg("v0.0.5");
+    cmd.arg("--deny=all");
+    cmd.assert().stderr("").failure();
+}
+
+#[serial]
+#[test]
 fn diff_public_items_with_manifest_path() {
     ensure_test_crate_is_cloned();
 

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -97,6 +97,20 @@ fn deny_when_not_diffing() {
 
 #[serial]
 #[test]
+fn deny_without_diff() {
+    ensure_test_crate_is_cloned();
+
+    let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();
+    cmd.current_dir(test_crate_path());
+    cmd.arg("--diff-git-checkouts");
+    cmd.arg("v0.2.0");
+    cmd.arg("v0.3.0");
+    cmd.arg("--deny=all");
+    cmd.assert().success();
+}
+
+#[serial]
+#[test]
 fn diff_public_items_with_manifest_path() {
     ensure_test_crate_is_cloned();
 

--- a/public-api/src/diff.rs
+++ b/public-api/src/diff.rs
@@ -106,6 +106,12 @@ impl PublicItemsDiff {
             added,
         }
     }
+
+    /// Check whether the diff is empty
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.removed.is_empty() && self.changed.is_empty() && self.added.is_empty()
+    }
 }
 
 /// Converts a set (read: bag) of public items into a hash map that maps a given
@@ -139,6 +145,7 @@ mod tests {
             added: vec![],
         };
         assert_eq!(actual, expected);
+        assert!(!actual.is_empty());
     }
 
     #[test]
@@ -153,6 +160,7 @@ mod tests {
             added: vec![item_with_path("foo")],
         };
         assert_eq!(actual, expected);
+        assert!(!actual.is_empty());
     }
 
     #[test]
@@ -171,6 +179,7 @@ mod tests {
             added: vec![item_with_path("2")],
         };
         assert_eq!(actual, expected);
+        assert!(!actual.is_empty());
     }
 
     #[test]
@@ -189,6 +198,7 @@ mod tests {
             added: vec![],
         };
         assert_eq!(actual, expected);
+        assert!(!actual.is_empty());
     }
 
     #[test]
@@ -233,6 +243,7 @@ mod tests {
             added: vec![item_with_path("4"), item_with_path("4")],
         };
         assert_eq!(actual, expected);
+        assert!(!actual.is_empty());
     }
 
     /// Regression test for
@@ -260,6 +271,7 @@ mod tests {
         };
         let actual = PublicItemsDiff::between(old, new);
         assert_eq!(actual, expected);
+        assert!(!actual.is_empty());
     }
 
     fn item_with_path(path: &str) -> PublicItem {

--- a/public-api/src/diff.rs
+++ b/public-api/src/diff.rs
@@ -274,6 +274,21 @@ mod tests {
         assert!(!actual.is_empty());
     }
 
+    #[test]
+    fn no_diff_means_empty_diff() {
+        let old = vec![item_with_path("foo")];
+        let new = vec![item_with_path("foo")];
+
+        let actual = PublicItemsDiff::between(old, new);
+        let expected = PublicItemsDiff {
+            removed: vec![],
+            changed: vec![],
+            added: vec![],
+        };
+        assert_eq!(actual, expected);
+        assert!(actual.is_empty());
+    }
+
     fn item_with_path(path: &str) -> PublicItem {
         PublicItem {
             path: path


### PR DESCRIPTION
Closes #63 

This is merely a proposal.

I am not very sure about the actual flag name. `--check` seems to be ambiguous for me, maybe something along `--check-diff-empty` or `--is-empty` is more asppropriate.

Tell me what you think!