### PR TITLE
Allow to override toolchain project-wide with env var

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -42,6 +42,11 @@ If you have built rustdoc yourself to try some rustdoc JSON fix, you can run `ca
 cargo public-api --rustdoc-json-toolchain +custom
 ```
 
+Another option is the `RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK` env var. Use it like this:
+```
+RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=+custom ./scripts/run-ci-locally.sh
+```
+
 ## Code coverage
 
 Exploring code coverage is a good way to ensure we have broad enough tests. This is the command I use personally to get started:

--- a/rustdoc-json/src/build.rs
+++ b/rustdoc-json/src/build.rs
@@ -10,7 +10,7 @@ use std::{
 /// For development purposes only. Sometimes when you work on this project you
 /// want to quickly use a different toolchain to build rustdoc JSON. You can
 /// specify what toolchain, by temporarily changing this.
-const OVERRIDDEN_TOOLCHAIN: Option<&str> = None; // Some("+nightly-2022-07-16");
+const OVERRIDDEN_TOOLCHAIN: Option<&str> = option_env!("RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK"); // Some("+nightly-2022-07-16");
 
 /// Run `cargo rustdoc` to produce rustdoc JSON and return the path to the built
 /// file.

--- a/scripts/bless-expected-output-for-tests.sh
+++ b/scripts/bless-expected-output-for-tests.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 set -o nounset -o pipefail -o errexit
 
+# `:-+nightly` means "if unset, use +nightly"
+toolchain=${RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK:-+nightly}
+
 for crate in comprehensive_api comprehensive_api_proc_macro; do
-    cargo +nightly rustdoc --lib --manifest-path "./test-apis/${crate}/Cargo.toml" -- -Z unstable-options --output-format json
+    cargo ${toolchain} rustdoc --lib --manifest-path "./test-apis/${crate}/Cargo.toml" -- -Z unstable-options --output-format json
     cargo run -p public-api -- "./test-apis/${crate}/target/doc/${crate}.json" > "public-api/tests/expected-output/${crate}.txt"
 done
 

--- a/scripts/update-rustdoc-json-for-tests.sh
+++ b/scripts/update-rustdoc-json-for-tests.sh
@@ -13,12 +13,15 @@ crates="
     example_api-v0.2.0
 "
 
+# `:-+nightly` means "if unset, use +nightly"
+toolchain=${RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK:-+nightly}
+
 for crate in ${crates}; do
     crate_split=(${crate//-/ })
     name=${crate_split[0]} # E.g. `example_api`
     version=${crate_split[1]} # E.g. `v0.1.0`
 
     crate_dir="./test-apis/${crate}"
-    cargo +nightly rustdoc --lib --manifest-path "${crate_dir}/Cargo.toml" -- -Z unstable-options --output-format json
+    cargo ${toolchain} rustdoc --lib --manifest-path "${crate_dir}/Cargo.toml" -- -Z unstable-options --output-format json
     cp -v "${crate_dir}/target/doc/${name}.json" "${output_dir}/${name}-${version}.json"
 done


### PR DESCRIPTION
It allows us to (quite) easily run our test suite with a custom toolchain, typically built from a rust-lang/rust PR that is in review. This makes it possible to run commands like these:

```bash
RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=+stage2 ./scripts/update-rustdoc-json-for-tests.sh
RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=+stage2 ./scripts/bless-expected-output-for-tests.sh
RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=+stage2 ./scripts/run-ci-locally.sh
```

In general I dislike these kinds of magic global variables, but after having tried to not add it for a long time, it has occurred to me that it is simply too inconvenient to be without. So let's add it.

The `_HACK` suffix is intended to make it clear that this is not meant to be used by regular users, and that it can be removed at any point.