### PR TITLE
CI: Enforce `--document-private-items` passes without warnings

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: RUSTDOCFLAGS='--deny warnings' cargo doc --locked --no-deps
+      - run: RUSTDOCFLAGS='--deny warnings' cargo doc --locked --no-deps --document-private-items
 
   cargo-clippy:
     name: cargo clippy -- --deny clippy::all --deny clippy::pedantic ...

--- a/scripts/run-ci-locally.sh
+++ b/scripts/run-ci-locally.sh
@@ -7,7 +7,7 @@ set -o nounset -o pipefail -o errexit -o xtrace
 
 cargo fmt -- --check
 
-RUSTDOCFLAGS='--deny warnings' cargo doc --locked --no-deps
+RUSTDOCFLAGS='--deny warnings' cargo doc --locked --no-deps --document-private-items
 
 scripts/cargo-clippy.sh
 


### PR DESCRIPTION
So that e.g. https://github.com/Enselic/cargo-public-api/pull/156#discussion_r978820594 is automatically detected and everyone saves some time :)