### PR TITLE
Properly render short-hand qualified paths with `Self::`

### DIFF
--- a/public-api/src/render.rs
+++ b/public-api/src/render.rs
@@ -543,11 +543,20 @@ fn render_borrowed_ref(lifetime: Option<&str>, mutable: bool, type_: &Type) -> V
 }
 
 fn render_qualified_path(type_: &Type, trait_: &Path, name: &str) -> Vec<Token> {
-    let mut output = vec![Token::symbol("<")];
-    output.extend(render_type(type_));
-    output.extend(vec![ws!(), Token::keyword("as"), ws!()]);
-    output.extend(render_resolved_path(trait_));
-    output.push(Token::symbol(">::"));
+    let mut output = vec![];
+    match type_ {
+        Type::Generic(name) if name == "Self" && trait_.name.is_empty() => {
+            output.push(Token::keyword("Self"));
+        }
+        _ => {
+            output.push(Token::symbol("<"));
+            output.extend(render_type(type_));
+            output.extend(vec![ws!(), Token::keyword("as"), ws!()]);
+            output.extend(render_resolved_path(trait_));
+            output.push(Token::symbol(">"));
+        }
+    }
+    output.push(Token::symbol("::"));
     output.push(Token::identifier(name));
     output
 }
@@ -1073,7 +1082,8 @@ mod test {
                 Token::keyword("as"),
                 ws!(),
                 Token::type_("trait"),
-                Token::symbol(">::"),
+                Token::symbol(">"),
+                Token::symbol("::"),
                 Token::identifier("name"),
             ],
             "<type as trait>::name",

--- a/public-api/tests/expected-output/comprehensive_api.txt
+++ b/public-api/tests/expected-output/comprehensive_api.txt
@@ -80,6 +80,8 @@ pub fn comprehensive_api::structs::Plain::s3(&mut self)
 pub fn comprehensive_api::structs::Plain::s4(&'a self)
 pub fn comprehensive_api::structs::WithLifetimeAndGenericParam::new(unit_ref: &'b Unit, t: String) -> Self
 pub fn comprehensive_api::traits::Simple::act()
+pub fn comprehensive_api::traits::TraitReferencingOwnAssociatedType::own_associated_type_output(&self) -> Self::OwnAssociatedType
+pub fn comprehensive_api::traits::TraitReferencingOwnAssociatedType::own_associated_type_output_explicit_as(&self) -> <Self as TraitReferencingOwnAssociatedType>::OwnAssociatedType
 pub macro comprehensive_api::simple_macro!
 pub mod comprehensive_api
 pub mod comprehensive_api::attributes
@@ -147,7 +149,9 @@ pub trait comprehensive_api::traits::AssociatedConstDefault
 pub trait comprehensive_api::traits::AssociatedType
 pub trait comprehensive_api::traits::Empty
 pub trait comprehensive_api::traits::Simple
+pub trait comprehensive_api::traits::TraitReferencingOwnAssociatedType
 pub type comprehensive_api::traits::AssociatedType::Type
+pub type comprehensive_api::traits::TraitReferencingOwnAssociatedType::OwnAssociatedType
 pub type comprehensive_api::typedefs::RedefinedResult<T, E> = Result<T, E>
 pub type comprehensive_api::typedefs::TypedefPlain = Plain
 pub union comprehensive_api::unions::Basic

--- a/public-api/tests/expected-output/comprehensive_api.txt
+++ b/public-api/tests/expected-output/comprehensive_api.txt
@@ -82,6 +82,7 @@ pub fn comprehensive_api::structs::WithLifetimeAndGenericParam::new(unit_ref: &'
 pub fn comprehensive_api::traits::Simple::act()
 pub fn comprehensive_api::traits::TraitReferencingOwnAssociatedType::own_associated_type_output(&self) -> Self::OwnAssociatedType
 pub fn comprehensive_api::traits::TraitReferencingOwnAssociatedType::own_associated_type_output_explicit_as(&self) -> <Self as TraitReferencingOwnAssociatedType>::OwnAssociatedType
+pub fn comprehensive_api::traits::TraitWithGenerics::bar() -> <Self as TraitWithGenerics<T, U>>::Foo
 pub macro comprehensive_api::simple_macro!
 pub mod comprehensive_api
 pub mod comprehensive_api::attributes
@@ -150,8 +151,10 @@ pub trait comprehensive_api::traits::AssociatedType
 pub trait comprehensive_api::traits::Empty
 pub trait comprehensive_api::traits::Simple
 pub trait comprehensive_api::traits::TraitReferencingOwnAssociatedType
+pub trait comprehensive_api::traits::TraitWithGenerics<T, U>
 pub type comprehensive_api::traits::AssociatedType::Type
 pub type comprehensive_api::traits::TraitReferencingOwnAssociatedType::OwnAssociatedType
+pub type comprehensive_api::traits::TraitWithGenerics::Foo
 pub type comprehensive_api::typedefs::RedefinedResult<T, E> = Result<T, E>
 pub type comprehensive_api::typedefs::TypedefPlain = Plain
 pub union comprehensive_api::unions::Basic

--- a/test-apis/comprehensive_api/src/traits.rs
+++ b/test-apis/comprehensive_api/src/traits.rs
@@ -25,6 +25,12 @@ pub trait TraitReferencingOwnAssociatedType {
     ) -> <Self as TraitReferencingOwnAssociatedType>::OwnAssociatedType;
 }
 
+pub trait TraitWithGenerics<T, U> {
+    type Foo;
+
+    fn bar() -> <Self as TraitWithGenerics<T, U>>::Foo;
+}
+
 // error[E0658]: associated type defaults are unstable
 // skip for now
 // pub trait AssociatedTypeDefault {

--- a/test-apis/comprehensive_api/src/traits.rs
+++ b/test-apis/comprehensive_api/src/traits.rs
@@ -16,6 +16,15 @@ pub trait AssociatedType {
     type Type;
 }
 
+pub trait TraitReferencingOwnAssociatedType {
+    type OwnAssociatedType;
+
+    fn own_associated_type_output(&self) -> Self::OwnAssociatedType;
+    fn own_associated_type_output_explicit_as(
+        &self,
+    ) -> <Self as TraitReferencingOwnAssociatedType>::OwnAssociatedType;
+}
+
 // error[E0658]: associated type defaults are unstable
 // skip for now
 // pub trait AssociatedTypeDefault {


### PR DESCRIPTION
Closes #140