### PR TITLE
Support `cargo +toolchain public-api` syntax

### DIFF
--- a/rustdoc-json/src/build.rs
+++ b/rustdoc-json/src/build.rs
@@ -57,6 +57,12 @@ fn cargo_rustdoc_command(options: &BuildOptions) -> Command {
     let overridden_toolchain = OVERRIDDEN_TOOLCHAIN.map(OsStr::new);
     if let Some(toolchain) = overridden_toolchain.or(requested_toolchain.as_deref()) {
         command.arg(toolchain);
+    } else {
+        // Remove `RUSTUP_TOOLCHAIN` so that it does not override that the caller
+        // of this function explicitly requested no specific toolchain, i.e.
+        // that the default toolchain shall be used. See
+        // <https://rust-lang.github.io/rustup/overrides.html>.
+        command.env_remove("RUSTUP_TOOLCHAIN");
     }
 
     command.arg("rustdoc");


### PR DESCRIPTION
This is prototype quality code that is heavily influenced by https://github.com/Enselic/cargo-public-api/pull/113 and a large portion of credit should be given to @Emilgardis

@Emilgardis If we end up using this, I want to make sure you feel properly credited, since I was heavily influenced by your code. For example, I would be perfectly fine with assigning you the copyright of this code and committing it in your name. Let me know what you prefer.

Now too the issue at hand: After thinking some more about this problem, my conclusion is that we must keep `--tolchain` after all. Because `+toolchain` only works when we are invoked with the rustup proxy, i.e. as `cargo +toolchain public-api`. When we are invoked with `cargo run` in our git, and as a raw binary, i.e `cargo-public-api`, it must also be possible to specify a toolchain. Now that I think about it... maybe we should parse `+` ourselves? 🤔 My gut feeling is "no", but it can certainly be discussed.

In any case, would you mind taking a look at this draft code? It should pass all tests, and it `cargo +toolchain public-api` seems to work according to my quick testing. I will need to add proper automated tests if we decide to go this route.

Looking forward to your thoughts!