### PR TITLE
test-invocation-variants.sh: Don't hardcode expected output

### DIFF
--- a/cargo-public-api/tests/expected-output/list_self_test_lib_items.txt
+++ b/cargo-public-api/tests/expected-output/list_self_test_lib_items.txt
@@ -1,0 +1,3 @@
+pub fn cargo_public_api::for_self_testing_purposes_please_ignore()
+pub mod cargo_public_api
+pub use cargo_public_api::public_api

--- a/scripts/bless-expected-output-for-tests.sh
+++ b/scripts/bless-expected-output-for-tests.sh
@@ -50,3 +50,8 @@ RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=${toolchain} cargo run -p cargo-public-ap
       --manifest-path "cargo-public-api/Cargo.toml" \
       --color=always > \
       "cargo-public-api/tests/expected-output/list_self_test_lib_items_colored.txt"
+
+RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=${toolchain} cargo run -p cargo-public-api -- \
+      --manifest-path "cargo-public-api/Cargo.toml" \
+      --color=never > \
+      "cargo-public-api/tests/expected-output/list_self_test_lib_items.txt"

--- a/scripts/test-invocation-variants.sh
+++ b/scripts/test-invocation-variants.sh
@@ -6,44 +6,34 @@ cd cargo-public-api
 
 td=$(mktemp -d)
 
-# We expect this public API to be printed to stdout
-expected_stdout="pub fn cargo_public_api::for_self_testing_purposes_please_ignore()
-pub mod cargo_public_api
-pub use cargo_public_api::public_api"
-
-# We want the tool to print progress when it builds rustdoc JSON. The presence
-# of this string is what we use to test if that is the case.
-expected_stderr="Documenting cargo-public-api"
-
 # We write stdout and stderr to temporary files so we can later assert on their
 # content.
 stdout_path="${td}/cargo-public-api-test-invocation-variants-stdout"
 stderr_path="${td}/cargo-public-api-test-invocation-variants-stderr"
 
-# Clean the temp directory
+# Clean the temp directory on EXIT so the tests don't have to worry about cleanup
 trap 'rm -rf "${td}"' EXIT
 
 # Helper that runs the command passed as the first arg, and then asserts on
 # stdout and stderr
 assert_progress_and_output() {
     local cmd="$1"
+    local expected_stdout_path="$2"
+    local expected_stderr_substring="$3"
 
     echo -n "${cmd} ... "
 
     CARGO_TERM_COLOR=never ${cmd} >${stdout_path} 2>${stderr_path}
 
-    local actual_stdout=$(cat ${stdout_path})
     local actual_stderr=$(cat ${stderr_path})
 
-    rm ${stdout_path} ${stderr_path}
-
-    if [[ ${actual_stdout} != ${expected_stdout} ]]; then
-        echo -e "FAIL: \n${actual_stdout}\n!=\n${expected_stdout}"
+    if ! diff -u "${expected_stdout_path}" "${stdout_path}"; then
+        echo -e "FAIL: \`diff -u ${expected_stdout_path} ${stdout_path}\` was not empty"
         exit 1
     fi
 
-    if [[ "${actual_stderr}" != *"${expected_stderr}"* ]]; then
-        echo -e "FAIL: \n${actual_stderr}\ndoes not contain \`${expected_stderr}\`"
+    if [[ "${actual_stderr}" != *"${expected_stderr_substring}"* ]]; then
+        echo -e "FAIL: \n${actual_stderr}\ndoes not contain \`${expected_stderr_substring}\`"
         exit 1
     fi
 
@@ -53,32 +43,59 @@ assert_progress_and_output() {
 # Now we are ready to run the actual tests
 
 # Make sure we can conveniently run the tool from the source dir
-assert_progress_and_output "cargo run"
+# We want the tool to print progress when it builds rustdoc JSON. The presence
+# of "Documenting cargo-public-api" on stderr is what we use to test if that is
+# the case.
+assert_progress_and_output \
+    "cargo run" \
+    tests/expected-output/list_self_test_lib_items.txt \
+    "Documenting cargo-public-api"
 
 # Make sure we can conveniently run the tool from the source dir on an external crate
-assert_progress_and_output "cargo run -- --manifest-path $(pwd)/Cargo.toml"
+assert_progress_and_output \
+    "cargo run -- --manifest-path $(pwd)/Cargo.toml" \
+    tests/expected-output/list_self_test_lib_items.txt \
+    "Documenting cargo-public-api"
 
 # Install the tool
 cargo install --debug --path .
 
 # Make sure we can run the tool on the current directory stand-alone
-assert_progress_and_output "cargo-public-api"
+assert_progress_and_output \
+    "cargo-public-api" \
+    tests/expected-output/list_self_test_lib_items.txt \
+    "Documenting cargo-public-api"
 
 # Make sure we can run the tool on an external directory stand-alone
-assert_progress_and_output "cargo-public-api --manifest-path $(pwd)/Cargo.toml"
+assert_progress_and_output \
+    "cargo-public-api --manifest-path $(pwd)/Cargo.toml" \
+    tests/expected-output/list_self_test_lib_items.txt \
+    "Documenting cargo-public-api"
 
 # Make sure we can run the tool with a specified package from a virtual manifest
-(cd .. && assert_progress_and_output "cargo-public-api --package cargo-public-api")
+(cd .. && assert_progress_and_output \
+    "cargo-public-api --package cargo-public-api" \
+    cargo-public-api/tests/expected-output/list_self_test_lib_items.txt \
+    "Documenting cargo-public-api")
 
 # Make sure we can run the tool on the current directory as a cargo sub-command
-assert_progress_and_output "cargo public-api"
+assert_progress_and_output \
+    "cargo public-api" \
+    tests/expected-output/list_self_test_lib_items.txt \
+    "Documenting cargo-public-api"
 
 # Make sure we can run the tool on an external directory as a cargo sub-command
-assert_progress_and_output "cargo public-api --manifest-path $(pwd)/Cargo.toml"
+assert_progress_and_output \
+    "cargo public-api --manifest-path $(pwd)/Cargo.toml" \
+    tests/expected-output/list_self_test_lib_items.txt \
+    "Documenting cargo-public-api"
 
 # Make sure we can run the tool with MINIMUM_RUSTDOC_JSON_VERSION
 rustup toolchain install --no-self-update nightly-2022-08-15
-assert_progress_and_output "cargo +nightly-2022-08-15 public-api --manifest-path $(pwd)/Cargo.toml"
+assert_progress_and_output \
+    "cargo +nightly-2022-08-15 public-api --manifest-path $(pwd)/Cargo.toml" \
+    tests/expected-output/list_self_test_lib_items.txt \
+    "Documenting cargo-public-api"
 
 # Sanity check to make sure we can make the tool build rustdoc JSON with a
 # custom toolchain via the rustup proxy mechanism (see


### PR DESCRIPTION
This is a preparation for an upcoming PR where the expected output will come from public-api lib.rs instead of cargo-public-api lib.rs.