### PR TITLE
Add build `--target` option

### DIFF
--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -112,6 +112,10 @@ pub struct Args {
     /// Useful if you have built a toolchain from source for example.
     #[clap(long, hide = true, default_value = "+nightly")]
     rustdoc_json_toolchain: String,
+
+    /// Build for the target triple
+    #[clap(long)]
+    target: Option<String>,
 }
 
 /// After listing or diffing, we might want to do some extra work. This struct
@@ -286,11 +290,14 @@ fn collect_public_items_from_commit(
         None
     };
 
-    let json_path = match rustdoc_json::build(
-        BuildOptions::default()
-            .toolchain(&args.rustdoc_json_toolchain)
-            .manifest_path(&args.manifest_path),
-    ) {
+    let mut build_options = BuildOptions::default()
+        .toolchain(&args.rustdoc_json_toolchain)
+        .manifest_path(&args.manifest_path);
+    if let Some(target) = &args.target {
+        build_options = build_options.target(target.to_owned());
+    }
+
+    let json_path = match rustdoc_json::build(build_options) {
         Err(BuildError::VirtualManifest(manifest_path)) => virtual_manifest_error(&manifest_path)?,
         res => res?,
     };

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -294,7 +294,7 @@ fn collect_public_items_from_commit(
         .toolchain(&args.rustdoc_json_toolchain)
         .manifest_path(&args.manifest_path);
     if let Some(target) = &args.target {
-        build_options = build_options.target(target.to_owned());
+        build_options = build_options.target(target.clone());
     }
 
     let json_path = match rustdoc_json::build(build_options) {

--- a/cargo-public-api/tests/expected-output/test_repo_api_latest.txt
+++ b/cargo-public-api/tests/expected-output/test_repo_api_latest.txt
@@ -1,0 +1,7 @@
+#[non_exhaustive] pub struct example_api::Struct
+pub fn example_api::Struct::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
+pub mod example_api
+pub struct example_api::StructV2
+pub struct field example_api::Struct::v1_field: usize
+pub struct field example_api::Struct::v2_field: usize
+pub struct field example_api::StructV2::field: usize

--- a/rustdoc-json/src/lib.rs
+++ b/rustdoc-json/src/lib.rs
@@ -54,6 +54,7 @@ pub enum BuildError {
 pub struct BuildOptions {
     toolchain: Option<OsString>,
     manifest_path: std::path::PathBuf,
+    target: Option<String>,
     quiet: bool,
 }
 

--- a/scripts/bless-expected-output-for-tests.sh
+++ b/scripts/bless-expected-output-for-tests.sh
@@ -22,6 +22,11 @@ RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=${toolchain} cargo run -p cargo-public-ap
 
 RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=${toolchain} cargo run -p cargo-public-api -- \
       --manifest-path "${test_git_dir}/Cargo.toml" \
+      --color=never > \
+      "cargo-public-api/tests/expected-output/test_repo_api_latest.txt"
+
+RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=${toolchain} cargo run -p cargo-public-api -- \
+      --manifest-path "${test_git_dir}/Cargo.toml" \
       --color=always --diff-git-checkouts "v0.1.0" "v0.2.0" > \
       "cargo-public-api/tests/expected-output/example_api_diff_v0.1.0_to_v0.2.0_colored.txt"
 


### PR DESCRIPTION
This makes it possible to generate public API listing for a crate for a specific Rust build target other than the default.

Such as `--target x86_64-unknown-linux-musl` or `--target wasm32-unknown-unknown`

Resolves: #105
