### PR TITLE
Support for `--package workspace-package` (or short form `-p`)

### DIFF
--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -133,6 +133,10 @@ pub struct Args {
     #[clap(long)]
     /// Do not activate the `default` feature
     no_default_features: bool,
+
+    /// Package to document
+    #[clap(long, short)]
+    package: Option<String>,
 }
 
 /// After listing or diffing, we might want to do some extra work. This struct
@@ -322,6 +326,10 @@ fn collect_public_api_from_commit(commit: Option<&str>) -> Result<(PublicApi, Op
         build_options = build_options.target(target.clone());
     }
 
+    if let Some(package) = &args.package {
+        build_options = build_options.package(package);
+    }
+
     let json_path = match rustdoc_json::build(build_options) {
         Err(BuildError::VirtualManifest(manifest_path)) => virtual_manifest_error(&manifest_path)?,
         res => res?,
@@ -362,14 +370,9 @@ fn virtual_manifest_error(manifest_path: &Path) -> Result<PathBuf> {
 
 Listing or diffing the public API of an entire workspace is not supported.
 
-Either do
+Try
 
-    cd specific-crate
-    cargo public-api
-
-or
-
-    cargo public-api --manifest-path specific-crate/Cargo.toml
+    cargo public-api -p specific-crate
 ",
         manifest_path
     ))

--- a/rustdoc-json/public-api.txt
+++ b/rustdoc-json/public-api.txt
@@ -16,6 +16,7 @@ pub fn rustdoc_json::BuildOptions::features<I: IntoIterator<Item = S>, S: AsRef<
 pub fn rustdoc_json::BuildOptions::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
 pub fn rustdoc_json::BuildOptions::manifest_path(self, manifest_path: impl AsRef<Path>) -> Self
 pub fn rustdoc_json::BuildOptions::no_default_features(self, no_default_features: bool) -> Self
+pub fn rustdoc_json::BuildOptions::package(self, package: impl AsRef<str>) -> Self
 pub fn rustdoc_json::BuildOptions::quiet(self, quiet: bool) -> Self
 pub fn rustdoc_json::BuildOptions::target(self, target: String) -> Self
 pub fn rustdoc_json::BuildOptions::toolchain(self, toolchain: impl AsRef<OsStr>) -> Self

--- a/rustdoc-json/src/lib.rs
+++ b/rustdoc-json/src/lib.rs
@@ -62,6 +62,7 @@ pub struct BuildOptions {
     no_default_features: bool,
     all_features: bool,
     features: Vec<String>,
+    package: Option<String>,
 }
 
 /// Generate rustdoc JSON for a library crate. Returns the path to the freshly


### PR DESCRIPTION
depends on #115

resolves #82
