### PR TITLE
Architecture docs and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,31 @@ and the API diff will be printed:
 
 You can also manually do a diff by writing the full list of items to a file for two different versions of your library and then do a regular `diff` between the files.
 
+### As a CI check
+
+Via CI you can ensure the public API is not changed for your crate by using `--deny=all` together with `--diff-git-checkouts`. For example, a GitHub Actions job to do this would look something like this:
+
+```yaml
+jobs:
+  deny-public-api-changes:
+    runs-on: ubuntu-latest
+    steps:
+      # Full git history needed
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # Install nightly (stable is already installed)
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+
+      # Install and run cargo public-api and deny any API diff
+      - run: cargo install cargo-public-api
+      - run: cargo public-api --diff-git-checkouts ${GITHUB_BASE_REF} ${GITHUB_HEAD_REF} --deny=all
+```
+
 ## Expected output
 
 Output aims to be character-by-character identical to the textual parts of the regular `cargo doc` HTML output. For example, [this item](https://docs.rs/bat/0.20.0/bat/struct.PrettyPrinter.html#method.input_files) has the following textual representation in the rendered HTML:

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -40,8 +40,8 @@ pub struct Args {
 
     /// Usage: --diff-git-checkouts <COMMIT_1> <COMMIT_2>
     ///
-    /// Rudimentary wrapper "script" to diff the public API across two different
-    /// commits. The following steps are performed:
+    /// Allows to diff the public API across two different commits. The
+    /// following steps are performed:
     ///
     /// 1. Do a literal in-tree, in-place `git checkout` of the first commit
     ///
@@ -53,18 +53,18 @@ pub struct Args {
     ///
     /// 5. Print the diff between public API in step 2 and step 4
     ///
+    /// 6. Restore the original commit before step 1
+    ///
+    /// If you have local changes, git will refuse to do `git checkout`, so your
+    /// work will not be discarded.
+    ///
     /// Do not use non-fixed commit references such as `HEAD^` since the meaning
     /// of `HEAD^` is different depending on what commit is the current commit.
     ///
-    /// While potentially annoying and in worst case destructive, doing this in
-    /// the current git repo has the benefit of making it likely for the build
-    /// to succeed. If we e.g. were to git clone a temporary copy of a commit
-    /// ourselves, the risk is high that additional steps are needed before a
-    /// build can succeed. Such as the need to set up git submodules.
-    ///
-    /// Tip: Make the second commit the same as your current commit, so that
-    /// the working tree is restored to your current state after the diff
-    /// has been printed.
+    /// Using the current git repo has the benefit of making it likely for the
+    /// build to succeed. If we e.g. were to git clone a temporary copy of a
+    /// commit ourselves, the risk is high that additional steps are needed
+    /// before a build can succeed. Such as the need to set up git submodules.
     #[clap(long, min_values = 2, max_values = 2)]
     diff_git_checkouts: Option<Vec<String>>,
 

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -71,7 +71,7 @@ pub struct Args {
     /// Usage: --diff-rustdoc-json <RUSTDOC_JSON_PATH_1> <RUSTDOC_JSON_PATH_2>
     ///
     /// Diff the public API across two different rustdoc JSON files.
-    #[clap(long, min_values = 2, max_values = 2)]
+    #[clap(long, min_values = 2, max_values = 2, hide = true)]
     diff_rustdoc_json: Option<Vec<String>>,
 
     /// Exit with failure if the specified API diff is detected. all = deny

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,22 @@
+# Architecture
+
+## Premise
+
+The premise of this tool is the following: The best way to answer the question "What is the public API of my library crate?" is to run `cargo doc --open` and look for yourself.
+
+The problem with rustdoc HTML output is that it does not lend itself well to API diffing. Luckily, a new rustdoc output format is being developed, namely [rustdoc JSON](https://github.com/rust-lang/rust/issues/76578).
+
+This tool is based on rustdoc JSON.
+
+## Listing
+
+To list the public API of a crate, we first build rustdoc JSON for it, and then parse the rustdoc JSON. Building happens with the help of the [`rustdoc-json`](https://crates.io/crates/rustdoc-json) crate. All the JSON parsing and analysis is done in the [`public-api`](https://crates.io/crates/public-api) crate. The code for these crates are found in the corresponding directories. `cargo-public-api` is essentially a convenient wrapper on top of these low-level crates. But it does contain a fair amount of its own code. It needs to manipulate git repos and write syntax highlighted output, for example.
+
+If you have a rustdoc JSON file, you can use the `public-api` binary directly on it, without using `cargo-public-api` at all.
+
+## Diffing
+
+Diffing is essentially:
+1. Build rustdoc JSON for two versions of a crate, by literally doing `git checkout`s and then building rustdoc JSON for each commit.
+1. Independently parse rustdoc JSON for both versions via the `public-api` crate to get the full public API for each version.
+1. Calculate the diff between the APIs (see [diff.rs](https://github.com/Enselic/cargo-public-api/blob/main/public-api/src/diff.rs))

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,4 +1,26 @@
-# Contributor guidelines
+# Architecture
+
+Before you get started, you might want to read about the [architecture](./ARCHITECTURE.md).
+
+# Getting started
+
+Just clone the repo. Then you can make changes and run tests:
+
+```
+git clone https://github.com/Enselic/cargo-public-api.git
+cd cargo-public-api
+
+cargo test
+```
+
+This project makes heavy use of CI. To simulate the CI pipeline locally, run
+```
+./scripts/run-ci-locally.sh
+```
+
+Note that you can run that script from within your IDE (see `.vscode/tasks.json` for an example configuration)
+
+# Constraints
 
 ## Minimum required stable Rust version
 
@@ -13,10 +35,6 @@ Since the rustdoc JSON format still changes in incompatible ways, there is a low
 Our CI runs every night, so any problems are generally detected quickly. If `cargo test` fails, make sure you have a recent enough nightly toolchain installed.
 
 # Tips to work on this tool
-
-## Running CI steps locally
-
-Run `./scripts/run-ci-locally.sh`.
 
 ## Run local copy of `cargo-public-api` on an arbitrary crate
 


### PR DESCRIPTION
```
commit 305429504e81d8893f48714cc2820656b2d1b366 (HEAD -> architecture-docs-and-more, origin/architecture-docs-and-more)
Author: Martin Nordholts <enselic@gmail.com>
Date:   Sat Aug 13 09:48:35 2022 +0200

    Add docs/ARCHITECTURE.md, improve docs/CONTRIBUTING.md

commit bd805521a5df2a90f00b34a43f2141b205fe0d9a
Author: Martin Nordholts <enselic@gmail.com>
Date:   Sat Aug 13 12:05:20 2022 +0200

    Hide `--diff-rustdoc-json` by default
    
    It is a fringe use case that I don't want regular users to be distracted
    by.

commit 41a8c46e302fb714e81ad0cc732dd30c3cef6864
Author: Martin Nordholts <enselic@gmail.com>
Date:   Sat Aug 13 12:04:43 2022 +0200

    Update `--diff-git-checkouts` help text
    
    It was forgotten in https://github.com/Enselic/cargo-public-api/pull/90.

commit 1e11bbff9efc3b35ac7d8d3e02145ad534087cde
Author: Martin Nordholts <enselic@gmail.com>
Date:   Sat Aug 13 12:03:05 2022 +0200

    README.md: Give example of CI diff check
```