### PR TITLE
Update tests to expect output from nightly-2022-09-01

### DIFF
--- a/public-api/tests/expected-output/comprehensive_api.txt
+++ b/public-api/tests/expected-output/comprehensive_api.txt
@@ -2,7 +2,8 @@
 #[no_mangle] #[link_section = ".custom"] pub static comprehensive_api::attributes::NO_MANGLE_WITH_CUSTOM_LINK_SECTION: usize
 #[non_exhaustive] pub enum comprehensive_api::attributes::NonExhaustive
 #[repr(C)] pub struct comprehensive_api::attributes::C
-pub async fn comprehensive_api::functions::async_fn() -> impl Future<Output = ()>
+pub async fn comprehensive_api::functions::async_fn() -> ()
+pub async fn comprehensive_api::functions::async_fn_ret_bool() -> bool
 pub const comprehensive_api::constants::CONST: &'static str
 pub const comprehensive_api::traits::AssociatedConst::CONST: bool
 pub const comprehensive_api::traits::AssociatedConstDefault::CONST_WITH_DEFAULT: bool

--- a/test-apis/comprehensive_api/src/functions.rs
+++ b/test-apis/comprehensive_api/src/functions.rs
@@ -102,3 +102,5 @@ pub fn dyn_arg_two_traits_one_lifetime(d: &(dyn std::io::Write + Send + 'static)
 pub unsafe fn unsafe_fn() {}
 
 pub async fn async_fn() {}
+
+pub async fn async_fn_ret_bool() -> bool {}


### PR DESCRIPTION
Because of https://github.com/rust-lang/rust/pull/101204

We do not need to update `MINIMUM_RUSTDOC_JSON_VERSION` since the JSON format has not changed. The consequence is only that developers that run tests need at least nightly-2022-09-01.