### PR TITLE
Support edge-case command `cargo public-api -p public-api`

### DIFF
--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -326,13 +326,13 @@ impl Args {
 }
 
 /// Get CLI args via `clap` while also handling when we are invoked as a cargo
-/// subcommand
+/// subcommand. When the user runs `cargo public-api -a -b -c` our args will be
+/// `cargo-public-api public-api -a -b -c`.
 fn get_args() -> Args {
-    // If we are invoked by cargo as `cargo public-api`, the second arg will
-    // be "public-api". Remove it before passing args on to clap. If we are
-    // not invoked as a cargo subcommand, it will not be part of args at all, so
-    // it is safe to filter it out also in that case.
-    let args = std::env::args_os().filter(|x| x != "public-api");
+    let args = std::env::args_os()
+        .enumerate()
+        .filter(|(index, arg)| *index != 1 || arg != "public-api")
+        .map(|(_, arg)| arg);
 
     Args::parse_from(args)
 }

--- a/scripts/bless-expected-output-for-tests.sh
+++ b/scripts/bless-expected-output-for-tests.sh
@@ -37,6 +37,11 @@ RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=${toolchain} cargo run -p cargo-public-ap
       "cargo-public-api/tests/expected-output/example_api_diff_v0.2.0_to_v0.3.0.txt"
 
 RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=${toolchain} cargo run -p cargo-public-api -- \
+      --manifest-path "public-api/Cargo.toml" \
+      --color=never > \
+      "cargo-public-api/tests/expected-output/public_api_list.txt"
+
+RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=${toolchain} cargo run -p cargo-public-api -- \
       --manifest-path "${test_git_dir}/Cargo.toml" \
       --color=never > \
       "cargo-public-api/tests/expected-output/test_repo_api_latest.txt"

--- a/scripts/test-invocation-variants.sh
+++ b/scripts/test-invocation-variants.sh
@@ -90,6 +90,12 @@ assert_progress_and_output \
     tests/expected-output/list_self_test_lib_items.txt \
     "Documenting cargo-public-api"
 
+# Make sure cargo subcommand args filtering of 'public-api' is not too aggressive
+assert_progress_and_output \
+    "cargo public-api -p public-api" \
+    tests/expected-output/public_api_list.txt \
+    "Documenting public-api"
+
 # Make sure we can run the tool with MINIMUM_RUSTDOC_JSON_VERSION
 rustup toolchain install --no-self-update nightly-2022-08-15
 assert_progress_and_output \


### PR DESCRIPTION
Depends on https://github.com/Enselic/cargo-public-api/pull/132