### PR TITLE
move `rustdoc_json::build` into a struct fn `BuildOptions::build`

### DIFF
--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -11,7 +11,7 @@ use public_api::diff::PublicItemsDiff;
 use public_api::{Options, PublicApi, PublicItem, MINIMUM_RUSTDOC_JSON_VERSION};
 
 use clap::Parser;
-use rustdoc_json::{BuildError, BuildOptions};
+use rustdoc_json::BuildError;
 
 mod arg_types;
 mod error;
@@ -365,21 +365,21 @@ fn collect_public_api_from_commit(
     } else {
         None
     };
-    let mut build_options = BuildOptions::default()
+    let mut builder = rustdoc_json::Builder::default()
         .toolchain(args.toolchain.clone())
         .manifest_path(&args.manifest_path)
         .all_features(args.all_features)
         .no_default_features(args.no_default_features)
         .features(&args.features);
     if let Some(target) = &args.target {
-        build_options = build_options.target(target.clone());
+        builder = builder.target(target.clone());
     }
 
     if let Some(package) = &args.package {
-        build_options = build_options.package(package);
+        builder = builder.package(package);
     }
 
-    let json_path = match rustdoc_json::build(build_options) {
+    let json_path = match builder.build() {
         Err(BuildError::VirtualManifest(manifest_path)) => virtual_manifest_error(&manifest_path)?,
         res => res?,
     };

--- a/cargo-public-api/tests/expected-output/rustdoc_json_list.txt
+++ b/cargo-public-api/tests/expected-output/rustdoc_json_list.txt
@@ -11,6 +11,7 @@ pub fn rustdoc_json::BuildError::from(source: cargo_toml::Error) -> Self
 pub fn rustdoc_json::BuildError::from(source: std::io::Error) -> Self
 pub fn rustdoc_json::BuildError::source(&self) -> std::option::Option<&(dyn std::error::Error + 'static)>
 pub fn rustdoc_json::BuildOptions::all_features(self, all_features: bool) -> Self
+pub fn rustdoc_json::BuildOptions::build(self) -> Result<PathBuf, rustdoc_json::BuildError>
 pub fn rustdoc_json::BuildOptions::default() -> Self
 pub fn rustdoc_json::BuildOptions::features<I: IntoIterator<Item = S>, S: AsRef<str>>(self, features: I) -> Self
 pub fn rustdoc_json::BuildOptions::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
@@ -20,6 +21,18 @@ pub fn rustdoc_json::BuildOptions::package(self, package: impl AsRef<str>) -> Se
 pub fn rustdoc_json::BuildOptions::quiet(self, quiet: bool) -> Self
 pub fn rustdoc_json::BuildOptions::target(self, target: String) -> Self
 pub fn rustdoc_json::BuildOptions::toolchain(self, toolchain: impl Into<Option<String>>) -> Self
-pub fn rustdoc_json::build(options: rustdoc_json::BuildOptions) -> Result<PathBuf, rustdoc_json::BuildError>
+pub fn rustdoc_json::Builder::all_features(self, all_features: bool) -> Self
+pub fn rustdoc_json::Builder::build(self) -> Result<PathBuf, rustdoc_json::BuildError>
+pub fn rustdoc_json::Builder::default() -> Self
+pub fn rustdoc_json::Builder::features<I: IntoIterator<Item = S>, S: AsRef<str>>(self, features: I) -> Self
+pub fn rustdoc_json::Builder::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
+pub fn rustdoc_json::Builder::manifest_path(self, manifest_path: impl AsRef<Path>) -> Self
+pub fn rustdoc_json::Builder::no_default_features(self, no_default_features: bool) -> Self
+pub fn rustdoc_json::Builder::package(self, package: impl AsRef<str>) -> Self
+pub fn rustdoc_json::Builder::quiet(self, quiet: bool) -> Self
+pub fn rustdoc_json::Builder::target(self, target: String) -> Self
+pub fn rustdoc_json::Builder::toolchain(self, toolchain: impl Into<Option<String>>) -> Self
+pub fn rustdoc_json::build(options: rustdoc_json::Builder) -> Result<PathBuf, rustdoc_json::BuildError>
 pub mod rustdoc_json
 pub struct rustdoc_json::BuildOptions
+pub struct rustdoc_json::Builder

--- a/public-api/examples/diff_public_api.rs
+++ b/public-api/examples/diff_public_api.rs
@@ -1,23 +1,20 @@
 use std::{error::Error, fs::read_to_string};
 
 use public_api::{diff::PublicItemsDiff, Options, PublicApi};
-use rustdoc_json::BuildOptions;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let options = Options::default();
 
-    let old_json = rustdoc_json::build(
-        BuildOptions::default()
-            .toolchain(String::from("+nightly"))
-            .manifest_path("test-apis/example_api-v0.1.0/Cargo.toml"),
-    )?;
+    let old_json = rustdoc_json::Builder::default()
+        .toolchain(String::from("+nightly"))
+        .manifest_path("test-apis/example_api-v0.1.0/Cargo.toml")
+        .build()?;
     let old = PublicApi::from_rustdoc_json_str(&read_to_string(old_json)?, options)?;
 
-    let new_json = rustdoc_json::build(
-        BuildOptions::default()
-            .toolchain(String::from("+nightly"))
-            .manifest_path("test-apis/example_api-v0.2.0/Cargo.toml"),
-    )?;
+    let new_json = rustdoc_json::Builder::default()
+        .toolchain(String::from("+nightly"))
+        .manifest_path("test-apis/example_api-v0.2.0/Cargo.toml")
+        .build()?;
     let new = PublicApi::from_rustdoc_json_str(&read_to_string(new_json)?, options)?;
 
     let diff = PublicItemsDiff::between(old.items, new.items);

--- a/public-api/examples/list_public_api.rs
+++ b/public-api/examples/list_public_api.rs
@@ -2,14 +2,11 @@ use std::{error::Error, fs::read_to_string};
 
 use public_api::{Options, PublicApi};
 
-use rustdoc_json::BuildOptions;
-
 fn main() -> Result<(), Box<dyn Error>> {
-    let json_path = rustdoc_json::build(
-        BuildOptions::default()
-            .toolchain(String::from("+nightly"))
-            .manifest_path("test-apis/example_api-v0.2.0/Cargo.toml"),
-    )?;
+    let json_path = rustdoc_json::Builder::default()
+        .toolchain(String::from("+nightly"))
+        .manifest_path("test-apis/example_api-v0.2.0/Cargo.toml")
+        .build()?;
 
     let public_api =
         PublicApi::from_rustdoc_json_str(&read_to_string(&json_path)?, Options::default())?;

--- a/rustdoc-json/CHANGELOG.md
+++ b/rustdoc-json/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.4.1
+* rename `BuildOptions` to `Builder`, a new insta-deprecated alias `BuildOptions` is available
+* deprecate `build()`, replaced with `Builder::build()`
+* make `BuildOptions`, replaced with `Builder::build()`
+
 ## v0.4.0
 * Support for specifying `--target`, `--features`, and `--package`
 * Make it clearer that `RUSTUP_TOOLCHAIN` and friends has an impact

--- a/rustdoc-json/examples/build-rustdoc-json.rs
+++ b/rustdoc-json/examples/build-rustdoc-json.rs
@@ -3,14 +3,11 @@
 /// cargo run --example build-rustdoc-json path/to/Cargo.toml
 /// ```
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    use rustdoc_json::BuildOptions;
-
     // Build it
-    let json_path = rustdoc_json::build(
-        BuildOptions::default()
-            .toolchain("+nightly".to_owned())
-            .manifest_path(&std::env::args().nth(1).unwrap()),
-    )?;
+    let json_path = rustdoc_json::Builder::default()
+        .toolchain("+nightly".to_owned())
+        .manifest_path(&std::env::args().nth(1).unwrap())
+        .build()?;
     println!("Built and wrote rustdoc JSON to {:?}", &json_path);
 
     // Show it

--- a/rustdoc-json/public-api.txt
+++ b/rustdoc-json/public-api.txt
@@ -11,6 +11,7 @@ pub fn rustdoc_json::BuildError::from(source: cargo_toml::Error) -> Self
 pub fn rustdoc_json::BuildError::from(source: std::io::Error) -> Self
 pub fn rustdoc_json::BuildError::source(&self) -> std::option::Option<&(dyn std::error::Error + 'static)>
 pub fn rustdoc_json::BuildOptions::all_features(self, all_features: bool) -> Self
+pub fn rustdoc_json::BuildOptions::build(self) -> Result<PathBuf, rustdoc_json::BuildError>
 pub fn rustdoc_json::BuildOptions::default() -> Self
 pub fn rustdoc_json::BuildOptions::features<I: IntoIterator<Item = S>, S: AsRef<str>>(self, features: I) -> Self
 pub fn rustdoc_json::BuildOptions::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
@@ -20,6 +21,18 @@ pub fn rustdoc_json::BuildOptions::package(self, package: impl AsRef<str>) -> Se
 pub fn rustdoc_json::BuildOptions::quiet(self, quiet: bool) -> Self
 pub fn rustdoc_json::BuildOptions::target(self, target: String) -> Self
 pub fn rustdoc_json::BuildOptions::toolchain(self, toolchain: impl Into<Option<String>>) -> Self
-pub fn rustdoc_json::build(options: rustdoc_json::BuildOptions) -> Result<PathBuf, rustdoc_json::BuildError>
+pub fn rustdoc_json::Builder::all_features(self, all_features: bool) -> Self
+pub fn rustdoc_json::Builder::build(self) -> Result<PathBuf, rustdoc_json::BuildError>
+pub fn rustdoc_json::Builder::default() -> Self
+pub fn rustdoc_json::Builder::features<I: IntoIterator<Item = S>, S: AsRef<str>>(self, features: I) -> Self
+pub fn rustdoc_json::Builder::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
+pub fn rustdoc_json::Builder::manifest_path(self, manifest_path: impl AsRef<Path>) -> Self
+pub fn rustdoc_json::Builder::no_default_features(self, no_default_features: bool) -> Self
+pub fn rustdoc_json::Builder::package(self, package: impl AsRef<str>) -> Self
+pub fn rustdoc_json::Builder::quiet(self, quiet: bool) -> Self
+pub fn rustdoc_json::Builder::target(self, target: String) -> Self
+pub fn rustdoc_json::Builder::toolchain(self, toolchain: impl Into<Option<String>>) -> Self
+pub fn rustdoc_json::build(options: rustdoc_json::Builder) -> Result<PathBuf, rustdoc_json::BuildError>
 pub mod rustdoc_json
 pub struct rustdoc_json::BuildOptions
+pub struct rustdoc_json::Builder

--- a/rustdoc-json/src/lib.rs
+++ b/rustdoc-json/src/lib.rs
@@ -2,17 +2,16 @@
 //!
 //! # Building
 //!
-//! Use [`build()`] to build rustdoc JSON. Like this:
+//! Use [`rustdoc_json::Builder::build()`][Builder] to build rustdoc JSON. Like this:
+//!
 //! ```
-//!    use rustdoc_json::BuildOptions;
+//! let json_path = rustdoc_json::Builder::default()
+//!     .toolchain("+nightly".to_owned())
+//!     .manifest_path("Cargo.toml")
+//!     .build()
+//!     .unwrap();
 //!
-//!    let json_path = rustdoc_json::build(
-//!        BuildOptions::default()
-//!            .toolchain("+nightly".to_owned())
-//!            .manifest_path("Cargo.toml"),
-//!    ).unwrap();
-//!
-//!    println!("Built and wrote rustdoc JSON to {:?}", &json_path);
+//! println!("Built and wrote rustdoc JSON to {:?}", &json_path);
 //! ```
 //!
 //! A compilable example can be found
@@ -25,7 +24,10 @@ use std::path::PathBuf;
 
 mod build;
 
-/// Represents all errors that can occur when using [`crate::build()`].
+#[deprecated(note = "this struct has been renamed to `rustdoc_json::Builder`")]
+pub use Builder as BuildOptions;
+
+/// Represents all errors that can occur when using [`Builder::build()`].
 #[derive(thiserror::Error, Debug)]
 pub enum BuildError {
     /// You tried to generate rustdoc JSON for a virtual manifest. That does not
@@ -50,11 +52,11 @@ pub enum BuildError {
     IoError(#[from] std::io::Error),
 }
 
-/// Contains all options for [`crate::build()`].
+/// Options for building a rustdoc json file.
 ///
 /// See [crate] for an example on how to use it.
 #[derive(Debug)]
-pub struct BuildOptions {
+pub struct Builder {
     toolchain: Option<String>,
     manifest_path: std::path::PathBuf,
     target: Option<String>,
@@ -74,6 +76,7 @@ pub struct BuildOptions {
 ///
 /// E.g. if building the JSON fails or if the manifest path does not exist or is
 /// invalid.
-pub fn build(options: BuildOptions) -> Result<PathBuf, BuildError> {
-    build::run_cargo_rustdoc(options)
+#[deprecated(note = "use `rustdoc_json::Builder::build()` instead")]
+pub fn build(options: Builder) -> Result<PathBuf, BuildError> {
+    options.build()
 }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -5,8 +5,6 @@
 
 use std::path::PathBuf;
 
-use rustdoc_json::BuildOptions;
-
 mod create_test_git_repo;
 pub use create_test_git_repo::create_test_git_repo;
 
@@ -17,13 +15,13 @@ pub fn rustdoc_json_path_for_crate(test_crate: &str) -> PathBuf {
     // The test framework is unable to capture output from child processes (see
     // https://users.rust-lang.org/t/cargo-doesnt-capture-stderr-in-tests/67045/4),
     // so build quietly to make running tests much less noisy
-    rustdoc_json::build(
-        BuildOptions::default()
-            .toolchain("+nightly".to_owned())
-            .manifest_path(&format!("{}/Cargo.toml", test_crate))
-            .quiet(true),
-    )
-    .unwrap()
+
+    rustdoc_json::Builder::default()
+        .toolchain("+nightly".to_owned())
+        .manifest_path(&format!("{}/Cargo.toml", test_crate))
+        .quiet(true)
+        .build()
+        .unwrap()
 }
 
 /// Helper to get a String of freshly built rustdoc JSON for the given


### PR DESCRIPTION
also deprecates `rustdoc_json::build` for this new method
