### PR TITLE
Replace test-utils crate with `#[path = "..."]` to allow cargo publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,6 @@ dependencies = [
  "public-api",
  "rustdoc-json",
  "tempfile",
- "test-utils",
  "thiserror",
 ]
 
@@ -422,7 +421,6 @@ dependencies = [
  "rustdoc-types",
  "serde",
  "serde_json",
- "test-utils",
  "thiserror",
 ]
 
@@ -585,13 +583,6 @@ name = "termtree"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
-
-[[package]]
-name = "test-utils"
-version = "0.1.0"
-dependencies = [
- "rustdoc-json",
-]
 
 [[package]]
 name = "textwrap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,6 @@ members = [
 
     # High-level CLI for "rustdoc-json" and "public-api"
     "cargo-public-api",
-
-    # Contains test utilities used by above crates
-    "test-utils"
 ]
 
 # Test APIs can't be part of the workspace because some test API crates use

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -31,7 +31,3 @@ assert_cmd = "2.0.4"
 predicates = "2.1.1"
 tempfile = "3.3.0"
 cargo_metadata = "0.14.2"
-
-[dev-dependencies.test-utils]
-path = "../test-utils"
-version = "*"

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -14,6 +14,9 @@ use std::{
 
 use assert_cmd::Command;
 use predicates::str::contains;
+
+#[path = "../../test-utils/src/lib.rs"]
+mod test_utils;
 use test_utils::rustdoc_json_path_for_crate;
 
 #[path = "../src/git_utils.rs"] // Say NO to copy-paste!

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -33,7 +33,3 @@ itertools = { version = "0.10.3", default-features = false }
 [dev-dependencies.rustdoc-json]
 path = "../rustdoc-json"
 version = "0.4.0"
-
-[dev-dependencies.test-utils]
-path = "../test-utils"
-version = "*"

--- a/public-api/tests/public-api-bin-tests.rs
+++ b/public-api/tests/public-api-bin-tests.rs
@@ -6,6 +6,8 @@ use std::{io::BufRead, str::from_utf8};
 use assert_cmd::Command;
 use public_api::MINIMUM_RUSTDOC_JSON_VERSION;
 
+#[path = "../../test-utils/src/lib.rs"]
+mod test_utils;
 use test_utils::rustdoc_json_path_for_crate;
 
 #[test]

--- a/public-api/tests/public-api-lib-tests.rs
+++ b/public-api/tests/public-api-lib-tests.rs
@@ -6,6 +6,8 @@ use std::fmt::Display;
 use pretty_assertions::assert_eq;
 use public_api::{public_api_from_rustdoc_json_str, Error, Options};
 
+#[path = "../../test-utils/src/lib.rs"]
+mod test_utils;
 use test_utils::rustdoc_json_str_for_crate;
 
 struct ExpectedDiff<'a> {

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,8 +1,0 @@
-[package]
-name = "test-utils"
-version = "0.1.0"
-edition = "2021"
-
-[dependencies.rustdoc-json]
-path = "../rustdoc-json"
-version = "*"

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -25,6 +25,7 @@ pub fn rustdoc_json_path_for_crate(test_crate: &str) -> PathBuf {
 /// Helper to get a String of freshly built rustdoc JSON for the given
 /// test-crate.
 #[must_use]
+#[allow(dead_code)]
 pub fn rustdoc_json_str_for_crate(test_crate: &str) -> String {
     std::fs::read_to_string(rustdoc_json_path_for_crate(test_crate)).unwrap()
 }


### PR DESCRIPTION
This makes `cargo publish --dry-run -p public-api` pass. See https://github.com/Enselic/cargo-public-api/pull/130#issuecomment-1236195191 and onwards.

Unfortunately rust-analyzer becomes confused, which is annoying, but not a super big deal, and it will probably be supported in the future:

<img width="939" alt="Screenshot 2022-09-04 at 05 23 02" src="https://user-images.githubusercontent.com/115040/188295708-2d3b7d7d-e6b0-47f4-b5aa-4757caa3834f.png">
