### PR TITLE
IntermediatePublicItem: Remove `pub root: &'a Crate` field

### DIFF
--- a/public-api/src/intermediate_public_item.rs
+++ b/public-api/src/intermediate_public_item.rs
@@ -1,7 +1,7 @@
 use crate::render;
 use std::rc::Rc;
 
-use rustdoc_types::{Crate, Item};
+use rustdoc_types::Item;
 
 use crate::tokens::Token;
 
@@ -9,7 +9,7 @@ use crate::tokens::Token;
 /// It wraps a single [Item] but adds additional calculated values to make it
 /// easier to work with. Later, one [`Self`] will be converted to exactly one
 /// [`crate::PublicItem`].
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct IntermediatePublicItem<'a> {
     /// The item we are effectively wrapping.
     pub item: &'a Item,
@@ -17,8 +17,6 @@ pub struct IntermediatePublicItem<'a> {
     /// The name of the item. Normally this is [Item::name]. But in the case of
     /// renamed imports (`pub use other::item as foo;`) it is the new name.
     pub name: &'a str,
-
-    pub root: &'a Crate,
 
     /// The parent item. If [Self::item] is e.g. an enum variant, then the
     /// parent is an enum. We follow the chain of parents to be able to know the
@@ -31,15 +29,9 @@ impl<'a> IntermediatePublicItem<'a> {
     pub fn new(
         item: &'a Item,
         name: &'a str,
-        root: &'a Crate,
         parent: Option<Rc<IntermediatePublicItem<'a>>>,
     ) -> Self {
-        Self {
-            item,
-            name,
-            root,
-            parent,
-        }
+        Self { item, name, parent }
     }
 
     #[must_use]

--- a/public-api/src/item_iterator.rs
+++ b/public-api/src/item_iterator.rs
@@ -131,12 +131,8 @@ impl<'a> ItemIterator<'a> {
         name: &'a str,
         parent: Option<Rc<IntermediatePublicItem<'a>>>,
     ) {
-        self.items_left.push(Rc::new(IntermediatePublicItem::new(
-            item,
-            name,
-            self.crate_,
-            parent,
-        )));
+        let public_item = Rc::new(IntermediatePublicItem::new(item, name, parent));
+        self.items_left.push(public_item);
     }
 
     fn add_missing_id(&mut self, id: &'a Id) {


### PR DESCRIPTION
I was always a bit sceptical of `IntermediatePublicItem::root`, but figured we might need it in the future, so I just let it be. I was expecting to need it when inlining imports, i.e. when doing https://github.com/Enselic/cargo-public-api/pull/77. But I didn't.

It was even in the way, because I needed to debug `IntermediatePublicItem`, but deriving `Debug` on it was not helpful, because it printed the entire crate (!).

So at this point it seems to create more problems than it solves. So I propose we remove it. If against all odds we need it in the future, we can add it back then.

Not only does that result in simpler code, it is also architecturally sound. It is better to not have each public item know about all other public items when it is not necessary.

And also  derive `Debug` on `IntermediatePublicItem` now.
