### PR TITLE
Support proper rendering of hidden tuple fields (requires `nightly-2022-09-07`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "rustdoc-types"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d1ecdf1172107d4fc7001f47259299641298a67347c59a0e4216af7b6618c8"
+checksum = "f70c7ece4c950663d460645336e36bfaaee7872065a04b7c6c64570e1cb720b2"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-public-api"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "public-api"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "assert_cmd",
  "hashbag",

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ List and diff the public API of Rust library crates between releases and commits
 # Install cargo-public-api with a recent regular stable Rust toolchain
 cargo install cargo-public-api
 
-# Ensure nightly-2022-09-06 or later is installed so cargo-public-api can build rustdoc JSON for you
+# Ensure nightly-2022-09-07 or later is installed so cargo-public-api can build rustdoc JSON for you
 rustup install nightly
 ```
 
@@ -96,7 +96,8 @@ cargo public-api --with-blanket-implementations
 
 | cargo-public-api | Understands the rustdoc JSON output of  |
 | ---------------- | --------------------------------------- |
-| 0.17.x           | nightly-2022-09-06 —                    |
+| 0.18.x           | nightly-2022-09-07 —                    |
+| 0.17.x           | nightly-2022-09-06 — nightly-2022-09-06 |
 | 0.15.x — 0.16.x  | nightly-2022-08-15 — nightly-2022-09-05 |
 | 0.13.x — 0.14.x  | nightly-2022-08-10 — nightly-2022-08-14 |
 | 0.12.x           | nightly-2022-05-19 — nightly-2022-08-09 |

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "cargo-public-api"
-version = "0.17.0"
+version = "0.18.0"
 default-run = "cargo-public-api"
 description = "List and diff the public API of Rust library crates between releases and commits. Detect breaking API changes and semver violations."
 homepage = "https://github.com/Enselic/cargo-public-api"
@@ -24,7 +24,7 @@ version = "0.4.0"
 
 [dependencies.public-api]
 path = "../public-api"
-version = "0.17.0"
+version = "0.18.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -405,7 +405,8 @@ fn public_api_from_rustdoc_json_path<T: AsRef<Path>>(
             "Failed to parse rustdoc JSON at {:?}.\n\
             This version of `cargo public-api` requires at least:\n\n    {}\n\n\
             If you have that, it might be `cargo public-api` that is out of date. Try\n\
-            to install the latest versions with `cargo install cargo-public-api`",
+            to install the latest versions with `cargo install cargo-public-api`. If the\n\
+            issue remains, please report at https://github.com/Enselic/cargo-public-api/issues.",
             json_path.as_ref(),
             MINIMUM_RUSTDOC_JSON_VERSION,
         )

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "public-api"
-version = "0.17.0"
+version = "0.18.0"
 description = "List and diff the public API of Rust library crates. Relies on rustdoc JSON output from the nightly toolchain."
 homepage = "https://github.com/Enselic/cargo-public-api/tree/main/rustdoc-json"
 documentation = "https://docs.rs/public-api"

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -23,7 +23,7 @@ features = ["unbounded_depth"]
 
 [dependencies.rustdoc-types]
 # path = "/Users/martin/src/rustdoc-types"
-version = "0.15.0"
+version = "0.16.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/public-api/README.md
+++ b/public-api/README.md
@@ -16,7 +16,7 @@ The library comes with a thin bin wrapper that can be used to explore the capabi
 # Build and install the thin bin wrapper with a recent stable Rust toolchain
 cargo install public-api
 
-# Install nightly-2022-09-06 or later so you can build up-to-date rustdoc JSON files
+# Install nightly-2022-09-07 or later so you can build up-to-date rustdoc JSON files
 rustup install nightly
 ```
 

--- a/public-api/src/intermediate_public_item.rs
+++ b/public-api/src/intermediate_public_item.rs
@@ -1,7 +1,7 @@
 use crate::render;
 use std::rc::Rc;
 
-use rustdoc_types::{Id, Item};
+use rustdoc_types::{Id, Item, Type};
 
 use crate::tokens::Token;
 
@@ -18,6 +18,11 @@ pub struct IntermediatePublicItem<'a> {
     /// renamed imports (`pub use other::item as foo;`) it is the new name.
     pub name: String,
 
+    /// This is a special case for `ItemEnum::Variant(Variant::Tuple(fields))`
+    /// for which we need to pre-lookup the corresponding
+    /// `ItemEnum::StructField` in order to be able to render the item.
+    pub enum_tuple_variant_types: Vec<Option<&'a Type>>,
+
     /// The parent item. If [Self::item] is e.g. an enum variant, then the
     /// parent is an enum. We follow the chain of parents to be able to know the
     /// correct path to an item in the output.
@@ -29,9 +34,15 @@ impl<'a> IntermediatePublicItem<'a> {
     pub fn new(
         item: &'a Item,
         name: String,
+        enum_tuple_variant_types: Vec<Option<&'a Type>>,
         parent: Option<Rc<IntermediatePublicItem<'a>>>,
     ) -> Self {
-        Self { item, name, parent }
+        Self {
+            item,
+            name,
+            enum_tuple_variant_types,
+            parent,
+        }
     }
 
     #[must_use]

--- a/public-api/src/item_iterator.rs
+++ b/public-api/src/item_iterator.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, fmt::Display, rc::Rc};
 
-use rustdoc_types::{Crate, Id, Impl, Import, Item, ItemEnum, Module, Path, Type};
+use rustdoc_types::{Crate, Id, Impl, Import, Item, ItemEnum, Module, Path, Type, Variant};
 
 use super::intermediate_public_item::IntermediatePublicItem;
 use crate::{tokens::Token, Options, PublicApi};
@@ -180,10 +180,33 @@ impl<'a> ItemIterator<'a> {
         let public_item = Rc::new(IntermediatePublicItem::new(
             item,
             name.unwrap_or_else(|| String::from("<<no_name>>")),
+            self.enum_tuple_variant_types_for_item(item),
             parent,
         ));
 
         self.items_left.push(public_item);
+    }
+
+    /// See [`IntermediatePublicItem::enum_tuple_variant_types`] docs for more
+    /// info.
+    fn enum_tuple_variant_types_for_item(&self, item: &'a Item) -> Vec<Option<&'a Type>> {
+        let mut enum_tuple_variant_types: Vec<Option<&Type>> = vec![];
+        if let ItemEnum::Variant(Variant::Tuple(fields)) = &item.inner {
+            for id in fields {
+                enum_tuple_variant_types.push(
+                    if let Some(Item {
+                        inner: ItemEnum::StructField(type_),
+                        ..
+                    }) = id.as_ref().and_then(|id| self.crate_.index.get(id))
+                    {
+                        Some(type_)
+                    } else {
+                        None
+                    },
+                );
+            }
+        }
+        enum_tuple_variant_types
     }
 
     fn add_missing_id(&mut self, id: &'a Id) {
@@ -241,8 +264,7 @@ fn items_in_container(item: &Item) -> Option<&Vec<Id>> {
         ItemEnum::Enum(e) => Some(&e.variants),
         ItemEnum::Trait(t) => Some(&t.items),
         ItemEnum::Impl(i) => Some(&i.items),
-        ItemEnum::Variant(rustdoc_types::Variant::Struct(ids)) => Some(ids),
-        // TODO: `ItemEnum::Variant(rustdoc_types::Variant::Tuple(ids)) => Some(ids),` when https://github.com/rust-lang/rust/issues/92945 is fixed
+        ItemEnum::Variant(rustdoc_types::Variant::Struct { fields, .. }) => Some(fields),
         _ => None,
     }
 }

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -61,7 +61,7 @@ pub use item_iterator::PublicItem;
 /// The rustdoc JSON format is still changing, so every now and then we update
 /// this library to support the latest format. If you use this version of
 /// nightly or later, you should be fine.
-pub const MINIMUM_RUSTDOC_JSON_VERSION: &str = "nightly-2022-09-06";
+pub const MINIMUM_RUSTDOC_JSON_VERSION: &str = "nightly-2022-09-07";
 
 /// Contains various options that you can pass to [`public_api_from_rustdoc_json_str`].
 #[derive(Copy, Clone, Debug)]

--- a/public-api/tests/expected-output/comprehensive_api.txt
+++ b/public-api/tests/expected-output/comprehensive_api.txt
@@ -11,6 +11,7 @@ pub const fn comprehensive_api::functions::const_fn()
 pub enum comprehensive_api::enums::DiverseVariants
 pub enum comprehensive_api::enums::EnumWithExplicitDiscriminants
 pub enum comprehensive_api::enums::EnumWithGenerics<'a, T, D: Debug> where T: Display
+pub enum comprehensive_api::enums::EnumWithStrippedTupleVariants
 pub enum comprehensive_api::enums::SingleVariant
 pub enum variant comprehensive_api::attributes::NonExhaustive::MoreToCome
 pub enum variant comprehensive_api::enums::DiverseVariants::Recursive
@@ -21,6 +22,11 @@ pub enum variant comprehensive_api::enums::EnumWithExplicitDiscriminants::First 
 pub enum variant comprehensive_api::enums::EnumWithExplicitDiscriminants::Second = 2
 pub enum variant comprehensive_api::enums::EnumWithExplicitDiscriminants::TenPlusTen = 20
 pub enum variant comprehensive_api::enums::EnumWithGenerics::Variant
+pub enum variant comprehensive_api::enums::EnumWithStrippedTupleVariants::Double(bool, bool)
+pub enum variant comprehensive_api::enums::EnumWithStrippedTupleVariants::DoubleFirstHidden(_, bool)
+pub enum variant comprehensive_api::enums::EnumWithStrippedTupleVariants::DoubleSecondHidden(bool, _)
+pub enum variant comprehensive_api::enums::EnumWithStrippedTupleVariants::Single(usize)
+pub enum variant comprehensive_api::enums::EnumWithStrippedTupleVariants::SingleHidden(_)
 pub enum variant comprehensive_api::enums::SingleVariant::Variant
 pub extern crate comprehensive_api::rand
 pub fn comprehensive_api::Plain::f()

--- a/rustdoc-json/src/build.rs
+++ b/rustdoc-json/src/build.rs
@@ -219,6 +219,10 @@ mod tests {
     #[test]
     fn ensure_toolchain_not_overridden() {
         // The override is only meant to be changed locally, do not git commit!
-        assert!(OVERRIDDEN_TOOLCHAIN.is_none());
+        // If the var is set from the env var, that's OK, so skip the check in
+        // that case.
+        if option_env!("RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK").is_none() {
+            assert!(OVERRIDDEN_TOOLCHAIN.is_none());
+        }
     }
 }

--- a/rustdoc-json/src/build.rs
+++ b/rustdoc-json/src/build.rs
@@ -14,8 +14,8 @@ const OVERRIDDEN_TOOLCHAIN: Option<&str> = option_env!("RUSTDOC_JSON_OVERRIDDEN_
 /// Run `cargo rustdoc` to produce rustdoc JSON and return the path to the built
 /// file.
 pub(crate) fn run_cargo_rustdoc(options: BuildOptions) -> Result<PathBuf, BuildError> {
-    let status = cargo_rustdoc_command(&options).status()?;
-    if status.success() {
+    let mut cmd = cargo_rustdoc_command(&options);
+    if cmd.status()?.success() {
         rustdoc_json_path_for_manifest_path(
             options.manifest_path,
             options.package.as_deref(),

--- a/scripts/test-invocation-variants.sh
+++ b/scripts/test-invocation-variants.sh
@@ -120,11 +120,13 @@ assert_progress_and_output \
     tests/expected-output/public_api_list.txt \
     "Documenting public-api"
 
-# Make sure we can run the tool with MINIMUM_RUSTDOC_JSON_VERSION
+# Make sure we can run the tool with MINIMUM_RUSTDOC_JSON_VERSION. Test against
+# comprehensive_api, because we want any rustdoc JSON format changes to be
+# detected
 assert_progress_and_output \
-    "cargo +${minimal_toolchain} public-api --manifest-path $(pwd)/Cargo.toml" \
-    tests/expected-output/list_self_test_lib_items.txt \
-    "Documenting cargo-public-api"
+    "cargo +${minimal_toolchain} public-api --manifest-path $(pwd)/../test-apis/comprehensive_api/Cargo.toml" \
+    ../public-api/tests/expected-output/comprehensive_api.txt \
+    "Documenting comprehensive_api"
 
 # Sanity check to make sure we can make the tool build rustdoc JSON with a
 # custom toolchain via the rustup proxy mechanism (see

--- a/scripts/test-invocation-variants.sh
+++ b/scripts/test-invocation-variants.sh
@@ -47,7 +47,8 @@ assert_progress_and_output() {
 
     echo -n "${cmd} ... "
 
-    CARGO_TERM_COLOR=never ${cmd} >${stdout_path} 2>${stderr_path}
+    CARGO_TERM_COLOR=never ${cmd} >${stdout_path} 2>${stderr_path} ||
+        (echo "\n\nFAIL: Error when running `${cmd}`. Stderr: \n$(cat ${stderr_path})" && exit 1)
 
     local actual_stderr=$(cat ${stderr_path})
 

--- a/test-apis/comprehensive_api/src/enums.rs
+++ b/test-apis/comprehensive_api/src/enums.rs
@@ -24,3 +24,11 @@ where
 {
     Variant { t: &'a T, d: D },
 }
+
+pub enum EnumWithStrippedTupleVariants {
+    Single(usize),
+    SingleHidden(#[doc(hidden)] usize),
+    Double(bool, bool),
+    DoubleFirstHidden(#[doc(hidden)] bool, bool),
+    DoubleSecondHidden(bool, #[doc(hidden)] bool),
+}


### PR DESCRIPTION
Preparation for https://github.com/rust-lang/rust/pull/101462 which is currently being tested for merging.

Blocked on cargo publish of https://github.com/aDotInTheVoid/rustdoc-types/pull/17