### PR TITLE
Replace `parameterized_test!` macro with regular code

### DIFF
--- a/public-api/src/render.rs
+++ b/public-api/src/render.rs
@@ -790,10 +790,6 @@ mod test {
     use super::*;
     use rustdoc_types::Id;
 
-    // Tests for the `render_type` function.
-    // Missing:
-    //  * ImplTrait
-    //  * FunctionPointer
     parameterized_test![
         test_type_infer:
         render_type(&Type::Infer,)
@@ -867,12 +863,5 @@ mod test {
         render_type(&Type::QualifiedPath { name: s!("name"), args: Box::new(GenericArgs::AngleBracketed { args: vec![], bindings: vec![] }), self_type: Box::new(Type::Generic(s!("type"))), trait_: Box::new(Type::Generic(s!("trait"))) },)
         => vec![Token::symbol("<"), Token::generic("type"), ws!(), Token::keyword("as"), ws!(), Token::generic("trait"), Token::symbol(">::"), Token::identifier("name")]
         => "<type as trait>::name";
-        //test_type_fn_pointer:
-        //render_type(&Type::FunctionPointer(Box::new(FunctionPointer{
-        //    decl: FnDecl{inputs: vec![(s!("a"), Type::Infer)], output: None, c_variadic: false},
-        //    generic_params: vec![],
-        //    header: Header{const_:false, unsafe_:false, async_:false, abi: Abi::Rust}})),)
-        //=> vec![Token::symbol("<"), Token::generic("type"), ws!(), Token::keyword("as"), ws!(), Token::generic("trait"), Token::symbol(">::"), Token::identifier("name")].into()
-        //=> "Fn(_)";
     ];
 }


### PR DESCRIPTION
@douweschulte Are you OK with replacing `parameterized_test!` with regular code? I found the macro invocation hard to change, and so did my tooling (rust-analyzer + vscode).

I actually think the code becomes clearer without the macro. What do you think?

I needed to make adjustments to prepare for https://github.com/rust-lang/rust/pull/100335 (these adjustments will be made in a separate PR and is not part of this PR. Edit: See https://github.com/Enselic/cargo-public-api/pull/95 for the other PR which depends on this PR)