### PR TITLE
Make all `cargo-public-api` tests regular `cargo test` tests

### DIFF
--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -26,8 +26,12 @@ mod git_utils;
 
 #[test]
 fn list_public_items() {
-    let cmd = Command::cargo_bin("cargo-public-api").unwrap();
-    assert_presence_of_own_library_items(cmd);
+    let mut cmd = TestCmd::new();
+    cmd.assert()
+        .stdout(include_str!(
+            "../../public-api/tests/expected-output/example_api-v0.3.0.txt"
+        ))
+        .success();
 }
 
 #[test]
@@ -52,10 +56,30 @@ fn custom_toolchain() {
 
 #[test]
 fn list_public_items_explicit_manifest_path() {
+    let test_repo = TestRepo::new();
+    let mut test_repo_manifest = PathBuf::from(test_repo.path());
+    test_repo_manifest.push("Cargo.toml");
+
     let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();
     cmd.arg("--manifest-path");
-    cmd.arg(current_dir_and("Cargo.toml"));
-    assert_presence_of_own_library_items(cmd);
+    cmd.arg(&test_repo_manifest);
+    cmd.assert()
+        .stdout(include_str!(
+            "../../public-api/tests/expected-output/example_api-v0.3.0.txt"
+        ))
+        .success();
+}
+
+/// Make sure we can run the tool with a specified package from a virtual
+/// manifest. Use the smallest crate in our workspace to make tests run fast
+#[test]
+fn list_public_items_via_package_spec() {
+    let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();
+    cmd.arg("--package");
+    cmd.arg("rustdoc-json");
+    cmd.assert()
+        .stdout(include_str!("./expected-output/rustdoc_json_list.txt"))
+        .success();
 }
 
 #[test]

--- a/public-api/tests/expected-output/example_api-v0.3.0.txt
+++ b/public-api/tests/expected-output/example_api-v0.3.0.txt
@@ -1,0 +1,7 @@
+#[non_exhaustive] pub struct example_api::Struct
+pub fn example_api::Struct::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
+pub mod example_api
+pub struct example_api::StructV2
+pub struct field example_api::Struct::v1_field: usize
+pub struct field example_api::Struct::v2_field: usize
+pub struct field example_api::StructV2::field: usize

--- a/scripts/bless-expected-output-for-tests.sh
+++ b/scripts/bless-expected-output-for-tests.sh
@@ -29,8 +29,13 @@ done
 
 BLESS=1 RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=${toolchain} cargo test -- cargo_public_api_with_features
 
-RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=${toolchain} cargo run -p public-api -- --with-blanket-implementations "./test-apis/example_api-v0.2.0/target/doc/example_api.json" > \
+RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=${toolchain} cargo run -p public-api -- \
+      --with-blanket-implementations "./test-apis/example_api-v0.2.0/target/doc/example_api.json" > \
       "public-api/tests/expected-output/example_api-v0.2.0-with-blanket-implementations.txt"
+
+RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=${toolchain} cargo run -p cargo-public-api -- \
+      --manifest-path "${test_git_dir}/Cargo.toml" > \
+      "public-api/tests/expected-output/example_api-v0.3.0.txt"
 
 RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=${toolchain} cargo run -p cargo-public-api -- \
       --manifest-path "${test_git_dir}/Cargo.toml" \


### PR DESCRIPTION
The more tests we have in `cargo test` the better, not least because of increased parallelization when running tests. It also takes us one step closer to being able to remove `cargo-public-api/src/lib.rs` completely.