### PR TITLE
Allow to pass `--cap-lints ...` to `cargo public-api`

### DIFF
--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -130,6 +130,10 @@ pub struct Args {
     /// Package to document
     #[clap(long, short)]
     package: Option<String>,
+
+    /// Forwarded to rustdoc JSON build command
+    #[clap(long, hide = true)]
+    cap_lints: Option<String>,
 }
 
 /// After listing or diffing, we might want to do some extra work. This struct
@@ -377,6 +381,10 @@ fn collect_public_api_from_commit(
 
     if let Some(package) = &args.package {
         builder = builder.package(package);
+    }
+
+    if let Some(cap_lints) = &args.cap_lints {
+        builder = builder.cap_lints(Some(cap_lints));
     }
 
     let json_path = match builder.build() {

--- a/cargo-public-api/tests/expected-output/rustdoc_json_list.txt
+++ b/cargo-public-api/tests/expected-output/rustdoc_json_list.txt
@@ -12,6 +12,7 @@ pub fn rustdoc_json::BuildError::from(source: std::io::Error) -> Self
 pub fn rustdoc_json::BuildError::source(&self) -> std::option::Option<&(dyn std::error::Error + 'static)>
 pub fn rustdoc_json::BuildOptions::all_features(self, all_features: bool) -> Self
 pub fn rustdoc_json::BuildOptions::build(self) -> Result<PathBuf, rustdoc_json::BuildError>
+pub fn rustdoc_json::BuildOptions::cap_lints(self, cap_lints: Option<impl AsRef<str>>) -> Self
 pub fn rustdoc_json::BuildOptions::default() -> Self
 pub fn rustdoc_json::BuildOptions::features<I: IntoIterator<Item = S>, S: AsRef<str>>(self, features: I) -> Self
 pub fn rustdoc_json::BuildOptions::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
@@ -23,6 +24,7 @@ pub fn rustdoc_json::BuildOptions::target(self, target: String) -> Self
 pub fn rustdoc_json::BuildOptions::toolchain(self, toolchain: impl Into<Option<String>>) -> Self
 pub fn rustdoc_json::Builder::all_features(self, all_features: bool) -> Self
 pub fn rustdoc_json::Builder::build(self) -> Result<PathBuf, rustdoc_json::BuildError>
+pub fn rustdoc_json::Builder::cap_lints(self, cap_lints: Option<impl AsRef<str>>) -> Self
 pub fn rustdoc_json::Builder::default() -> Self
 pub fn rustdoc_json::Builder::features<I: IntoIterator<Item = S>, S: AsRef<str>>(self, features: I) -> Self
 pub fn rustdoc_json::Builder::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result

--- a/rustdoc-json/CHANGELOG.md
+++ b/rustdoc-json/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.4.1
 * rename `BuildOptions` to `Builder`, a new insta-deprecated alias `BuildOptions` is available
 * deprecate `build()`, replaced with `Builder::build()`
+* Allow changing `--cap-lints`
 
 ## v0.4.0
 * Support for specifying `--target`, `--features`, and `--package`

--- a/rustdoc-json/public-api.txt
+++ b/rustdoc-json/public-api.txt
@@ -12,6 +12,7 @@ pub fn rustdoc_json::BuildError::from(source: std::io::Error) -> Self
 pub fn rustdoc_json::BuildError::source(&self) -> std::option::Option<&(dyn std::error::Error + 'static)>
 pub fn rustdoc_json::BuildOptions::all_features(self, all_features: bool) -> Self
 pub fn rustdoc_json::BuildOptions::build(self) -> Result<PathBuf, rustdoc_json::BuildError>
+pub fn rustdoc_json::BuildOptions::cap_lints(self, cap_lints: Option<impl AsRef<str>>) -> Self
 pub fn rustdoc_json::BuildOptions::default() -> Self
 pub fn rustdoc_json::BuildOptions::features<I: IntoIterator<Item = S>, S: AsRef<str>>(self, features: I) -> Self
 pub fn rustdoc_json::BuildOptions::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
@@ -23,6 +24,7 @@ pub fn rustdoc_json::BuildOptions::target(self, target: String) -> Self
 pub fn rustdoc_json::BuildOptions::toolchain(self, toolchain: impl Into<Option<String>>) -> Self
 pub fn rustdoc_json::Builder::all_features(self, all_features: bool) -> Self
 pub fn rustdoc_json::Builder::build(self) -> Result<PathBuf, rustdoc_json::BuildError>
+pub fn rustdoc_json::Builder::cap_lints(self, cap_lints: Option<impl AsRef<str>>) -> Self
 pub fn rustdoc_json::Builder::default() -> Self
 pub fn rustdoc_json::Builder::features<I: IntoIterator<Item = S>, S: AsRef<str>>(self, features: I) -> Self
 pub fn rustdoc_json::Builder::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result

--- a/rustdoc-json/src/build.rs
+++ b/rustdoc-json/src/build.rs
@@ -46,6 +46,7 @@ fn cargo_rustdoc_command(options: &Builder) -> Command {
         all_features,
         features,
         package,
+        cap_lints,
     } = options;
 
     let mut command =
@@ -83,7 +84,9 @@ fn cargo_rustdoc_command(options: &Builder) -> Command {
     command.arg("--");
     command.args(["-Z", "unstable-options"]);
     command.args(["--output-format", "json"]);
-    command.args(["--cap-lints", "warn"]);
+    if let Some(cap_lints) = cap_lints {
+        command.args(["--cap-lints", cap_lints]);
+    }
     command
 }
 
@@ -140,6 +143,7 @@ impl Default for Builder {
             all_features: false,
             features: vec![],
             package: None,
+            cap_lints: Some(String::from("warn")),
         }
     }
 }
@@ -212,6 +216,13 @@ impl Builder {
     #[must_use]
     pub fn package(mut self, package: impl AsRef<str>) -> Self {
         self.package = Some(package.as_ref().to_owned());
+        self
+    }
+
+    /// What to pass as `--cap-lints` to rustdoc JSON build command
+    #[must_use]
+    pub fn cap_lints(mut self, cap_lints: Option<impl AsRef<str>>) -> Self {
+        self.cap_lints = cap_lints.map(|c| c.as_ref().to_owned());
         self
     }
 

--- a/rustdoc-json/src/lib.rs
+++ b/rustdoc-json/src/lib.rs
@@ -65,6 +65,7 @@ pub struct Builder {
     all_features: bool,
     features: Vec<String>,
     package: Option<String>,
+    cap_lints: Option<String>,
 }
 
 /// Generate rustdoc JSON for a library crate. Returns the path to the freshly

--- a/scripts/bless-expected-output-for-tests.sh
+++ b/scripts/bless-expected-output-for-tests.sh
@@ -72,7 +72,7 @@ RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=${toolchain} cargo run -p cargo-public-ap
       --diff-git-checkouts "v0.1.0" "v0.2.0" > \
       "cargo-public-api/tests/expected-output/example_api_diff_v0.1.0_to_v0.2.0.txt"
 
-echo 'FIXME: Do not hardcode to `--cap-lints warn` in `rustdoc-json` crate'
 RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=${toolchain} cargo run -p cargo-public-api -- \
+      --cap-lints allow \
       --manifest-path "./test-apis/lint_error/Cargo.toml" > \
       "cargo-public-api/tests/expected-output/lint_error_list.txt"


### PR DESCRIPTION
@Emilgardis It would be nice to get this included in your upcoming `rustdoc_json` release

This silences this warning when running `./scripts/bless-expected-output-for-tests.sh`:
```
 Documenting lint_error v0.1.0 (/Users/martin/src/cargo-public-api/test-apis/lint_error)
warning: missing documentation for a struct
  --> src/lib.rs:12:1
   |
12 | pub struct MissingDocs;
   | ^^^^^^^^^^^^^^^^^^^^^^
   |
note: the lint level is defined here
  --> src/lib.rs:9:9
   |
9  | #![deny(missing_docs)]
   |         ^^^^^^^^^^^^

warning: `lint_error` (lib doc) generated 1 warning
    Finished dev [unoptimized + debuginfo] target(s) in 0.28s
```