### PR TITLE
Make `test-invocation-variants.sh` run 200% faster

### DIFF
--- a/cargo-public-api/tests/expected-output/rustdoc_json_list.txt
+++ b/cargo-public-api/tests/expected-output/rustdoc_json_list.txt
@@ -1,0 +1,25 @@
+pub enum rustdoc_json::BuildError
+pub enum variant rustdoc_json::BuildError::CargoMetadataError(cargo_metadata::Error)
+pub enum variant rustdoc_json::BuildError::CargoTomlError(cargo_toml::Error)
+pub enum variant rustdoc_json::BuildError::General(String)
+pub enum variant rustdoc_json::BuildError::IoError(std::io::Error)
+pub enum variant rustdoc_json::BuildError::VirtualManifest(PathBuf)
+pub fn rustdoc_json::BuildError::fmt(&self, __formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result
+pub fn rustdoc_json::BuildError::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
+pub fn rustdoc_json::BuildError::from(source: cargo_metadata::Error) -> Self
+pub fn rustdoc_json::BuildError::from(source: cargo_toml::Error) -> Self
+pub fn rustdoc_json::BuildError::from(source: std::io::Error) -> Self
+pub fn rustdoc_json::BuildError::source(&self) -> std::option::Option<&(dyn std::error::Error + 'static)>
+pub fn rustdoc_json::BuildOptions::all_features(self, all_features: bool) -> Self
+pub fn rustdoc_json::BuildOptions::default() -> Self
+pub fn rustdoc_json::BuildOptions::features<I: IntoIterator<Item = S>, S: AsRef<str>>(self, features: I) -> Self
+pub fn rustdoc_json::BuildOptions::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
+pub fn rustdoc_json::BuildOptions::manifest_path(self, manifest_path: impl AsRef<Path>) -> Self
+pub fn rustdoc_json::BuildOptions::no_default_features(self, no_default_features: bool) -> Self
+pub fn rustdoc_json::BuildOptions::package(self, package: impl AsRef<str>) -> Self
+pub fn rustdoc_json::BuildOptions::quiet(self, quiet: bool) -> Self
+pub fn rustdoc_json::BuildOptions::target(self, target: String) -> Self
+pub fn rustdoc_json::BuildOptions::toolchain(self, toolchain: impl Into<Option<String>>) -> Self
+pub fn rustdoc_json::build(options: BuildOptions) -> Result<PathBuf, BuildError>
+pub mod rustdoc_json
+pub struct rustdoc_json::BuildOptions

--- a/public-api/tests/expected-output/comprehensive_api.txt
+++ b/public-api/tests/expected-output/comprehensive_api.txt
@@ -28,7 +28,7 @@ pub enum variant comprehensive_api::enums::EnumWithStrippedTupleVariants::Double
 pub enum variant comprehensive_api::enums::EnumWithStrippedTupleVariants::Single(usize)
 pub enum variant comprehensive_api::enums::EnumWithStrippedTupleVariants::SingleHidden(_)
 pub enum variant comprehensive_api::enums::SingleVariant::Variant
-pub extern crate comprehensive_api::rand
+pub extern crate comprehensive_api::unicode_ident
 pub fn comprehensive_api::Plain::f()
 pub fn comprehensive_api::Plain::new() -> Plain
 pub fn comprehensive_api::Plain::s1(self)
@@ -139,7 +139,6 @@ pub struct field comprehensive_api::structs::WithLifetimeAndGenericParam::t: T
 pub struct field comprehensive_api::structs::WithLifetimeAndGenericParam::unit_ref: &'a Unit
 pub struct field comprehensive_api::unions::Basic::x: usize
 pub struct field comprehensive_api::unions::Basic::y: usize
-pub trait comprehensive_api::RngCore
 pub trait comprehensive_api::higher_ranked_trait_bounds::B<'x>
 pub trait comprehensive_api::higher_ranked_trait_bounds::Trait<'x>
 pub trait comprehensive_api::traits::AssociatedConst
@@ -153,10 +152,11 @@ pub type comprehensive_api::typedefs::TypedefPlain = Plain
 pub union comprehensive_api::unions::Basic
 pub unsafe fn comprehensive_api::functions::unsafe_fn()
 pub unsafe trait comprehensive_api::traits::UnsafeTrait
-pub use comprehensive_api::<<rand::distributions::uniform::*>>
+pub use comprehensive_api::<<unicode_ident::*>>
 pub use comprehensive_api::exports::recursion_1::recursion_2::recursion_1
 pub use comprehensive_api::exports::recursion_2::recursion_1::recursion_2
 pub use comprehensive_api::exports::recursion_glob_1::<<super::recursion_glob_1::*>>
 pub use comprehensive_api::exports::recursion_glob_2::<<super::recursion_glob_2::*>>
+pub use comprehensive_api::is_xid_start
 pub use comprehensive_api::my_i32
 pub use comprehensive_api::u32

--- a/test-apis/comprehensive_api/Cargo.toml
+++ b/test-apis/comprehensive_api/Cargo.toml
@@ -4,5 +4,8 @@ name = "comprehensive_api"
 version = "0.1.0"
 edition = "2021"
 
+# So we can test "pub extern crate ..." statements. This should be a crate
+# without any dependencies, so that it is quick to compile, which speeds up
+# running tests, since we re-compile this crate with different toolchains.
 [dependencies]
-rand = "0.8.5" # So we can test "pub extern crate ..." statements
+unicode-ident = "1.0.3"

--- a/test-apis/comprehensive_api/src/lib.rs
+++ b/test-apis/comprehensive_api/src/lib.rs
@@ -1,8 +1,3 @@
-pub extern crate rand;
-// We expect rustdoc JSON to not contain these external items
-pub use rand::distributions::uniform::*;
-pub use rand::RngCore;
-
 mod private;
 pub use private::StructInPrivateMod;
 
@@ -36,3 +31,12 @@ pub mod unions;
 
 pub use i32 as my_i32;
 pub use u32;
+
+pub extern crate unicode_ident;
+
+// We currently expect rustdoc JSON to not contain these external items, see
+// <https://github.com/rust-lang/rust/issues/99513>
+pub use unicode_ident::*;
+
+// This explicitly exported item we expect to see in the rustdoc JSON however
+pub use unicode_ident::is_xid_start;


### PR DESCRIPTION
On my machine it now runs in ~8s instead of ~24s, mainly by doing this:

* Make comprehensive_api depend in a crate without any more dependencies

* Make tests use comprehensive_api instead of cargo-public-api. The former has only one small dependency and builds fast, whereas the latter has many dependencies and builds slow.