### PR TITLE
Properly show re-exported primitive types

### DIFF
--- a/public-api/tests/expected-output/comprehensive_api.txt
+++ b/public-api/tests/expected-output/comprehensive_api.txt
@@ -119,3 +119,5 @@ pub type comprehensive_api::typedefs::TypedefPlain = Plain
 pub union comprehensive_api::unions::Basic
 pub unsafe fn comprehensive_api::functions::unsafe_fn()
 pub unsafe trait comprehensive_api::traits::UnsafeTrait
+pub use comprehensive_api::my_i32
+pub use comprehensive_api::u32

--- a/test-apis/comprehensive_api/src/lib.rs
+++ b/test-apis/comprehensive_api/src/lib.rs
@@ -1,23 +1,33 @@
 pub extern crate rand;
-
-pub use private::StructInPrivateMod;
 pub use rand::RngCore;
+
+mod private;
+pub use private::StructInPrivateMod;
+
+pub mod attributes;
+
+pub mod constants;
+
+pub mod enums;
+
+pub mod functions;
+
+pub mod higher_ranked_trait_bounds;
+
+pub mod impls;
+
+pub mod macros;
+
+pub mod statics;
+
+pub mod structs;
 pub use structs::Plain;
 pub use structs::Plain as RenamedPlain;
 
-mod private;
-
-pub mod attributes;
-pub mod constants;
-pub mod enums;
-pub mod functions;
-pub mod higher_ranked_trait_bounds;
-pub mod impls;
-pub mod macros;
-pub mod statics;
-pub mod structs;
 pub mod traits;
+
 pub mod typedefs;
+
 pub mod unions;
 
 pub use u32;

--- a/test-apis/comprehensive_api/src/lib.rs
+++ b/test-apis/comprehensive_api/src/lib.rs
@@ -19,3 +19,6 @@ pub mod structs;
 pub mod traits;
 pub mod typedefs;
 pub mod unions;
+
+pub use u32;
+pub use i32 as my_i32;


### PR DESCRIPTION
And also make comments more up to date and accurate.