### PR TITLE
Add `RenderingContext` to `render.rs`

### DIFF
--- a/public-api/src/intermediate_public_item.rs
+++ b/public-api/src/intermediate_public_item.rs
@@ -1,9 +1,8 @@
-use crate::render;
 use std::rc::Rc;
 
 use rustdoc_types::{Id, Item, Type};
 
-use crate::tokens::Token;
+use crate::{render::RenderingContext, tokens::Token};
 
 /// This struct represents one public item of a crate, but in intermediate form.
 /// It wraps a single [Item] but adds additional calculated values to make it
@@ -85,7 +84,7 @@ impl<'a> IntermediatePublicItem<'a> {
         self.path().iter().any(|m| m.item.id == *id)
     }
 
-    pub fn render_token_stream(&self) -> Vec<Token> {
-        render::token_stream(self)
+    pub fn render_token_stream(&self, context: &RenderingContext) -> Vec<Token> {
+        context.token_stream(self)
     }
 }

--- a/public-api/src/intermediate_public_item.rs
+++ b/public-api/src/intermediate_public_item.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use rustdoc_types::{Id, Item, Type};
+use rustdoc_types::{Id, Item};
 
 use crate::{render::RenderingContext, tokens::Token};
 
@@ -17,29 +17,6 @@ pub struct IntermediatePublicItem<'a> {
     /// renamed imports (`pub use other::item as foo;`) it is the new name.
     pub name: String,
 
-    /// Sometimes an item references other items via ID that we do not include
-    /// in the output. Currently this only happens for tuple structs (both
-    /// regular and enum variants). The reason we can get away with that is
-    /// because the tuple type already contains the full info, so also listing
-    /// fields as individual items is just noise.
-    ///
-    /// To be more concrete: It is sufficient to list the public API of `pub
-    /// struct Foo(bool, u32)` as
-    /// ```txt
-    /// pub struct root::Foo(bool, u32)
-    /// ```
-    /// because listing it as
-    /// ```txt
-    /// pub struct root::Foo(bool, u32)
-    /// pub struct field root::Foo::0: bool
-    /// pub struct field root::Foo::1: u32
-    /// ```
-    /// does not convey any more information.
-    ///
-    /// This special case requires us to pre-resolve the IDs however, and that
-    /// is what this field is for.
-    pub pre_resolved_fields: Vec<Option<&'a Type>>,
-
     /// The parent item. If [Self::item] is e.g. an enum variant, then the
     /// parent is an enum. We follow the chain of parents to be able to know the
     /// correct path to an item in the output.
