### PR TITLE
Replace abandoned `ansi_term` with `nu-ansi-term`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,13 +96,13 @@ dependencies = [
 name = "cargo-public-api"
 version = "0.19.0"
 dependencies = [
- "ansi_term",
  "anyhow",
  "assert_cmd",
  "atty",
  "cargo_metadata",
  "clap",
  "diff",
+ "nu-ansi-term",
  "predicates",
  "public-api",
  "rustdoc-json",
@@ -308,6 +308,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +343,12 @@ checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "predicates"

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 repository = "https://github.com/Enselic/cargo-public-api"
 
 [dependencies]
-ansi_term = "0.12.1"
+nu-ansi-term = "0.46.0"
 anyhow = "1.0.53"
 atty = "0.2.14"
 clap = { version = "3.1.2", features = ["derive"] }

--- a/cargo-public-api/src/plain.rs
+++ b/cargo-public-api/src/plain.rs
@@ -1,6 +1,6 @@
 use std::io::{Result, Write};
 
-use ansi_term::{ANSIString, ANSIStrings, Color, Style};
+use nu_ansi_term::{AnsiString, AnsiStrings, Color, Style};
 use public_api::{diff::PublicItemsDiff, tokens::Token, PublicItem};
 
 use crate::Args;
@@ -83,14 +83,14 @@ fn color_item(item: &public_api::PublicItem) -> String {
 
 fn color_token_stream<'a>(tokens: impl Iterator<Item = &'a Token>, bg: Option<Color>) -> String {
     let styled = tokens.map(|t| color_item_token(t, bg)).collect::<Vec<_>>();
-    ANSIStrings(&styled).to_string()
+    AnsiStrings(&styled).to_string()
 }
 
 /// Color the given Token to render it with a nice syntax highlighting. The
 /// theme is inspired by dark+ in VS Code and uses the default colors from the
 /// terminal to always provide a readable and consistent color scheme.
 /// An extra color can be provided to be used as background color.
-fn color_item_token(token: &Token, bg: Option<Color>) -> ANSIString<'_> {
+fn color_item_token(token: &Token, bg: Option<Color>) -> AnsiString<'_> {
     let style = |colour: Style, text: &str| {
         if let Some(bg) = bg {
             colour.on(bg).paint(text.to_string())
@@ -138,7 +138,7 @@ fn color_item_with_diff(diff_slice: &[diff::Result<&&Token>], is_old_item: bool)
         })
         .collect::<Vec<_>>();
 
-    ANSIStrings(&styled_strings).to_string()
+    AnsiStrings(&styled_strings).to_string()
 }
 
 pub fn print_items_with_header<T>(


### PR DESCRIPTION
Otherwise dependabot complains about that this dependency is potentially insecure. Not sure I agree, but doing this seems to be the path of least resistance.

See https://github.com/ogham/rust-ansi-term/issues/72.