### PR TITLE
Run `scripts/bless-expected-output-for-tests.sh` with `nightly-2022-07-26`

### DIFF
--- a/public-api/tests/expected-output/comprehensive_api.txt
+++ b/public-api/tests/expected-output/comprehensive_api.txt
@@ -3,7 +3,7 @@
 #[non_exhaustive] pub enum comprehensive_api::attributes::NonExhaustive
 #[repr(C)] pub struct comprehensive_api::attributes::C
 pub async fn comprehensive_api::functions::async_fn() -> impl Future<Output = ()>
-pub const comprehensive_api::constants::CONST: &str
+pub const comprehensive_api::constants::CONST: &'static str
 pub const comprehensive_api::traits::AssociatedConst::CONST: bool
 pub const comprehensive_api::traits::AssociatedConstDefault::CONST_WITH_DEFAULT: bool
 pub const fn comprehensive_api::functions::const_fn()


### PR DESCRIPTION
Our nightly CI job [detected](https://github.com/Enselic/cargo-public-api/actions/runs/2736941493) an upstream change which I think is caused by https://github.com/rust-lang/rust/pull/97313. I tried to git bisect it but it didn't want to cooperate, so I gave up.

In either case, the change looks reasonable, so let's just adopt it.

I will wait with merging a day or two though, because sometimes changes like that gets reverted quite fast.