@@ -51,15 +28,9 @@ impl<'a> IntermediatePublicItem<'a> {
     pub fn new(
         item: &'a Item,
         name: String,
-        pre_resolved_fields: Vec<Option<&'a Type>>,
         parent: Option<Rc<IntermediatePublicItem<'a>>>,
     ) -> Self {
-        Self {
-            item,
-            name,
-            pre_resolved_fields,
-            parent,
-        }
+        Self { item, name, parent }
     }
 
     #[must_use]

--- a/public-api/src/item_iterator.rs
+++ b/public-api/src/item_iterator.rs
@@ -1,8 +1,6 @@
 use std::{collections::HashMap, fmt::Display, rc::Rc};
 
-use rustdoc_types::{
-    Crate, Id, Impl, Import, Item, ItemEnum, Module, Struct, StructKind, Type, Variant,
-};
+use rustdoc_types::{Crate, Id, Impl, Import, Item, ItemEnum, Module, Struct, StructKind, Type};
 
 use super::intermediate_public_item::IntermediatePublicItem;
 use crate::{render::RenderingContext, tokens::Token, Options, PublicApi};
@@ -201,43 +199,10 @@ impl<'a> ItemIterator<'a> {
         let public_item = Rc::new(IntermediatePublicItem::new(
             item,
             name.unwrap_or_else(|| String::from("<<no_name>>")),
-            self.pre_resolved_fields_for_item(item),
             parent,
         ));
 
         self.items_left.push(public_item);
-    }
-
-    /// See [`IntermediatePublicItem::pre_resolved_fields`] docs for more info.
-    fn pre_resolved_fields_for_item(&self, item: &'a Item) -> Vec<Option<&'a Type>> {
-        let mut pre_resolved_fields: Vec<Option<&Type>> = vec![];
-
-        let fields_to_pre_resolve = match &item.inner {
-            ItemEnum::Variant(Variant::Tuple(fields))
-            | ItemEnum::Struct(Struct {
-                kind: StructKind::Tuple(fields),
-                ..
-            }) => Some(fields),
-            _ => None,
-        };
-
-        if let Some(fields) = fields_to_pre_resolve {
-            for id in fields {
-                pre_resolved_fields.push(
-                    if let Some(Item {
-                        inner: ItemEnum::StructField(type_),
-                        ..
-                    }) = id.as_ref().and_then(|id| self.crate_.index.get(id))
-                    {
-                        Some(type_)
-                    } else {
-                        None
-                    },
-                );
-            }
-        }
-
-        pre_resolved_fields
     }
 
     fn add_missing_id(&mut self, id: &'a Id) {

--- a/public-api/src/item_iterator.rs
+++ b/public-api/src/item_iterator.rs
@@ -5,7 +5,7 @@ use rustdoc_types::{
 };
 
 use super::intermediate_public_item::IntermediatePublicItem;
-use crate::{tokens::Token, Options, PublicApi};
+use crate::{render::RenderingContext, tokens::Token, Options, PublicApi};
 
 type Impls<'a> = HashMap<&'a Id, Vec<&'a Impl>>;
 
@@ -329,10 +329,11 @@ fn items_in_container(item: &Item) -> Option<&Vec<Id>> {
 }
 
 pub fn public_api_in_crate(crate_: &Crate, options: Options) -> super::PublicApi {
+    let context = RenderingContext { crate_ };
     let mut item_iterator = ItemIterator::new(crate_, options);
     let items = item_iterator
         .by_ref()
-        .map(|p| intermediate_public_item_to_public_item(&p))
+        .map(|p| intermediate_public_item_to_public_item(&context, &p))
         .collect();
 
     PublicApi {
@@ -346,6 +347,7 @@ pub fn public_api_in_crate(crate_: &Crate, options: Options) -> super::PublicApi
 }
 
 fn intermediate_public_item_to_public_item(
+    context: &RenderingContext,
     public_item: &Rc<IntermediatePublicItem<'_>>,
 ) -> PublicItem {
     PublicItem {
@@ -354,7 +356,7 @@ fn intermediate_public_item_to_public_item(
             .iter()
             .map(|i| i.name.clone())
             .collect::<PublicItemPath>(),
-        tokens: public_item.render_token_stream(),
+        tokens: public_item.render_token_stream(context),
     }
 }
 

--- a/public-api/src/render.rs
+++ b/public-api/src/render.rs
@@ -1,10 +1,11 @@
+#![allow(clippy::unused_self)]
 use crate::intermediate_public_item::IntermediatePublicItem;
 use std::rc::Rc;
 
 use rustdoc_types::{
-    Abi, Constant, FnDecl, FunctionPointer, GenericArg, GenericArgs, GenericBound, GenericParamDef,
-    GenericParamDefKind, Generics, Header, ItemEnum, MacroKind, Path, PolyTrait, StructKind, Term,
-    Type, TypeBinding, TypeBindingKind, Variant, WherePredicate,
+    Abi, Constant, Crate, FnDecl, FunctionPointer, GenericArg, GenericArgs, GenericBound,
+    GenericParamDef, GenericParamDefKind, Generics, Header, ItemEnum, MacroKind, Path, PolyTrait,
+    StructKind, Term, Type, TypeBinding, TypeBindingKind, Variant, WherePredicate,
 };
 
 /// A simple macro to write `Token::Whitespace` in less characters.
@@ -16,749 +17,765 @@ macro_rules! ws {
 
 use crate::tokens::Token;
 
-#[allow(clippy::too_many_lines)]
-pub fn token_stream(item: &IntermediatePublicItem) -> Vec<Token> {
-    let mut tokens = vec![];
+pub struct RenderingContext<'a> {
+    pub crate_: &'a Crate,
+}
 
-    for attr in &item.item.attrs {
-        if attr_relevant_for_public_apis(attr) {
-            tokens.push(Token::Annotation(attr.clone()));
-            tokens.push(ws!());
-        }
-    }
+impl<'a> RenderingContext<'a> {
+    #[allow(clippy::too_many_lines)]
+    pub fn token_stream(&self, item: &IntermediatePublicItem) -> Vec<Token> {
+        let mut tokens = vec![];
 
-    let inner_tokens = match &item.item.inner {
-        ItemEnum::Module(_) => render_simple(&["mod"], &item.path()),
-        ItemEnum::ExternCrate { .. } => render_simple(&["extern", "crate"], &item.path()),
-        ItemEnum::Import(_) => render_simple(&["use"], &item.path()),
-        ItemEnum::Union(_) => render_simple(&["union"], &item.path()),
-        ItemEnum::Struct(s) => {
-            let mut output = render_simple(&["struct"], &item.path());
-            output.extend(render_generics(&s.generics));
-            if matches!(s.kind, StructKind::Tuple(_)) {
-                output.extend(render_option_tuple(
-                    &item.pre_resolved_fields,
-                    Some(&pub_()),
-                ));
+        for attr in &item.item.attrs {
+            if attr_relevant_for_public_apis(attr) {
+                tokens.push(Token::Annotation(attr.clone()));
+                tokens.push(ws!());
             }
-            output
         }
-        ItemEnum::StructField(inner) => {
-            let mut output = render_simple(&["struct", "field"], &item.path());
-            output.extend(colon());
-            output.extend(render_type(inner));
-            output
-        }
-        ItemEnum::Enum(e) => {
-            let mut output = render_simple(&["enum"], &item.path());
-            output.extend(render_generics(&e.generics));
-            output
-        }
-        ItemEnum::Variant(inner) => {
-            let mut output = render_simple(&["enum", "variant"], &item.path());
-            match inner {
-                Variant::Struct { .. } => {} // Each struct field is printed individually
-                Variant::Plain(discriminant) => {
-                    if let Some(discriminant) = discriminant {
-                        output.extend(equals());
-                        output.push(Token::identifier(&discriminant.value));
+
+        let inner_tokens = match &item.item.inner {
+            ItemEnum::Module(_) => self.render_simple(&["mod"], &item.path()),
+            ItemEnum::ExternCrate { .. } => self.render_simple(&["extern", "crate"], &item.path()),
+            ItemEnum::Import(_) => self.render_simple(&["use"], &item.path()),
+            ItemEnum::Union(_) => self.render_simple(&["union"], &item.path()),
+            ItemEnum::Struct(s) => {
+                let mut output = self.render_simple(&["struct"], &item.path());
+                output.extend(self.render_generics(&s.generics));
+                if matches!(s.kind, StructKind::Tuple(_)) {
+                    output
+                        .extend(self.render_option_tuple(&item.pre_resolved_fields, Some(&pub_())));
+                }
+                output
+            }
+            ItemEnum::StructField(inner) => {
+                let mut output = self.render_simple(&["struct", "field"], &item.path());
+                output.extend(colon());
+                output.extend(self.render_type(inner));
+                output
+            }
+            ItemEnum::Enum(e) => {
+                let mut output = self.render_simple(&["enum"], &item.path());
+                output.extend(self.render_generics(&e.generics));
+                output
+            }
+            ItemEnum::Variant(inner) => {
+                let mut output = self.render_simple(&["enum", "variant"], &item.path());
+                match inner {
+                    Variant::Struct { .. } => {} // Each struct field is printed individually
+                    Variant::Plain(discriminant) => {
+                        if let Some(discriminant) = discriminant {
+                            output.extend(equals());
+                            output.push(Token::identifier(&discriminant.value));
+                        }
+                    }
+                    Variant::Tuple(_) => {
+                        output.extend(self.render_option_tuple(&item.pre_resolved_fields, None));
                     }
                 }
-                Variant::Tuple(_) => {
-                    output.extend(render_option_tuple(&item.pre_resolved_fields, None));
-                }
-            }
-            output
-        }
-        ItemEnum::Function(inner) => render_function(
-            render_path(&item.path()),
-            &inner.decl,
-            &inner.generics,
-            &inner.header,
-        ),
-        ItemEnum::Method(inner) => render_function(
-            render_path(&item.path()),
-            &inner.decl,
-            &inner.generics,
-            &inner.header,
-        ),
-        ItemEnum::Trait(inner) => {
-            let tags = if inner.is_unsafe {
-                vec!["unsafe", "trait"]
-            } else {
-                vec!["trait"]
-            };
-            let mut output = render_simple(&tags, &item.path());
-            output.extend(render_generics(&inner.generics));
-            output
-        }
-        ItemEnum::TraitAlias(_) => render_simple(&["trait", "alias"], &item.path()),
-        ItemEnum::Impl(_) => render_simple(&["impl"], &item.path()),
-        ItemEnum::Typedef(inner) => {
-            let mut output = render_simple(&["type"], &item.path());
-            output.extend(render_generics(&inner.generics));
-            output.extend(equals());
-            output.extend(render_type(&inner.type_));
-            output
-        }
-        ItemEnum::AssocType {
-            generics,
-            bounds,
-            default,
-        } => {
-            let mut output = render_simple(&["type"], &item.path());
-            output.extend(render_generics(generics));
-            output.extend(render_generic_bounds(bounds));
-            if let Some(ty) = default {
-                output.extend(equals());
-                output.extend(render_type(ty));
-            }
-            output
-        }
-        ItemEnum::OpaqueTy(_) => render_simple(&["opaque", "type"], &item.path()),
-        ItemEnum::Constant(con) => {
-            let mut output = render_simple(&["const"], &item.path());
-            output.extend(colon());
-            output.extend(render_constant(con));
-            output
-        }
-        ItemEnum::AssocConst { type_, .. } => {
-            let mut output = render_simple(&["const"], &item.path());
-            output.extend(colon());
-            output.extend(render_type(type_));
-            output
-        }
-        ItemEnum::Static(inner) => {
-            let tags = if inner.mutable {
-                vec!["mut", "static"]
-            } else {
-                vec!["static"]
-            };
-            let mut output = render_simple(&tags, &item.path());
-            output.extend(colon());
-            output.extend(render_type(&inner.type_));
-            output
-        }
-        ItemEnum::ForeignType => render_simple(&["type"], &item.path()),
-        ItemEnum::Macro(_definition) => {
-            // TODO: _definition contains the whole definition, it would be really neat to get out all possible ways to invoke it
-            let mut output = render_simple(&["macro"], &item.path());
-            output.push(Token::symbol("!"));
-            output
-        }
-        ItemEnum::ProcMacro(inner) => {
-            let mut output = render_simple(&["proc", "macro"], &item.path());
-            output.pop(); // Remove name of macro to possibly wrap it in `#[]`
-            let name = Token::identifier(item.item.name.as_ref().unwrap_or(&"".to_string()));
-            match inner.kind {
-                MacroKind::Bang => output.extend(vec![name, Token::symbol("!()")]),
-                MacroKind::Attr => {
-                    output.extend(vec![Token::symbol("#["), name, Token::symbol("]")]);
-                }
-                MacroKind::Derive => {
-                    output.extend(vec![Token::symbol("#[derive("), name, Token::symbol(")]")]);
-                }
-            }
-            output
-        }
-        ItemEnum::PrimitiveType(_) => render_simple(&["primitive", "type"], &item.path()),
-    };
-
-    tokens.extend(inner_tokens);
-
-    tokens
-}
-
-fn render_simple(tags: &[&str], path: &[Rc<IntermediatePublicItem<'_>>]) -> Vec<Token> {
-    let mut output = pub_();
-    output.extend(
-        tags.iter()
-            .flat_map(|t| [Token::kind(*t), ws!()])
-            .collect::<Vec<Token>>(),
-    );
-    output.extend(render_path(path));
-    output
-}
-
-fn render_path(path: &[Rc<IntermediatePublicItem<'_>>]) -> Vec<Token> {
-    let mut output = vec![];
-    for item in path {
-        let token_fn = if matches!(item.item.inner, ItemEnum::Function(_) | ItemEnum::Method(_)) {
-            Token::function
-        } else if matches!(
-            item.item.inner,
-            ItemEnum::Trait(_)
-                | ItemEnum::Struct(_)
-                | ItemEnum::Union(_)
-                | ItemEnum::Enum(_)
-                | ItemEnum::Typedef(_)
-        ) {
-            Token::type_
-        } else {
-            Token::identifier
-        };
-        output.push(token_fn(item.name.clone()));
-        output.push(Token::symbol("::"));
-    }
-    if !path.is_empty() {
-        output.pop();
-    }
-    output
-}
-
-#[allow(clippy::needless_pass_by_value)]
-fn render_sequence<T>(
-    start: Vec<Token>,
-    end: Vec<Token>,
-    between: Vec<Token>,
-    sequence: &[T],
-    render: impl Fn(&T) -> Vec<Token>,
-) -> Vec<Token> {
-    render_sequence_impl(start, end, between, false, sequence, render)
-}
-
-#[allow(clippy::needless_pass_by_value)]
-fn render_sequence_if_not_empty<T>(
-    start: Vec<Token>,
-    end: Vec<Token>,
-    between: Vec<Token>,
-    sequence: &[T],
-    render: impl Fn(&T) -> Vec<Token>,
-) -> Vec<Token> {
-    render_sequence_impl(start, end, between, true, sequence, render)
-}
-
-#[allow(clippy::needless_pass_by_value)]
-fn render_sequence_impl<T>(
-    start: Vec<Token>,
-    end: Vec<Token>,
-    between: Vec<Token>,
-    return_nothing_if_empty: bool,
-    sequence: &[T],
-    render: impl Fn(&T) -> Vec<Token>,
-) -> Vec<Token> {
-    if return_nothing_if_empty && sequence.is_empty() {
-        return vec![];
-    }
-    let mut output = start;
-    for (index, seq) in sequence.iter().enumerate() {
-        output.extend(render(seq));
-        if index < sequence.len() - 1 {
-            output.extend(between.clone());
-        }
-    }
-    output.extend(end);
-    output
-}
-
-fn render_type(ty: &Type) -> Vec<Token> {
-    render_option_type(&Some(ty))
-}
-
-#[allow(clippy::ref_option_ref, clippy::trivially_copy_pass_by_ref)] // Because of `render_sequence()` arg types
-fn render_option_type(ty: &Option<&Type>) -> Vec<Token> {
-    let ty = match ty {
-        Some(ty) => ty,
-        None => return vec![Token::symbol("_")], // The `_` in `EnumWithStrippedTupleVariants::DoubleFirstHidden(_, bool)`
-    };
-    match ty {
-        Type::ResolvedPath(path) => render_resolved_path(path),
-        Type::DynTrait(dyn_trait) => render_dyn_trait(dyn_trait),
-        Type::Generic(name) => vec![Token::generic(name)],
-        Type::Primitive(name) => vec![Token::primitive(name)],
-        Type::FunctionPointer(ptr) => render_function_pointer(ptr),
-        Type::Tuple(types) => render_tuple(types),
-        Type::Slice(ty) => render_slice(ty),
-        Type::Array { type_, len } => render_array(type_, len),
-        Type::ImplTrait(bounds) => render_impl_trait(bounds),
-        Type::Infer => vec![Token::symbol("_")],
-        Type::RawPointer { mutable, type_ } => render_raw_pointer(*mutable, type_),
-        Type::BorrowedRef {
-            lifetime,
-            mutable,
-            type_,
-        } => render_borrowed_ref(lifetime.as_deref(), *mutable, type_),
-        Type::QualifiedPath {
-            name,
-            args: _,
-            self_type,
-            trait_,
-        } => render_qualified_path(self_type, trait_, name),
-    }
-}
-
-fn render_dyn_trait(dyn_trait: &rustdoc_types::DynTrait) -> Vec<Token> {
-    let mut output = vec![];
-
-    let more_than_one = dyn_trait.traits.len() > 1 || dyn_trait.lifetime.is_some();
-    if more_than_one {
-        output.push(Token::symbol("("));
-    }
-
-    output.extend(render_sequence_if_not_empty(
-        vec![Token::keyword("dyn"), ws!()],
-        vec![],
-        plus(),
-        &dyn_trait.traits,
-        render_poly_trait,
-    ));
-
-    if let Some(lt) = &dyn_trait.lifetime {
-        output.extend(plus());
-        output.extend(vec![Token::lifetime(lt)]);
-    }
-
-    if more_than_one {
-        output.push(Token::symbol(")"));
-    }
-
-    output
-}
-
-fn render_function(
-    name: Vec<Token>,
-    decl: &FnDecl,
-    generics: &Generics,
-    header: &Header,
-) -> Vec<Token> {
-    let mut output = pub_();
-    if header.unsafe_ {
-        output.extend(vec![Token::qualifier("unsafe"), ws!()]);
-    };
-    if header.const_ {
-        output.extend(vec![Token::qualifier("const"), ws!()]);
-    };
-    if header.async_ {
-        output.extend(vec![Token::qualifier("async"), ws!()]);
-    };
-    if header.abi != Abi::Rust {
-        output.push(match &header.abi {
-            Abi::C { .. } => Token::qualifier("c"),
-            Abi::Cdecl { .. } => Token::qualifier("cdecl"),
-            Abi::Stdcall { .. } => Token::qualifier("stdcall"),
-            Abi::Fastcall { .. } => Token::qualifier("fastcall"),
-            Abi::Aapcs { .. } => Token::qualifier("aapcs"),
-            Abi::Win64 { .. } => Token::qualifier("win64"),
-            Abi::SysV64 { .. } => Token::qualifier("sysV64"),
-            Abi::System { .. } => Token::qualifier("system"),
-            Abi::Other(text) => Token::qualifier(text),
-            Abi::Rust => unreachable!(),
-        });
-        output.push(ws!());
-    }
-
-    output.extend(vec![Token::kind("fn"), ws!()]);
-    output.extend(name);
-
-    // Generic parameters
-    output.extend(render_generic_param_defs(&generics.params));
-
-    // Regular parameters and return type
-    output.extend(render_fn_decl(decl));
-
-    // Where predicates
-    output.extend(render_where_predicates(&generics.where_predicates));
-
-    output
-}
-
-fn render_fn_decl(decl: &FnDecl) -> Vec<Token> {
-    let mut output = vec![];
-    // Main arguments
-    output.extend(render_sequence(
-        vec![Token::symbol("(")],
-        vec![Token::symbol(")")],
-        comma(),
-        &decl.inputs,
-        |(name, ty)| {
-            simplified_self(name, ty).unwrap_or_else(|| {
-                let mut output = vec![];
-                if name != "_" {
-                    output.extend(vec![Token::identifier(name), Token::symbol(":"), ws!()]);
-                }
-                output.extend(render_type(ty));
                 output
-            })
-        },
-    ));
-    // Return type
-    if let Some(ty) = &decl.output {
-        output.extend(arrow());
-        output.extend(render_type(ty));
-    }
-    output
-}
+            }
+            ItemEnum::Function(inner) => self.render_function(
+                self.render_path(&item.path()),
+                &inner.decl,
+                &inner.generics,
+                &inner.header,
+            ),
+            ItemEnum::Method(inner) => self.render_function(
+                self.render_path(&item.path()),
+                &inner.decl,
+                &inner.generics,
+                &inner.header,
+            ),
+            ItemEnum::Trait(inner) => {
+                let tags = if inner.is_unsafe {
+                    vec!["unsafe", "trait"]
+                } else {
+                    vec!["trait"]
+                };
+                let mut output = self.render_simple(&tags, &item.path());
+                output.extend(self.render_generics(&inner.generics));
+                output
+            }
+            ItemEnum::TraitAlias(_) => self.render_simple(&["trait", "alias"], &item.path()),
+            ItemEnum::Impl(_) => self.render_simple(&["impl"], &item.path()),
+            ItemEnum::Typedef(inner) => {
+                let mut output = self.render_simple(&["type"], &item.path());
+                output.extend(self.render_generics(&inner.generics));
+                output.extend(equals());
+                output.extend(self.render_type(&inner.type_));
+                output
+            }
+            ItemEnum::AssocType {
+                generics,
+                bounds,
+                default,
+            } => {
+                let mut output = self.render_simple(&["type"], &item.path());
+                output.extend(self.render_generics(generics));
+                output.extend(self.render_generic_bounds(bounds));
+                if let Some(ty) = default {
+                    output.extend(equals());
+                    output.extend(self.render_type(ty));
+                }
+                output
+            }
+            ItemEnum::OpaqueTy(_) => self.render_simple(&["opaque", "type"], &item.path()),
+            ItemEnum::Constant(con) => {
+                let mut output = self.render_simple(&["const"], &item.path());
+                output.extend(colon());
+                output.extend(self.render_constant(con));
+                output
+            }
+            ItemEnum::AssocConst { type_, .. } => {
+                let mut output = self.render_simple(&["const"], &item.path());
+                output.extend(colon());
+                output.extend(self.render_type(type_));
+                output
+            }
+            ItemEnum::Static(inner) => {
+                let tags = if inner.mutable {
+                    vec!["mut", "static"]
+                } else {
+                    vec!["static"]
+                };
+                let mut output = self.render_simple(&tags, &item.path());
+                output.extend(colon());
+                output.extend(self.render_type(&inner.type_));
+                output
+            }
+            ItemEnum::ForeignType => self.render_simple(&["type"], &item.path()),
+            ItemEnum::Macro(_definition) => {
+                // TODO: _definition contains the whole definition, it would be really neat to get out all possible ways to invoke it
+                let mut output = self.render_simple(&["macro"], &item.path());
+                output.push(Token::symbol("!"));
+                output
+            }
+            ItemEnum::ProcMacro(inner) => {
+                let mut output = self.render_simple(&["proc", "macro"], &item.path());
+                output.pop(); // Remove name of macro to possibly wrap it in `#[]`
+                let name = Token::identifier(item.item.name.as_ref().unwrap_or(&"".to_string()));
+                match inner.kind {
+                    MacroKind::Bang => output.extend(vec![name, Token::symbol("!()")]),
+                    MacroKind::Attr => {
+                        output.extend(vec![Token::symbol("#["), name, Token::symbol("]")]);
+                    }
+                    MacroKind::Derive => {
+                        output.extend(vec![Token::symbol("#[derive("), name, Token::symbol(")]")]);
+                    }
+                }
+                output
+            }
+            ItemEnum::PrimitiveType(_) => self.render_simple(&["primitive", "type"], &item.path()),
+        };
 
-fn simplified_self(name: &str, ty: &Type) -> Option<Vec<Token>> {
-    if name == "self" {
+        tokens.extend(inner_tokens);
+
+        tokens
+    }
+
+    fn render_simple(&self, tags: &[&str], path: &[Rc<IntermediatePublicItem<'_>>]) -> Vec<Token> {
+        let mut output = pub_();
+        output.extend(
+            tags.iter()
+                .flat_map(|t| [Token::kind(*t), ws!()])
+                .collect::<Vec<Token>>(),
+        );
+        output.extend(self.render_path(path));
+        output
+    }
+
+    fn render_path(&self, path: &[Rc<IntermediatePublicItem<'_>>]) -> Vec<Token> {
+        let mut output = vec![];
+        for item in path {
+            let token_fn = if matches!(item.item.inner, ItemEnum::Function(_) | ItemEnum::Method(_))
+            {
+                Token::function
+            } else if matches!(
+                item.item.inner,
+                ItemEnum::Trait(_)
+                    | ItemEnum::Struct(_)
+                    | ItemEnum::Union(_)
+                    | ItemEnum::Enum(_)
+                    | ItemEnum::Typedef(_)
+            ) {
+                Token::type_
+            } else {
+                Token::identifier
+            };
+            output.push(token_fn(item.name.clone()));
+            output.push(Token::symbol("::"));
+        }
+        if !path.is_empty() {
+            output.pop();
+        }
+        output
+    }
+
+    #[allow(clippy::needless_pass_by_value)]
+    fn render_sequence<T>(
+        &self,
+        start: Vec<Token>,
+        end: Vec<Token>,
+        between: Vec<Token>,
+        sequence: &[T],
+        render: impl Fn(&T) -> Vec<Token>,
+    ) -> Vec<Token> {
+        self.render_sequence_impl(start, end, between, false, sequence, render)
+    }
+
+    #[allow(clippy::needless_pass_by_value)]
+    fn render_sequence_if_not_empty<T>(
+        &self,
+        start: Vec<Token>,
+        end: Vec<Token>,
+        between: Vec<Token>,
+        sequence: &[T],
+        render: impl Fn(&T) -> Vec<Token>,
+    ) -> Vec<Token> {
+        self.render_sequence_impl(start, end, between, true, sequence, render)
+    }
+
+    #[allow(clippy::needless_pass_by_value)]
+    fn render_sequence_impl<T>(
+        &self,
+        start: Vec<Token>,
+        end: Vec<Token>,
+        between: Vec<Token>,
+        return_nothing_if_empty: bool,
+        sequence: &[T],
+        render: impl Fn(&T) -> Vec<Token>,
+    ) -> Vec<Token> {
+        if return_nothing_if_empty && sequence.is_empty() {
+            return vec![];
+        }
+        let mut output = start;
+        for (index, seq) in sequence.iter().enumerate() {
+            output.extend(render(seq));
+            if index < sequence.len() - 1 {
+                output.extend(between.clone());
+            }
+        }
+        output.extend(end);
+        output
+    }
+
+    fn render_type(&self, ty: &Type) -> Vec<Token> {
+        self.render_option_type(&Some(ty))
+    }
+
+    #[allow(clippy::ref_option_ref, clippy::trivially_copy_pass_by_ref)] // Because of `render_sequence()` arg types
+    fn render_option_type(&self, ty: &Option<&Type>) -> Vec<Token> {
+        let ty = match ty {
+            Some(ty) => ty,
+            None => return vec![Token::symbol("_")], // The `_` in `EnumWithStrippedTupleVariants::DoubleFirstHidden(_, bool)`
+        };
         match ty {
-            Type::Generic(name) if name == "Self" => Some(vec![Token::self_("self")]),
+            Type::ResolvedPath(path) => self.render_resolved_path(path),
+            Type::DynTrait(dyn_trait) => self.render_dyn_trait(dyn_trait),
+            Type::Generic(name) => vec![Token::generic(name)],
+            Type::Primitive(name) => vec![Token::primitive(name)],
+            Type::FunctionPointer(ptr) => self.render_function_pointer(ptr),
+            Type::Tuple(types) => self.render_tuple(types),
+            Type::Slice(ty) => self.render_slice(ty),
+            Type::Array { type_, len } => self.render_array(type_, len),
+            Type::ImplTrait(bounds) => self.render_impl_trait(bounds),
+            Type::Infer => vec![Token::symbol("_")],
+            Type::RawPointer { mutable, type_ } => self.render_raw_pointer(*mutable, type_),
             Type::BorrowedRef {
                 lifetime,
                 mutable,
                 type_,
-            } => match type_.as_ref() {
-                Type::Generic(name) if name == "Self" => {
-                    let mut output = vec![Token::symbol("&")];
-                    if let Some(lt) = lifetime {
-                        output.extend(vec![Token::lifetime(lt), ws!()]);
-                    }
-                    if *mutable {
-                        output.extend(vec![Token::keyword("mut"), ws!()]);
-                    }
-                    output.push(Token::self_("self"));
-                    Some(output)
-                }
-                _ => None,
-            },
-            _ => None,
-        }
-    } else {
-        None
-    }
-}
-
-fn render_resolved_path(path: &Path) -> Vec<Token> {
-    let mut output = vec![];
-    let name = &path.name;
-    if !name.is_empty() {
-        let split: Vec<_> = name.split("::").collect();
-        let len = split.len();
-        for (index, part) in split.into_iter().enumerate() {
-            if index == 0 && part == "$crate" {
-                output.push(Token::identifier("$crate"));
-            } else if index == len - 1 {
-                output.push(Token::type_(part));
-            } else {
-                output.push(Token::identifier(part));
-            }
-            output.push(Token::symbol("::"));
-        }
-        if len > 0 {
-            output.pop();
-        }
-        if let Some(args) = &path.args {
-            output.extend(render_generic_args(args));
+            } => self.render_borrowed_ref(lifetime.as_deref(), *mutable, type_),
+            Type::QualifiedPath {
+                name,
+                args: _,
+                self_type,
+                trait_,
+            } => self.render_qualified_path(self_type, trait_, name),
         }
     }
-    output
-}
 
-fn render_function_pointer(ptr: &FunctionPointer) -> Vec<Token> {
-    let mut output = render_higher_rank_trait_bounds(&ptr.generic_params);
-    output.push(Token::kind("fn"));
-    output.extend(render_fn_decl(&ptr.decl));
-    output
-}
+    fn render_dyn_trait(&self, dyn_trait: &rustdoc_types::DynTrait) -> Vec<Token> {
+        let mut output = vec![];
 
-fn render_tuple(types: &[Type]) -> Vec<Token> {
-    let option_tuple: Vec<Option<&Type>> = types.iter().map(Some).collect();
-    render_option_tuple(&option_tuple, None)
-}
-
-/// `prefix` is to handle the difference  between tuple structs and enum variant
-/// tuple structs. The former marks public fields as `pub ` whereas all fields
-/// of enum tuple structs are always implicitly `pub`.
-fn render_option_tuple(types: &[Option<&Type>], prefix: Option<&[Token]>) -> Vec<Token> {
-    render_sequence(
-        vec![Token::symbol("(")],
-        vec![Token::symbol(")")],
-        comma(),
-        types,
-        |type_| {
-            let mut output: Vec<Token> = vec![];
-            if let (Some(prefix), Some(_)) = (prefix, type_) {
-                output.extend(prefix.to_owned());
-            }
-            output.extend(render_option_type(type_));
-            output
-        },
-    )
-}
-
-fn render_slice(ty: &Type) -> Vec<Token> {
-    let mut output = vec![Token::symbol("[")];
-    output.extend(render_type(ty));
-    output.push(Token::symbol("]"));
-    output
-}
-
-fn render_array(type_: &Type, len: &str) -> Vec<Token> {
-    let mut output = vec![Token::symbol("[")];
-    output.extend(render_type(type_));
-    output.extend(vec![
-        Token::symbol(";"),
-        ws!(),
-        Token::primitive(len),
-        Token::symbol("]"),
-    ]);
-    output
-}
-
-fn render_impl_trait(bounds: &[GenericBound]) -> Vec<Token> {
-    let mut output = vec![Token::keyword("impl")];
-    output.push(ws!());
-    output.extend(render_generic_bounds(bounds));
-    output
-}
-
-fn render_raw_pointer(mutable: bool, type_: &Type) -> Vec<Token> {
-    let mut output = vec![Token::symbol("*")];
-    output.push(Token::keyword(if mutable { "mut" } else { "const" }));
-    output.push(ws!());
-    output.extend(render_type(type_));
-    output
-}
-
-fn render_borrowed_ref(lifetime: Option<&str>, mutable: bool, type_: &Type) -> Vec<Token> {
-    let mut output = vec![Token::symbol("&")];
-    if let Some(lt) = lifetime {
-        output.extend(vec![Token::lifetime(lt), ws!()]);
-    }
-    if mutable {
-        output.extend(vec![Token::keyword("mut"), ws!()]);
-    }
-    output.extend(render_type(type_));
-    output
-}
-
-fn render_qualified_path(type_: &Type, trait_: &Path, name: &str) -> Vec<Token> {
-    let mut output = vec![];
-    match type_ {
-        Type::Generic(name) if name == "Self" && trait_.name.is_empty() => {
-            output.push(Token::keyword("Self"));
+        let more_than_one = dyn_trait.traits.len() > 1 || dyn_trait.lifetime.is_some();
+        if more_than_one {
+            output.push(Token::symbol("("));
         }
-        _ => {
-            output.push(Token::symbol("<"));
-            output.extend(render_type(type_));
-            output.extend(vec![ws!(), Token::keyword("as"), ws!()]);
-            output.extend(render_resolved_path(trait_));
-            output.push(Token::symbol(">"));
-        }
-    }
-    output.push(Token::symbol("::"));
-    output.push(Token::identifier(name));
-    output
-}
 
-fn render_generic_args(args: &GenericArgs) -> Vec<Token> {
-    match args {
-        GenericArgs::AngleBracketed { args, bindings } => render_angle_bracketed(args, bindings),
-        GenericArgs::Parenthesized { inputs, output } => render_parenthesized(inputs, output),
-    }
-}
-
-fn render_parenthesized(inputs: &[Type], return_ty: &Option<Type>) -> Vec<Token> {
-    let mut output = render_sequence(
-        vec![Token::symbol("(")],
-        vec![Token::symbol(")")],
-        comma(),
-        inputs,
-        render_type,
-    );
-    if let Some(return_ty) = return_ty {
-        output.extend(arrow());
-        output.extend(render_type(return_ty));
-    }
-    output
-}
-
-fn render_angle_bracketed(args: &[GenericArg], bindings: &[TypeBinding]) -> Vec<Token> {
-    enum Arg<'a> {
-        GenericArg(&'a GenericArg),
-        TypeBinding(&'a TypeBinding),
-    }
-    render_sequence_if_not_empty(
-        vec![Token::symbol("<")],
-        vec![Token::symbol(">")],
-        comma(),
-        &args
-            .iter()
-            .map(Arg::GenericArg)
-            .chain(bindings.iter().map(Arg::TypeBinding))
-            .collect::<Vec<_>>(),
-        |arg| match arg {
-            Arg::GenericArg(arg) => render_generic_arg(arg),
-            Arg::TypeBinding(binding) => render_type_binding(binding),
-        },
-    )
-}
-
-fn render_term(term: &Term) -> Vec<Token> {
-    match term {
-        Term::Type(ty) => render_type(ty),
-        Term::Constant(c) => render_constant(c),
-    }
-}
-
-fn render_poly_trait(poly_trait: &PolyTrait) -> Vec<Token> {
-    let mut output = render_higher_rank_trait_bounds(&poly_trait.generic_params);
-    output.extend(render_resolved_path(&poly_trait.trait_));
-    output
-}
-
-fn render_generic_arg(arg: &GenericArg) -> Vec<Token> {
-    match arg {
-        GenericArg::Lifetime(name) => vec![Token::lifetime(name)],
-        GenericArg::Type(ty) => render_type(ty),
-        GenericArg::Const(c) => render_constant(c),
-        GenericArg::Infer => vec![Token::symbol("_")],
-    }
-}
-
-fn render_type_binding(binding: &TypeBinding) -> Vec<Token> {
-    let mut output = vec![Token::identifier(&binding.name)];
-    output.extend(render_generic_args(&binding.args));
-    match &binding.binding {
-        TypeBindingKind::Equality(term) => {
-            output.extend(equals());
-            output.extend(render_term(term));
-        }
-        TypeBindingKind::Constraint(bounds) => {
-            output.extend(render_generic_bounds(bounds));
-        }
-    }
-    output
-}
-
-fn render_constant(constant: &Constant) -> Vec<Token> {
-    let mut output = render_type(&constant.type_);
-    if let Some(value) = &constant.value {
-        output.extend(equals());
-        if constant.is_literal {
-            output.push(Token::primitive(value));
-        } else {
-            output.push(Token::identifier(value));
-        }
-    }
-    output
-}
-
-fn render_generics(generics: &Generics) -> Vec<Token> {
-    let mut output = vec![];
-    output.extend(render_generic_param_defs(&generics.params));
-    output.extend(render_where_predicates(&generics.where_predicates));
-    output
-}
-
-fn render_generic_param_defs(params: &[GenericParamDef]) -> Vec<Token> {
-    let params_without_synthetics: Vec<_> = params
-        .iter()
-        .filter(|p| {
-            if let GenericParamDefKind::Type { synthetic, .. } = p.kind {
-                !synthetic
-            } else {
-                true
-            }
-        })
-        .collect();
-
-    render_sequence_if_not_empty(
-        vec![Token::symbol("<")],
-        vec![Token::symbol(">")],
-        comma(),
-        &params_without_synthetics,
-        |param| render_generic_param_def(param),
-    )
-}
-
-fn render_generic_param_def(generic_param_def: &GenericParamDef) -> Vec<Token> {
-    let mut output = vec![];
-    match &generic_param_def.kind {
-        GenericParamDefKind::Lifetime { outlives } => {
-            output.push(Token::lifetime(&generic_param_def.name));
-            if !outlives.is_empty() {
-                output.extend(colon());
-                output.extend(render_sequence(vec![], vec![], plus(), outlives, |s| {
-                    vec![Token::lifetime(s)]
-                }));
-            }
-        }
-        GenericParamDefKind::Type { bounds, .. } => {
-            output.push(Token::generic(&generic_param_def.name));
-            if !bounds.is_empty() {
-                output.extend(colon());
-                output.extend(render_generic_bounds(bounds));
-            }
-        }
-        GenericParamDefKind::Const { type_, .. } => {
-            output.push(Token::qualifier("const"));
-            output.push(ws!());
-            output.push(Token::identifier(&generic_param_def.name));
-            output.extend(colon());
-            output.extend(render_type(type_));
-        }
-    }
-    output
-}
-
-fn render_where_predicates(where_predicates: &[WherePredicate]) -> Vec<Token> {
-    let mut output = vec![];
-    if !where_predicates.is_empty() {
-        output.push(ws!());
-        output.push(Token::Keyword("where".to_owned()));
-        output.push(ws!());
-        output.extend(render_sequence(
+        output.extend(self.render_sequence_if_not_empty(
+            vec![Token::keyword("dyn"), ws!()],
             vec![],
-            vec![],
-            comma(),
-            where_predicates,
-            render_where_predicate,
+            plus(),
+            &dyn_trait.traits,
+            |p| self.render_poly_trait(p),
         ));
+
+        if let Some(lt) = &dyn_trait.lifetime {
+            output.extend(plus());
+            output.extend(vec![Token::lifetime(lt)]);
+        }
+
+        if more_than_one {
+            output.push(Token::symbol(")"));
+        }
+
+        output
     }
-    output
-}
 
-fn render_where_predicate(where_predicate: &WherePredicate) -> Vec<Token> {
-    let mut output = vec![];
-    match where_predicate {
-        WherePredicate::BoundPredicate {
-            type_,
-            bounds,
-            generic_params,
-        } => {
-            output.extend(render_higher_rank_trait_bounds(generic_params));
-            output.extend(render_type(type_));
-            output.extend(colon());
-            output.extend(render_generic_bounds(bounds));
+    fn render_function(
+        &self,
+        name: Vec<Token>,
+        decl: &FnDecl,
+        generics: &Generics,
+        header: &Header,
+    ) -> Vec<Token> {
+        let mut output = pub_();
+        if header.unsafe_ {
+            output.extend(vec![Token::qualifier("unsafe"), ws!()]);
+        };
+        if header.const_ {
+            output.extend(vec![Token::qualifier("const"), ws!()]);
+        };
+        if header.async_ {
+            output.extend(vec![Token::qualifier("async"), ws!()]);
+        };
+        if header.abi != Abi::Rust {
+            output.push(match &header.abi {
+                Abi::C { .. } => Token::qualifier("c"),
+                Abi::Cdecl { .. } => Token::qualifier("cdecl"),
+                Abi::Stdcall { .. } => Token::qualifier("stdcall"),
+                Abi::Fastcall { .. } => Token::qualifier("fastcall"),
+                Abi::Aapcs { .. } => Token::qualifier("aapcs"),
+                Abi::Win64 { .. } => Token::qualifier("win64"),
+                Abi::SysV64 { .. } => Token::qualifier("sysV64"),
+                Abi::System { .. } => Token::qualifier("system"),
+                Abi::Other(text) => Token::qualifier(text),
+                Abi::Rust => unreachable!(),
+            });
+            output.push(ws!());
         }
-        WherePredicate::RegionPredicate {
-            lifetime,
-            bounds: _,
-        } => output.push(Token::Lifetime(lifetime.clone())),
-        WherePredicate::EqPredicate { lhs, rhs } => {
-            output.extend(render_type(lhs));
-            output.extend(equals());
-            output.extend(render_term(rhs));
+
+        output.extend(vec![Token::kind("fn"), ws!()]);
+        output.extend(name);
+
+        // Generic parameters
+        output.extend(self.render_generic_param_defs(&generics.params));
+
+        // Regular parameters and return type
+        output.extend(self.render_fn_decl(decl));
+
+        // Where predicates
+        output.extend(self.render_where_predicates(&generics.where_predicates));
+
+        output
+    }
+
+    fn render_fn_decl(&self, decl: &FnDecl) -> Vec<Token> {
+        let mut output = vec![];
+        // Main arguments
+        output.extend(self.render_sequence(
+            vec![Token::symbol("(")],
+            vec![Token::symbol(")")],
+            comma(),
+            &decl.inputs,
+            |(name, ty)| {
+                self.simplified_self(name, ty).unwrap_or_else(|| {
+                    let mut output = vec![];
+                    if name != "_" {
+                        output.extend(vec![Token::identifier(name), Token::symbol(":"), ws!()]);
+                    }
+                    output.extend(self.render_type(ty));
+                    output
+                })
+            },
+        ));
+        // Return type
+        if let Some(ty) = &decl.output {
+            output.extend(arrow());
+            output.extend(self.render_type(ty));
+        }
+        output
+    }
+
+    fn simplified_self(&self, name: &str, ty: &Type) -> Option<Vec<Token>> {
+        if name == "self" {
+            match ty {
+                Type::Generic(name) if name == "Self" => Some(vec![Token::self_("self")]),
+                Type::BorrowedRef {
+                    lifetime,
+                    mutable,
+                    type_,
+                } => match type_.as_ref() {
+                    Type::Generic(name) if name == "Self" => {
+                        let mut output = vec![Token::symbol("&")];
+                        if let Some(lt) = lifetime {
+                            output.extend(vec![Token::lifetime(lt), ws!()]);
+                        }
+                        if *mutable {
+                            output.extend(vec![Token::keyword("mut"), ws!()]);
+                        }
+                        output.push(Token::self_("self"));
+                        Some(output)
+                    }
+                    _ => None,
+                },
+                _ => None,
+            }
+        } else {
+            None
         }
     }
-    output
-}
 
-fn render_generic_bounds(bounds: &[GenericBound]) -> Vec<Token> {
-    render_sequence_if_not_empty(vec![], vec![], plus(), bounds, |bound| match bound {
-        GenericBound::TraitBound {
-            trait_,
-            generic_params,
-            ..
-        } => {
-            let mut output = vec![];
-            output.extend(render_higher_rank_trait_bounds(generic_params));
-            output.extend(render_resolved_path(trait_));
-            output
+    fn render_resolved_path(&self, path: &Path) -> Vec<Token> {
+        let mut output = vec![];
+        let name = &path.name;
+        if !name.is_empty() {
+            let split: Vec<_> = name.split("::").collect();
+            let len = split.len();
+            for (index, part) in split.into_iter().enumerate() {
+                if index == 0 && part == "$crate" {
+                    output.push(Token::identifier("$crate"));
+                } else if index == len - 1 {
+                    output.push(Token::type_(part));
+                } else {
+                    output.push(Token::identifier(part));
+                }
+                output.push(Token::symbol("::"));
+            }
+            if len > 0 {
+                output.pop();
+            }
+            if let Some(args) = &path.args {
+                output.extend(self.render_generic_args(args));
+            }
         }
-        GenericBound::Outlives(id) => vec![Token::lifetime(id)],
-    })
-}
+        output
+    }
 
-fn render_higher_rank_trait_bounds(generic_params: &[GenericParamDef]) -> Vec<Token> {
-    let mut output = vec![];
-    if !generic_params.is_empty() {
-        output.push(Token::keyword("for"));
-        output.extend(render_generic_param_defs(generic_params));
+    fn render_function_pointer(&self, ptr: &FunctionPointer) -> Vec<Token> {
+        let mut output = self.render_higher_rank_trait_bounds(&ptr.generic_params);
+        output.push(Token::kind("fn"));
+        output.extend(self.render_fn_decl(&ptr.decl));
+        output
+    }
+
+    fn render_tuple(&self, types: &[Type]) -> Vec<Token> {
+        let option_tuple: Vec<Option<&Type>> = types.iter().map(Some).collect();
+        self.render_option_tuple(&option_tuple, None)
+    }
+
+    /// `prefix` is to handle the difference  between tuple structs and enum variant
+    /// tuple structs. The former marks public fields as `pub ` whereas all fields
+    /// of enum tuple structs are always implicitly `pub`.
+    fn render_option_tuple(&self, types: &[Option<&Type>], prefix: Option<&[Token]>) -> Vec<Token> {
+        self.render_sequence(
+            vec![Token::symbol("(")],
+            vec![Token::symbol(")")],
+            comma(),
+            types,
+            |type_| {
+                let mut output: Vec<Token> = vec![];
+                if let (Some(prefix), Some(_)) = (prefix, type_) {
+                    output.extend(prefix.to_owned());
+                }
+                output.extend(self.render_option_type(type_));
+                output
+            },
+        )
+    }
+
+    fn render_slice(&self, ty: &Type) -> Vec<Token> {
+        let mut output = vec![Token::symbol("[")];
+        output.extend(self.render_type(ty));
+        output.push(Token::symbol("]"));
+        output
+    }
+
+    fn render_array(&self, type_: &Type, len: &str) -> Vec<Token> {
+        let mut output = vec![Token::symbol("[")];
+        output.extend(self.render_type(type_));
+        output.extend(vec![
+            Token::symbol(";"),
+            ws!(),
+            Token::primitive(len),
+            Token::symbol("]"),
+        ]);
+        output
+    }
+
+    fn render_impl_trait(&self, bounds: &[GenericBound]) -> Vec<Token> {
+        let mut output = vec![Token::keyword("impl")];
         output.push(ws!());
+        output.extend(self.render_generic_bounds(bounds));
+        output
     }
-    output
+
+    fn render_raw_pointer(&self, mutable: bool, type_: &Type) -> Vec<Token> {
+        let mut output = vec![Token::symbol("*")];
+        output.push(Token::keyword(if mutable { "mut" } else { "const" }));
+        output.push(ws!());
+        output.extend(self.render_type(type_));
+        output
+    }
+
+    fn render_borrowed_ref(
+        &self,
+        lifetime: Option<&str>,
+        mutable: bool,
+        type_: &Type,
+    ) -> Vec<Token> {
+        let mut output = vec![Token::symbol("&")];
+        if let Some(lt) = lifetime {
+            output.extend(vec![Token::lifetime(lt), ws!()]);
+        }
+        if mutable {
+            output.extend(vec![Token::keyword("mut"), ws!()]);
+        }
+        output.extend(self.render_type(type_));
+        output
+    }
+
+    fn render_qualified_path(&self, type_: &Type, trait_: &Path, name: &str) -> Vec<Token> {
+        let mut output = vec![];
+        match type_ {
+            Type::Generic(name) if name == "Self" && trait_.name.is_empty() => {
+                output.push(Token::keyword("Self"));
+            }
+            _ => {
+                output.push(Token::symbol("<"));
+                output.extend(self.render_type(type_));
+                output.extend(vec![ws!(), Token::keyword("as"), ws!()]);
+                output.extend(self.render_resolved_path(trait_));
+                output.push(Token::symbol(">"));
+            }
+        }
+        output.push(Token::symbol("::"));
+        output.push(Token::identifier(name));
+        output
+    }
+
+    fn render_generic_args(&self, args: &GenericArgs) -> Vec<Token> {
+        match args {
+            GenericArgs::AngleBracketed { args, bindings } => {
+                self.render_angle_bracketed(args, bindings)
+            }
+            GenericArgs::Parenthesized { inputs, output } => {
+                self.render_parenthesized(inputs, output)
+            }
+        }
+    }
+
+    fn render_parenthesized(&self, inputs: &[Type], return_ty: &Option<Type>) -> Vec<Token> {
+        let mut output = self.render_sequence(
+            vec![Token::symbol("(")],
+            vec![Token::symbol(")")],
+            comma(),
+            inputs,
+            |type_| self.render_type(type_),
+        );
+        if let Some(return_ty) = return_ty {
+            output.extend(arrow());
+            output.extend(self.render_type(return_ty));
+        }
+        output
+    }
+
+    fn render_angle_bracketed(&self, args: &[GenericArg], bindings: &[TypeBinding]) -> Vec<Token> {
+        enum Arg<'a> {
+            GenericArg(&'a GenericArg),
+            TypeBinding(&'a TypeBinding),
+        }
+        self.render_sequence_if_not_empty(
+            vec![Token::symbol("<")],
+            vec![Token::symbol(">")],
+            comma(),
+            &args
+                .iter()
+                .map(Arg::GenericArg)
+                .chain(bindings.iter().map(Arg::TypeBinding))
+                .collect::<Vec<_>>(),
+            |arg| match arg {
+                Arg::GenericArg(arg) => self.render_generic_arg(arg),
+                Arg::TypeBinding(binding) => self.render_type_binding(binding),
+            },
+        )
+    }
+
+    fn render_term(&self, term: &Term) -> Vec<Token> {
+        match term {
+            Term::Type(ty) => self.render_type(ty),
+            Term::Constant(c) => self.render_constant(c),
+        }
+    }
+
+    fn render_poly_trait(&self, poly_trait: &PolyTrait) -> Vec<Token> {
+        let mut output = self.render_higher_rank_trait_bounds(&poly_trait.generic_params);
+        output.extend(self.render_resolved_path(&poly_trait.trait_));
+        output
+    }
+
+    fn render_generic_arg(&self, arg: &GenericArg) -> Vec<Token> {
+        match arg {
+            GenericArg::Lifetime(name) => vec![Token::lifetime(name)],
+            GenericArg::Type(ty) => self.render_type(ty),
+            GenericArg::Const(c) => self.render_constant(c),
+            GenericArg::Infer => vec![Token::symbol("_")],
+        }
+    }
+
+    fn render_type_binding(&self, binding: &TypeBinding) -> Vec<Token> {
+        let mut output = vec![Token::identifier(&binding.name)];
+        output.extend(self.render_generic_args(&binding.args));
+        match &binding.binding {
+            TypeBindingKind::Equality(term) => {
+                output.extend(equals());
+                output.extend(self.render_term(term));
+            }
+            TypeBindingKind::Constraint(bounds) => {
+                output.extend(self.render_generic_bounds(bounds));
+            }
+        }
+        output
+    }
+
+    fn render_constant(&self, constant: &Constant) -> Vec<Token> {
+        let mut output = self.render_type(&constant.type_);
+        if let Some(value) = &constant.value {
+            output.extend(equals());
+            if constant.is_literal {
+                output.push(Token::primitive(value));
+            } else {
+                output.push(Token::identifier(value));
+            }
+        }
+        output
+    }
+
+    fn render_generics(&self, generics: &Generics) -> Vec<Token> {
+        let mut output = vec![];
+        output.extend(self.render_generic_param_defs(&generics.params));
+        output.extend(self.render_where_predicates(&generics.where_predicates));
+        output
+    }
+
+    fn render_generic_param_defs(&self, params: &[GenericParamDef]) -> Vec<Token> {
+        let params_without_synthetics: Vec<_> = params
+            .iter()
+            .filter(|p| {
+                if let GenericParamDefKind::Type { synthetic, .. } = p.kind {
+                    !synthetic
+                } else {
+                    true
+                }
+            })
+            .collect();
+
+        self.render_sequence_if_not_empty(
+            vec![Token::symbol("<")],
+            vec![Token::symbol(">")],
+            comma(),
+            &params_without_synthetics,
+            |param| self.render_generic_param_def(param),
+        )
+    }
+
+    fn render_generic_param_def(&self, generic_param_def: &GenericParamDef) -> Vec<Token> {
+        let mut output = vec![];
+        match &generic_param_def.kind {
+            GenericParamDefKind::Lifetime { outlives } => {
+                output.push(Token::lifetime(&generic_param_def.name));
+                if !outlives.is_empty() {
+                    output.extend(colon());
+                    output.extend(self.render_sequence(vec![], vec![], plus(), outlives, |s| {
+                        vec![Token::lifetime(s)]
+                    }));
+                }
+            }
+            GenericParamDefKind::Type { bounds, .. } => {
+                output.push(Token::generic(&generic_param_def.name));
+                if !bounds.is_empty() {
+                    output.extend(colon());
+                    output.extend(self.render_generic_bounds(bounds));
+                }
+            }
+            GenericParamDefKind::Const { type_, .. } => {
+                output.push(Token::qualifier("const"));
+                output.push(ws!());
+                output.push(Token::identifier(&generic_param_def.name));
+                output.extend(colon());
+                output.extend(self.render_type(type_));
+            }
+        }
+        output
+    }
+
+    fn render_where_predicates(&self, where_predicates: &[WherePredicate]) -> Vec<Token> {
+        let mut output = vec![];
+        if !where_predicates.is_empty() {
+            output.push(ws!());
+            output.push(Token::Keyword("where".to_owned()));
+            output.push(ws!());
+            output.extend(
+                self.render_sequence(vec![], vec![], comma(), where_predicates, |p| {
+                    self.render_where_predicate(p)
+                }),
+            );
+        }
+        output
+    }
+
+    fn render_where_predicate(&self, where_predicate: &WherePredicate) -> Vec<Token> {
+        let mut output = vec![];
+        match where_predicate {
+            WherePredicate::BoundPredicate {
+                type_,
+                bounds,
+                generic_params,
+            } => {
+                output.extend(self.render_higher_rank_trait_bounds(generic_params));
+                output.extend(self.render_type(type_));
+                output.extend(colon());
+                output.extend(self.render_generic_bounds(bounds));
+            }
+            WherePredicate::RegionPredicate {
+                lifetime,
+                bounds: _,
+            } => output.push(Token::Lifetime(lifetime.clone())),
+            WherePredicate::EqPredicate { lhs, rhs } => {
+                output.extend(self.render_type(lhs));
+                output.extend(equals());
+                output.extend(self.render_term(rhs));
+            }
+        }
+        output
+    }
+
+    fn render_generic_bounds(&self, bounds: &[GenericBound]) -> Vec<Token> {
+        self.render_sequence_if_not_empty(vec![], vec![], plus(), bounds, |bound| match bound {
+            GenericBound::TraitBound {
+                trait_,
+                generic_params,
+                ..
+            } => {
+                let mut output = vec![];
+                output.extend(self.render_higher_rank_trait_bounds(generic_params));
+                output.extend(self.render_resolved_path(trait_));
+                output
+            }
+            GenericBound::Outlives(id) => vec![Token::lifetime(id)],
+        })
+    }
+
+    fn render_higher_rank_trait_bounds(&self, generic_params: &[GenericParamDef]) -> Vec<Token> {
+        let mut output = vec![];
+        if !generic_params.is_empty() {
+            output.push(Token::keyword("for"));
+            output.extend(self.render_generic_param_defs(generic_params));
+            output.push(ws!());
+        }
+        output
+    }
 }
 
 /// Our list of allowed attributes comes from
@@ -813,18 +830,24 @@ mod test {
         };
     }
 
+    use std::collections::HashMap;
+
     use super::*;
     use rustdoc_types::Id;
 
     #[test]
     fn test_type_infer() {
-        assert_render(render_type(&Type::Infer), vec![Token::symbol("_")], "_");
+        assert_render(
+            |context| context.render_type(&Type::Infer),
+            vec![Token::symbol("_")],
+            "_",
+        );
     }
 
     #[test]
     fn test_type_generic() {
         assert_render(
-            render_type(&Type::Generic(s!("name"))),
+            |context| context.render_type(&Type::Generic(s!("name"))),
             vec![Token::generic("name")],
             "name",
         );
@@ -833,7 +856,7 @@ mod test {
     #[test]
     fn test_type_primitive() {
         assert_render(
-            render_type(&Type::Primitive(s!("name"))),
+            |context| context.render_type(&Type::Primitive(s!("name"))),
             vec![Token::primitive("name")],
             "name",
         );
@@ -842,11 +865,13 @@ mod test {
     #[test]
     fn test_type_resolved_simple() {
         assert_render(
-            render_type(&Type::ResolvedPath(Path {
-                name: s!("name"),
-                args: None,
-                id: Id(s!("id")),
-            })),
+            |context| {
+                context.render_type(&Type::ResolvedPath(Path {
+                    name: s!("name"),
+                    args: None,
+                    id: Id(s!("id")),
+                }))
+            },
             vec![Token::type_("name")],
             "name",
         );
@@ -855,11 +880,13 @@ mod test {
     #[test]
     fn test_type_resolved_long_name() {
         assert_render(
-            render_type(&Type::ResolvedPath(Path {
-                name: s!("name::with::parts"),
-                args: None,
-                id: Id(s!("id")),
-            })),
+            |context| {
+                context.render_type(&Type::ResolvedPath(Path {
+                    name: s!("name::with::parts"),
+                    args: None,
+                    id: Id(s!("id")),
+                }))
+            },
             vec![
                 Token::identifier("name"),
                 Token::symbol("::"),
@@ -874,11 +901,13 @@ mod test {
     #[test]
     fn test_type_resolved_crate_name() {
         assert_render(
-            render_type(&Type::ResolvedPath(Path {
-                name: s!("$crate::name"),
-                args: None,
-                id: Id(s!("id")),
-            })),
+            |context| {
+                context.render_type(&Type::ResolvedPath(Path {
+                    name: s!("$crate::name"),
+                    args: None,
+                    id: Id(s!("id")),
+                }))
+            },
             vec![
                 Token::identifier("$crate"),
                 Token::symbol("::"),
@@ -891,11 +920,13 @@ mod test {
     #[test]
     fn test_type_resolved_name_crate() {
         assert_render(
-            render_type(&Type::ResolvedPath(Path {
-                name: s!("name::$crate"),
-                args: None,
-                id: Id(s!("id")),
-            })),
+            |context| {
+                context.render_type(&Type::ResolvedPath(Path {
+                    name: s!("name::$crate"),
+                    args: None,
+                    id: Id(s!("id")),
+                }))
+            },
             vec![
                 Token::identifier("name"),
                 Token::symbol("::"),
@@ -908,7 +939,7 @@ mod test {
     #[test]
     fn test_type_tuple_empty() {
         assert_render(
-            render_type(&Type::Tuple(vec![])),
+            |context| context.render_type(&Type::Tuple(vec![])),
             vec![Token::symbol("("), Token::symbol(")")],
             "()",
         );
@@ -917,7 +948,9 @@ mod test {
     #[test]
     fn test_type_tuple() {
         assert_render(
-            render_type(&Type::Tuple(vec![Type::Infer, Type::Generic(s!("gen"))])),
+            |context| {
+                context.render_type(&Type::Tuple(vec![Type::Infer, Type::Generic(s!("gen"))]))
+            },
             vec![
                 Token::symbol("("),
                 Token::symbol("_"),
@@ -933,7 +966,7 @@ mod test {
     #[test]
     fn test_type_slice() {
         assert_render(
-            render_type(&Type::Slice(Box::new(Type::Infer))),
+            |context| context.render_type(&Type::Slice(Box::new(Type::Infer))),
             vec![Token::symbol("["), Token::symbol("_"), Token::symbol("]")],
             "[_]",
         );
@@ -942,10 +975,12 @@ mod test {
     #[test]
     fn test_type_array() {
         assert_render(
-            render_type(&Type::Array {
-                type_: Box::new(Type::Infer),
-                len: s!("20"),
-            }),
+            |context| {
+                context.render_type(&Type::Array {
+                    type_: Box::new(Type::Infer),
+                    len: s!("20"),
+                })
+            },
             vec![
                 Token::symbol("["),
                 Token::symbol("_"),
@@ -961,10 +996,12 @@ mod test {
     #[test]
     fn test_type_pointer() {
         assert_render(
-            render_type(&Type::RawPointer {
-                mutable: false,
-                type_: Box::new(Type::Infer),
-            }),
+            |context| {
+                context.render_type(&Type::RawPointer {
+                    mutable: false,
+                    type_: Box::new(Type::Infer),
+                })
+            },
             vec![
                 Token::symbol("*"),
                 Token::keyword("const"),
@@ -978,10 +1015,12 @@ mod test {
     #[test]
     fn test_type_pointer_mut() {
         assert_render(
-            render_type(&Type::RawPointer {
-                mutable: true,
-                type_: Box::new(Type::Infer),
-            }),
+            |context| {
+                context.render_type(&Type::RawPointer {
+                    mutable: true,
+                    type_: Box::new(Type::Infer),
+                })
+            },
             vec![
                 Token::symbol("*"),
                 Token::keyword("mut"),
@@ -995,11 +1034,13 @@ mod test {
     #[test]
     fn test_type_ref() {
         assert_render(
-            render_type(&Type::BorrowedRef {
-                lifetime: None,
-                mutable: false,
-                type_: Box::new(Type::Infer),
-            }),
+            |context| {
+                context.render_type(&Type::BorrowedRef {
+                    lifetime: None,
+                    mutable: false,
+                    type_: Box::new(Type::Infer),
+                })
+            },
             vec![Token::symbol("&"), Token::symbol("_")],
             "&_",
         );
@@ -1008,11 +1049,13 @@ mod test {
     #[test]
     fn test_type_ref_mut() {
         assert_render(
-            render_type(&Type::BorrowedRef {
-                lifetime: None,
-                mutable: true,
-                type_: Box::new(Type::Infer),
-            }),
+            |context| {
+                context.render_type(&Type::BorrowedRef {
+                    lifetime: None,
+                    mutable: true,
+                    type_: Box::new(Type::Infer),
+                })
+            },
             vec![
                 Token::symbol("&"),
                 Token::keyword("mut"),
@@ -1026,11 +1069,13 @@ mod test {
     #[test]
     fn test_type_ref_lt() {
         assert_render(
-            render_type(&Type::BorrowedRef {
-                lifetime: Some(s!("'a")),
-                mutable: false,
-                type_: Box::new(Type::Infer),
-            }),
+            |context| {
+                context.render_type(&Type::BorrowedRef {
+                    lifetime: Some(s!("'a")),
+                    mutable: false,
+                    type_: Box::new(Type::Infer),
+                })
+            },
             vec![
                 Token::symbol("&"),
                 Token::lifetime("'a"),
@@ -1044,11 +1089,13 @@ mod test {
     #[test]
     fn test_type_ref_lt_mut() {
         assert_render(
-            render_type(&Type::BorrowedRef {
-                lifetime: Some(s!("'a")),
-                mutable: true,
-                type_: Box::new(Type::Infer),
-            }),
+            |context| {
+                context.render_type(&Type::BorrowedRef {
+                    lifetime: Some(s!("'a")),
+                    mutable: true,
+                    type_: Box::new(Type::Infer),
+                })
+            },
             vec![
                 Token::symbol("&"),
                 Token::lifetime("'a"),
@@ -1064,19 +1111,21 @@ mod test {
     #[test]
     fn test_type_path() {
         assert_render(
-            render_type(&Type::QualifiedPath {
-                name: s!("name"),
-                args: Box::new(GenericArgs::AngleBracketed {
-                    args: vec![],
-                    bindings: vec![],
-                }),
-                self_type: Box::new(Type::Generic(s!("type"))),
-                trait_: Path {
-                    name: String::from("trait"),
-                    args: None,
-                    id: Id(s!("id")),
-                },
-            }),
+            |context| {
+                context.render_type(&Type::QualifiedPath {
+                    name: s!("name"),
+                    args: Box::new(GenericArgs::AngleBracketed {
+                        args: vec![],
+                        bindings: vec![],
+                    }),
+                    self_type: Box::new(Type::Generic(s!("type"))),
+                    trait_: Path {
+                        name: String::from("trait"),
+                        args: None,
+                        id: Id(s!("id")),
+                    },
+                })
+            },
             vec![
                 Token::symbol("<"),
                 Token::generic("type"),
@@ -1093,7 +1142,24 @@ mod test {
     }
 
     #[allow(clippy::needless_pass_by_value)]
-    fn assert_render(actual: Vec<Token>, expected: Vec<Token>, expected_string: &str) {
+    fn assert_render(
+        render_fn: impl Fn(RenderingContext) -> Vec<Token>,
+        expected: Vec<Token>,
+        expected_string: &str,
+    ) {
+        let crate_ = Crate {
+            root: Id(String::from("1:2:3")),
+            crate_version: None,
+            includes_private: false,
+            index: HashMap::new(),
+            paths: HashMap::new(),
+            external_crates: HashMap::new(),
+            format_version: 0,
+        };
+        let context = RenderingContext { crate_: &crate_ };
+
+        let actual = render_fn(context);
+
         assert_eq!(actual, expected);
         assert_eq!(
             crate::item_iterator::tokens_to_string(&actual),


### PR DESCRIPTION
This used to be just a regular arg that was passed around but was later removed (see #78). It turns out we need something like this after all. Add it back, but instead of explicitly passing it around, pass it round implicitly via `self` in a new `RenderingContext`. This makes it a bit easier to work with.

This allows us to get rid of `pre_resolved_fields` since we can look it up on-demand in the render code. It also enables us (with some more upcoming work that I have prototyped) to solve both #145 and #36. Solving these issues requires us to resolve the path of items from only their ID.