### PR TITLE
Rename `--rustdoc-json-toolchain` to just `--toolchain`

### DIFF
--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -109,9 +109,10 @@ pub struct Args {
     verbose: bool,
 
     /// Allows you to build rustdoc JSON with a toolchain other than `+nightly`.
-    /// Useful if you have built a toolchain from source for example.
-    #[clap(long, hide = true, default_value = "+nightly")]
-    rustdoc_json_toolchain: String,
+    /// Useful if you have built a toolchain from source for example, or if you
+    /// want to use a fixed toolchain in CI.
+    #[clap(long, default_value = "+nightly")]
+    toolchain: String,
 }
 
 /// After listing or diffing, we might want to do some extra work. This struct
@@ -288,7 +289,7 @@ fn collect_public_items_from_commit(
 
     let json_path = match rustdoc_json::build(
         BuildOptions::default()
-            .toolchain(&args.rustdoc_json_toolchain)
+            .toolchain(&args.toolchain)
             .manifest_path(&args.manifest_path),
     ) {
         Err(BuildError::VirtualManifest(manifest_path)) => virtual_manifest_error(&manifest_path)?,

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -37,7 +37,7 @@ fn list_public_items_with_lint_error() {
 #[test]
 fn custom_toolchain() {
     let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();
-    cmd.args(["--rustdoc-json-toolchain", "+nightly"]);
+    cmd.args(["--toolchain", "+nightly"]);
     assert_presence_of_own_library_items(cmd);
 }
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -61,7 +61,7 @@ You can also combine both ways:
 If you have built rustdoc yourself to try some rustdoc JSON fix, you can run `cargo public-api` with your [custom toolchain](https://rustc-dev-guide.rust-lang.org/building/how-to-build-and-run.html#creating-a-rustup-toolchain) like this:
 
 ```
-cargo public-api --rustdoc-json-toolchain +custom
+cargo public-api --toolchain +custom
 ```
 
 Another option is the `RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK` env var. Use it like this:


### PR DESCRIPTION
It was previously considered an internal arg, but I have now realized it is useful for regular users in CI to use a fixed nightly version, and the old name is simply too long and unintuitive. I will add docs later on how to make use of it.

Closes #111