### PR TITLE
Warn about clippy lints in code, leave deny to CI

### DIFF
--- a/cargo-public-api/src/lib.rs
+++ b/cargo-public-api/src/lib.rs
@@ -1,3 +1,6 @@
+// deny in CI, only warn here
+#![warn(clippy::all, clippy::pedantic)]
+
 /// For self-testing purposes. Please ignore.
 pub fn for_self_testing_purposes_please_ignore() {
     println!("If you are looking for the library this tool uses, it can be found at https://github.com/Enselic/cargo-public-api/tree/main/public-api");

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -1,3 +1,6 @@
+// deny in CI, only warn here
+#![warn(clippy::all, clippy::pedantic)]
+
 use std::io::stdout;
 use std::path::{Path, PathBuf};
 

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -1,3 +1,6 @@
+// deny in CI, only warn here
+#![warn(clippy::all, clippy::pedantic)]
+
 //! To update expected output it is in many cases sufficient to run
 //! ```bash
 //! ./scripts/bless-expected-output-for-tests.sh

--- a/cargo-public-api/tests/cargo-public-api-readme-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-readme-tests.rs
@@ -1,3 +1,6 @@
+// deny in CI, only warn here
+#![warn(clippy::all, clippy::pedantic)]
+
 use public_api::MINIMUM_RUSTDOC_JSON_VERSION;
 
 #[test]

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -36,6 +36,9 @@
 //! in the thin binary wrapper around the library, see
 //! <https://github.com/Enselic/cargo-public-api/blob/main/public-api/src/main.rs>.
 
+// deny in CI, only warn here
+#![warn(clippy::all, clippy::pedantic, missing_docs)]
+
 mod error;
 mod intermediate_public_item;
 mod item_iterator;

--- a/public-api/src/main.rs
+++ b/public-api/src/main.rs
@@ -1,6 +1,9 @@
 //! Simple wrapper around the library. For a much more sophisticated CLI, see
 //! <https://github.com/Enselic/cargo-public-api/blob/main/cargo-public-api/src/main.rs>.
 
+// deny in CI, only warn here
+#![warn(clippy::all, clippy::pedantic)]
+
 use std::io::{stdout, ErrorKind, Write};
 use std::path::{Path, PathBuf};
 

--- a/public-api/tests/public-api-bin-tests.rs
+++ b/public-api/tests/public-api-bin-tests.rs
@@ -1,3 +1,6 @@
+// deny in CI, only warn here
+#![warn(clippy::all, clippy::pedantic)]
+
 use std::{io::BufRead, str::from_utf8};
 
 use assert_cmd::Command;

--- a/public-api/tests/public-api-lib-tests.rs
+++ b/public-api/tests/public-api-lib-tests.rs
@@ -1,3 +1,6 @@
+// deny in CI, only warn here
+#![warn(clippy::all, clippy::pedantic)]
+
 use std::fmt::Display;
 
 use pretty_assertions::assert_eq;

--- a/public-api/tests/public-api-readme-tests.rs
+++ b/public-api/tests/public-api-readme-tests.rs
@@ -1,3 +1,6 @@
+// deny in CI, only warn here
+#![warn(clippy::all, clippy::pedantic)]
+
 use public_api::MINIMUM_RUSTDOC_JSON_VERSION;
 
 #[test]

--- a/rustdoc-json/src/lib.rs
+++ b/rustdoc-json/src/lib.rs
@@ -18,6 +18,9 @@
 //! A compilable example can be found
 //! [here](https://github.com/Enselic/cargo-public-api/blob/main/rustdoc-json/examples/build-rustdoc-json.rs)
 
+// deny in CI, only warn here
+#![warn(clippy::all, clippy::pedantic, missing_docs)]
+
 use std::{ffi::OsString, path::PathBuf};
 
 mod build;


### PR DESCRIPTION
We must not use `deny` in code because that will make e.g. `git bisect` or `--diff-git-checkouts` annoying in the future.

I probably missed to add `warn` in some place, but this is a good start.

CC @Emilgardis 
