### PR TITLE
Add `--print-minimum-rustdoc-json-version` to `public-api`

### DIFF
--- a/public-api/src/main.rs
+++ b/public-api/src/main.rs
@@ -24,11 +24,16 @@ type Result<T> = std::result::Result<T, Error>;
 struct Args {
     help: bool,
     with_blanket_implementations: bool,
+    print_minimum_rustdoc_json_version: bool,
     files: Vec<PathBuf>,
 }
 
 fn main_() -> Result<()> {
     let args = args();
+    if args.print_minimum_rustdoc_json_version {
+        println!("{}", MINIMUM_RUSTDOC_JSON_VERSION);
+        return Ok(());
+    }
 
     let mut options = Options::default();
     options.with_blanket_implementations = args.with_blanket_implementations;
@@ -160,6 +165,8 @@ fn args() -> Args {
     for arg in std::env::args_os().skip(1) {
         if arg == "--with-blanket-implementations" {
             args.with_blanket_implementations = true;
+        } else if arg == "--print-minimum-rustdoc-json-version" {
+            args.print_minimum_rustdoc_json_version = true;
         } else if arg == "--help" || arg == "-h" {
             args.help = true;
         } else {

--- a/public-api/tests/public-api-bin-tests.rs
+++ b/public-api/tests/public-api-bin-tests.rs
@@ -177,6 +177,16 @@ fn no_args_shows_help() {
 }
 
 #[test]
+fn print_minimum_rustdoc_json_version() {
+    let mut cmd = Command::cargo_bin("public-api").unwrap();
+    cmd.arg("--print-minimum-rustdoc-json-version");
+    cmd.assert()
+        .stdout(format!("{}\n", MINIMUM_RUSTDOC_JSON_VERSION))
+        .stderr("")
+        .success();
+}
+
+#[test]
 fn too_many_args_shows_help() {
     let mut cmd = Command::cargo_bin("public-api").unwrap();
     cmd.args(&["too", "many", "args"]);

--- a/scripts/test-invocation-variants.sh
+++ b/scripts/test-invocation-variants.sh
@@ -2,7 +2,11 @@
 set -o errexit -o nounset -o pipefail
 
 # The oldest nightly toolchain that we support
-minimal_toolchain=$(sed -n 's/pub const MINIMUM_RUSTDOC_JSON_VERSION: &str = "\(nightly-[^"]\+\)";/\1/p' public-api/src/lib.rs)
+minimal_toolchain=$(cargo run -p public-api -- --print-minimum-rustdoc-json-version)
+if [ -z "${minimal_toolchain}" ]; then
+    echo "FAIL: Could not figure out minimal_toolchain"
+    exit 1
+fi
 
 # A toolchain that produces rustdoc JSON that we do not understand how to parse.
 unusable_toolchain="nightly-2022-06-01"


### PR DESCRIPTION
And use it in `test-invocation-variants.sh`. The current hack is already broken for me 😳

Idea from https://github.com/Enselic/cargo-public-api/pull/134#discussion_r962331019