### PR TITLE
Make tests run in parallel (stop using #[serial])

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
  "predicates",
  "public-api",
  "rustdoc-json",
- "serial_test",
+ "tempfile",
  "thiserror",
 ]
 
@@ -204,6 +204,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,16 +295,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
-name = "lock_api"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,31 +330,6 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
  "winapi",
 ]
 
@@ -446,7 +420,6 @@ dependencies = [
  "rustdoc-types",
  "serde",
  "serde_json",
- "serial_test",
  "thiserror",
 ]
 
@@ -461,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "534cfe58d6a18cc17120fbf4635d53d14691c1fe4d951064df9bd326178d7d5a"
 dependencies = [
  "bitflags",
 ]
@@ -492,6 +465,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "rustdoc-json"
 version = "0.3.0"
 dependencies = [
@@ -510,22 +492,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
-
-[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
@@ -568,36 +538,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serial_test"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bcc41d18f7a1d50525d080fd3e953be87c4f9f1a974f3c21798ca00d54ec15"
-dependencies = [
- "lazy_static",
- "parking_lot",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2881bccd7d60fb32dfa3d7b3136385312f8ad75e2674aab2852867a09790cae8"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +552,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,4 @@ exclude = [
 
     # To test that we pass --cap-lints when building rustdoc JSON
     "test-apis/lint_error",
-
-    # git repo used in tests.
-    "target/tmp/cargo-public-api-example-api-repo",
 ]

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -29,4 +29,4 @@ version = "0.12.4"
 [dev-dependencies]
 assert_cmd = "2.0.4"
 predicates = "2.1.1"
-serial_test = "0.6.0"
+tempfile = "3.3.0"

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -29,7 +29,6 @@ version = "0.11.0"
 assert_cmd = "2.0.4"
 pretty_assertions = "1.1.0"
 itertools = { version = "0.10.3", default-features = false }
-serial_test = "0.6.0"
 
 [dev-dependencies.rustdoc-json]
 path = "../rustdoc-json"

--- a/public-api/tests/public-api-bin-tests.rs
+++ b/public-api/tests/public-api-bin-tests.rs
@@ -4,11 +4,9 @@ use assert_cmd::Command;
 use public_api::MINIMUM_RUSTDOC_JSON_VERSION;
 
 mod utils;
-use serial_test::serial;
 use utils::rustdoc_json_path_for_crate;
 
 #[test]
-#[serial] // Writing and reading rustdoc JSON to/from file-system; must run one test at a time
 fn print_public_api() {
     cmd_with_rustdoc_json_args(&["../test-apis/comprehensive_api"], |mut cmd| {
         cmd.assert()
@@ -19,7 +17,6 @@ fn print_public_api() {
 }
 
 #[test]
-#[serial]
 fn print_public_api_with_blanket_implementations() {
     cmd_with_rustdoc_json_args(&["../test-apis/example_api-v0.2.0"], |mut cmd| {
         cmd.arg("--with-blanket-implementations");
@@ -33,7 +30,6 @@ fn print_public_api_with_blanket_implementations() {
 }
 
 #[test]
-#[serial]
 fn print_diff() {
     cmd_with_rustdoc_json_args(
         &[
@@ -66,7 +62,6 @@ Added:
 }
 
 #[test]
-#[serial]
 fn print_diff_reversed() {
     cmd_with_rustdoc_json_args(
         &[
@@ -99,7 +94,6 @@ Added:
 }
 
 #[test]
-#[serial]
 fn print_no_diff() {
     cmd_with_rustdoc_json_args(
         &[
@@ -129,7 +123,6 @@ Added:
 /// Uses a bash one-liner to test that public-api gracefully handles
 /// `std::io::ErrorKind::BrokenPipe`
 #[test]
-#[serial]
 fn broken_pipe() {
     // Use the JSON for a somewhat large API so the pipe has time to become closed
     // before all output has been written to stdout

--- a/public-api/tests/public-api-lib-tests.rs
+++ b/public-api/tests/public-api-lib-tests.rs
@@ -4,7 +4,6 @@ use pretty_assertions::assert_eq;
 use public_api::{public_api_from_rustdoc_json_str, Error, Options};
 
 mod utils;
-use serial_test::serial;
 use utils::rustdoc_json_str_for_crate;
 
 struct ExpectedDiff<'a> {
@@ -14,7 +13,6 @@ struct ExpectedDiff<'a> {
 }
 
 #[test]
-#[serial] // Writing and reading rustdoc JSON to/from file-system; must run one test at a time
 fn with_blanket_implementations() {
     assert_public_api_with_blanket_implementations(
         &rustdoc_json_str_for_crate("../test-apis/example_api-v0.2.0"),
@@ -23,7 +21,6 @@ fn with_blanket_implementations() {
 }
 
 #[test]
-#[serial]
 fn diff_with_added_items() {
     assert_public_api_diff(
         &rustdoc_json_str_for_crate("../test-apis/example_api-v0.1.0"),
@@ -50,7 +47,6 @@ fn diff_with_added_items() {
 }
 
 #[test]
-#[serial]
 fn no_diff() {
     // No change to the public API
     assert_public_api_diff(
@@ -65,7 +61,6 @@ fn no_diff() {
 }
 
 #[test]
-#[serial]
 fn diff_with_removed_items() {
     assert_public_api_diff(
         &rustdoc_json_str_for_crate("../test-apis/example_api-v0.2.0"),
@@ -92,7 +87,6 @@ fn diff_with_removed_items() {
 }
 
 #[test]
-#[serial]
 fn comprehensive_api() {
     assert_public_api(
         &rustdoc_json_str_for_crate("../test-apis/comprehensive_api"),
@@ -101,7 +95,6 @@ fn comprehensive_api() {
 }
 
 #[test]
-#[serial]
 fn comprehensive_api_proc_macro() {
     assert_public_api(
         &rustdoc_json_str_for_crate("../test-apis/comprehensive_api_proc_macro"),
@@ -111,7 +104,6 @@ fn comprehensive_api_proc_macro() {
 
 /// I confess: this test is mainly to get function code coverage on Ord
 #[test]
-#[serial]
 fn public_item_ord() {
     let public_api = public_api_from_rustdoc_json_str(
         &rustdoc_json_str_for_crate("../test-apis/comprehensive_api"),
@@ -134,7 +126,6 @@ fn public_item_ord() {
 }
 
 #[test]
-#[serial]
 fn invalid_json() {
     let result = public_api_from_rustdoc_json_str("}}}}}}}}}", Options::default());
     ensure_impl_debug(&result);
@@ -153,7 +144,6 @@ fn options() {
 }
 
 #[test]
-#[serial]
 fn pretty_printed_diff() {
     let options = Options::default();
     let old = public_api_from_rustdoc_json_str(

--- a/scripts/create-test-git-repo.sh
+++ b/scripts/create-test-git-repo.sh
@@ -25,8 +25,12 @@ mkdir -p "${dest}"
 # we want to use regular git commands, but git should pretend we are in ${dest}
 git_cmd="git -C ${dest}"
 
+# We don't want noise when running tests normally, so be quiet by default.
+# Temporarily change to empty string to stop being quiet.
+quiet="--quiet"
+
 # First step: git init
-${git_cmd} init --initial-branch main "${dest}"
+${git_cmd} init $quiet --initial-branch main "${dest}"
 
 # Needed to prevent errors in CI
 ${git_cmd} config user.email "cargo-public-api@example.com"
@@ -40,6 +44,6 @@ for v in v0.1.0 v0.1.1 v0.2.0 v0.3.0; do
     cp "${test_apis_dir}/example_api-${v}/src/lib.rs" "${dest}/src/lib.rs"
 
     ${git_cmd} add .
-    ${git_cmd} commit -m "example_api ${v}"
+    ${git_cmd} commit $quiet -m "example_api ${v}"
     ${git_cmd} tag "${v}"
 done


### PR DESCRIPTION
Closes  #81 

On my 10 core machine this makes `cargo test` take 8 seconds instead of 25 seconds.

The use of serial_test seemed needed before in public-api, but does not seem needed longer. Maybe cargo takes care of locking its build dir better now than before. I have run tests locally one hundred times in a row without any race condition problems.
