### PR TITLE
README.md: Remove 'Limitations' section; no known limitations left

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,6 @@ Use `--with-blanket-implementations` if you want to include items of blanket imp
 cargo public-api --with-blanket-implementations
 ```
 
-## Limitations
-
-See [`[limitation]`](https://github.com/Enselic/cargo-public-api/labels/limitation)
-labeled issues.
-
 # Compatibility matrix
 
 | cargo-public-api | Understands the rustdoc JSON output of  |


### PR DESCRIPTION
https://github.com/Enselic/cargo-public-api/pull/86 closed the last known/significant limitation, and it's quite silly to link to an empty list, so remote this section for now. We can add it back later if needed.