### PR TITLE
Make `--verbose` print missing item IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "public-api"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "assert_cmd",
  "hashbag",

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.3.1"
 
 [dependencies.public-api]
 path = "../public-api"
-version = "0.14.0"
+version = "0.15.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/cargo-public-api/src/lib.rs
+++ b/cargo-public-api/src/lib.rs
@@ -2,3 +2,6 @@
 pub fn for_self_testing_purposes_please_ignore() {
     println!("If you are looking for the library this tool uses, it can be found at https://github.com/Enselic/cargo-public-api/tree/main/public-api");
 }
+
+/// Self-test for verbose output about missing items
+pub use public_api;

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -467,6 +467,7 @@ fn list_public_items_markdown() {
             "## Public API\n\
              * `pub fn cargo_public_api::for_self_testing_purposes_please_ignore()`\n\
              * `pub mod cargo_public_api`\n\
+             * `pub use cargo_public_api::public_api`\n\
              \n\
              ",
         )
@@ -477,7 +478,10 @@ fn list_public_items_markdown() {
 fn verbose() {
     let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();
     cmd.arg("--verbose");
-    cmd.assert().stdout(contains("Processing \"")).success();
+    cmd.assert()
+        .stdout(contains("Processing \""))
+        .stdout(contains("rustdoc JSON missing referenced item"))
+        .success();
 }
 
 #[test]
@@ -499,6 +503,7 @@ fn assert_presence_of_own_library_items(mut cmd: Command) {
         .stdout(
             "pub fn cargo_public_api::for_self_testing_purposes_please_ignore()\n\
              pub mod cargo_public_api\n\
+             pub use cargo_public_api::public_api\n\
              ",
         )
         .success();

--- a/cargo-public-api/tests/expected-output/list_self_test_lib_items_colored.txt
+++ b/cargo-public-api/tests/expected-output/list_self_test_lib_items_colored.txt
@@ -1,2 +1,3 @@
 [34mpub[0m [34mfn[0m [36mcargo_public_api[0m::[33mfor_self_testing_purposes_please_ignore[0m()
 [34mpub[0m [34mmod[0m [36mcargo_public_api[0m
+[34mpub[0m [34muse[0m [36mcargo_public_api[0m::[36mpublic_api[0m

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "public-api"
-version = "0.14.0"
+version = "0.15.0"
 description = "List and diff the public API of Rust library crates. Relies on rustdoc JSON output from the nightly toolchain."
 homepage = "https://github.com/Enselic/cargo-public-api/tree/main/rustdoc-json"
 documentation = "https://docs.rs/public-api"

--- a/public-api/examples/diff_public_api.rs
+++ b/public-api/examples/diff_public_api.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         options,
     )?;
 
-    let diff = PublicItemsDiff::between(old, new);
+    let diff = PublicItemsDiff::between(old.items, new.items);
     println!("{:#?}", diff);
 
     Ok(())

--- a/public-api/examples/list_public_api.rs
+++ b/public-api/examples/list_public_api.rs
@@ -8,7 +8,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         Options::default(),
     )?;
 
-    for public_item in public_api {
+    for public_item in public_api.items {
         println!("{}", public_item);
     }
 

--- a/public-api/public-api.txt
+++ b/public-api/public-api.txt
@@ -1,5 +1,6 @@
 #[non_exhaustive] pub enum public_api::Error
 #[non_exhaustive] pub struct public_api::Options
+#[non_exhaustive] pub struct public_api::PublicApi
 pub const public_api::MINIMUM_RUSTDOC_JSON_VERSION: &'static str
 pub enum public_api::tokens::Token
 pub enum variant public_api::Error::SerdeJsonError(serde_json::Error)
@@ -23,6 +24,7 @@ pub fn public_api::Error::source(&self) -> std::option::Option<&(dyn std::error:
 pub fn public_api::Options::clone(&self) -> Options
 pub fn public_api::Options::default() -> Self
 pub fn public_api::Options::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
+pub fn public_api::PublicApi::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
 pub fn public_api::PublicItem::clone(&self) -> PublicItem
 pub fn public_api::PublicItem::cmp(&self, other: &Self) -> std::cmp::Ordering
 pub fn public_api::PublicItem::eq(&self, other: &PublicItem) -> bool
@@ -41,7 +43,7 @@ pub fn public_api::diff::PublicItemsDiff::clone(&self) -> PublicItemsDiff
 pub fn public_api::diff::PublicItemsDiff::eq(&self, other: &PublicItemsDiff) -> bool
 pub fn public_api::diff::PublicItemsDiff::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
 pub fn public_api::diff::PublicItemsDiff::is_empty(&self) -> bool
-pub fn public_api::public_api_from_rustdoc_json_str(rustdoc_json_str: &str, options: Options) -> Result<Vec<PublicItem>>
+pub fn public_api::public_api_from_rustdoc_json_str(rustdoc_json_str: &str, options: Options) -> Result<PublicApi>
 pub fn public_api::tokens::Token::clone(&self) -> Token
 pub fn public_api::tokens::Token::cmp(&self, other: &Token) -> $crate::cmp::Ordering
 pub fn public_api::tokens::Token::eq(&self, other: &Token) -> bool
@@ -55,6 +57,8 @@ pub mod public_api::diff
 pub mod public_api::tokens
 pub struct field public_api::Options::sorted: bool
 pub struct field public_api::Options::with_blanket_implementations: bool
+pub struct field public_api::PublicApi::items: Vec<PublicItem>
+pub struct field public_api::PublicApi::missing_item_ids: Vec<String>
 pub struct field public_api::diff::ChangedPublicItem::new: PublicItem
 pub struct field public_api::diff::ChangedPublicItem::old: PublicItem
 pub struct field public_api::diff::PublicItemsDiff::added: Vec<PublicItem>

--- a/public-api/src/main.rs
+++ b/public-api/src/main.rs
@@ -49,7 +49,7 @@ fn main_() -> Result<()> {
 fn print_public_api(path: &Path, options: Options) -> Result<()> {
     let json = &std::fs::read_to_string(path)?;
 
-    for public_item in public_api_from_rustdoc_json_str(json, options)? {
+    for public_item in public_api_from_rustdoc_json_str(json, options)?.items {
         writeln!(std::io::stdout(), "{}", public_item)?;
     }
 
@@ -58,12 +58,12 @@ fn print_public_api(path: &Path, options: Options) -> Result<()> {
 
 fn print_public_api_diff(old: &Path, new: &Path, options: Options) -> Result<()> {
     let old_json = std::fs::read_to_string(old)?;
-    let old_items = public_api_from_rustdoc_json_str(&old_json, options)?;
+    let old = public_api_from_rustdoc_json_str(&old_json, options)?;
 
     let new_json = std::fs::read_to_string(new)?;
-    let new_items = public_api_from_rustdoc_json_str(&new_json, options)?;
+    let new = public_api_from_rustdoc_json_str(&new_json, options)?;
 
-    let diff = PublicItemsDiff::between(old_items, new_items);
+    let diff = PublicItemsDiff::between(old.items, new.items);
     print_diff_with_headers(&diff, &mut stdout(), "Removed:", "Changed:", "Added:")?;
 
     Ok(())

--- a/public-api/tests/public-api-lib-tests.rs
+++ b/public-api/tests/public-api-lib-tests.rs
@@ -112,12 +112,14 @@ fn public_item_ord() {
     .unwrap();
 
     let generic_arg = public_api
+        .items
         .clone()
         .into_iter()
         .find(|x| format!("{}", x).contains("generic_arg"))
         .unwrap();
 
     let generic_bound = public_api
+        .items
         .into_iter()
         .find(|x| format!("{}", x).contains("generic_bound"))
         .unwrap();
@@ -157,7 +159,7 @@ fn pretty_printed_diff() {
     )
     .unwrap();
 
-    let diff = public_api::diff::PublicItemsDiff::between(old, new);
+    let diff = public_api::diff::PublicItemsDiff::between(old.items, new.items);
     let pretty_printed = format!("{:#?}", diff);
     assert_eq!(
         pretty_printed,
@@ -186,7 +188,7 @@ fn assert_public_api_diff(old_json: &str, new_json: &str, expected: &ExpectedDif
     let old = public_api_from_rustdoc_json_str(old_json, Options::default()).unwrap();
     let new = public_api_from_rustdoc_json_str(new_json, Options::default()).unwrap();
 
-    let diff = public_api::diff::PublicItemsDiff::between(old, new);
+    let diff = public_api::diff::PublicItemsDiff::between(old.items, new.items);
 
     assert_eq!(expected.added, into_strings(diff.added));
     assert_eq!(expected.removed, into_strings(diff.removed));
@@ -221,7 +223,11 @@ fn assert_public_api_impl(
     options.with_blanket_implementations = with_blanket_implementations;
     options.sorted = true;
 
-    let actual = into_strings(public_api_from_rustdoc_json_str(rustdoc_json_str, options).unwrap());
+    let actual = into_strings(
+        public_api_from_rustdoc_json_str(rustdoc_json_str, options)
+            .unwrap()
+            .items,
+    );
 
     let expected = expected_output_to_string_vec(expected_output);
 

--- a/scripts/test-invocation-variants.sh
+++ b/scripts/test-invocation-variants.sh
@@ -6,7 +6,8 @@ cd cargo-public-api
 
 # We expect this public API to be printed to stdout
 expected_stdout="pub fn cargo_public_api::for_self_testing_purposes_please_ignore()
-pub mod cargo_public_api"
+pub mod cargo_public_api
+pub use cargo_public_api::public_api"
 
 # We want the tool to print progress when it builds rustdoc JSON. The presence
 # of this string is what we use to test if that is the case.


### PR DESCRIPTION
For a long time I have wanted to somehow allow users to know about missing IDs. It is useful to debug issues like https://github.com/Enselic/cargo-public-api/issues/103.

The downside, if it can be called that, is that we need to make the `public_api` API _slightly_ more complicated to be able to propagate this info to the apps.

But now I have done that, which enables output that looks like this:
```
% cargo public-api --verbose
Processing "/Users/martin/src/cargo-new-lib/target/doc/cargo_new_lib.json"
NOTE: rustdoc JSON missing referenced item with ID "20:0:1592"
pub mod cargo_new_lib
pub use cargo_new_lib::my_rand
```

for a `lib.rs` that looks like this:

```
pub use rand as my_rand;
```