### PR TITLE
Make even more tests blessable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,7 @@ dependencies = [
  "diff",
  "nu-ansi-term",
  "predicates",
+ "pretty_assertions",
  "public-api",
  "rustdoc-json",
  "tempfile",
@@ -420,6 +421,7 @@ dependencies = [
 name = "public-api"
 version = "0.19.0"
 dependencies = [
+ "anyhow",
  "assert_cmd",
  "hashbag",
  "itertools",
@@ -596,7 +598,9 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 name = "test-utils"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "assert_cmd",
+ "pretty_assertions",
  "rustdoc-json",
  "tempfile",
 ]

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -29,5 +29,6 @@ version = "0.19.0"
 [dev-dependencies]
 assert_cmd = "2.0.4"
 predicates = "2.1.1"
+pretty_assertions = "1.3.0"
 tempfile = "3.3.0"
 cargo_metadata = "0.14.2"

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -30,9 +30,10 @@ mod git_utils;
 #[test]
 #[cfg_attr(all(target_family = "windows", in_ci), ignore)]
 fn list_public_items() {
-    let mut cmd = TestCmd::new();
+    let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();
+    cmd.args(["--manifest-path", "../public-api/Cargo.toml"]);
     cmd.assert()
-        .stdout_or_bless("./tests/expected-output/example_api-v0.3.0.txt")
+        .stdout_or_bless("./tests/expected-output/public_api_list.txt")
         .success();
 }
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -20,6 +20,13 @@ This project makes heavy use of CI. To simulate the CI pipeline locally, run
 
 Note that you can run that script from within your IDE (see `.vscode/tasks.json` for an example configuration)
 
+## Blessing new expected output
+
+To make your changes become the expected output, run
+```
+./scripts/bless-expected-output-for-tests.sh
+```
+
 # Constraints
 
 ## Minimum required stable Rust version

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -26,6 +26,7 @@ features = ["unbounded_depth"]
 version = "0.17.0"
 
 [dev-dependencies]
+anyhow = "1.0.53"
 assert_cmd = "2.0.4"
 pretty_assertions = "1.3.0"
 tempfile = "3.3.0"

--- a/public-api/tests/expected-output/diff_with_added_items.txt
+++ b/public-api/tests/expected-output/diff_with_added_items.txt
@@ -1,0 +1,23 @@
+PublicItemsDiff {
+    removed: [],
+    changed: [
+        ChangedPublicItem {
+            old: pub fn example_api::function(v1_param: example_api::Struct),
+            new: pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize),
+        },
+        ChangedPublicItem {
+            old: pub struct example_api::Struct,
+            new: #[non_exhaustive] pub struct example_api::Struct,
+        },
+    ],
+    added: [
+        impl RefUnwindSafe for example_api::StructV2,
+        impl Send for example_api::StructV2,
+        impl Sync for example_api::StructV2,
+        impl Unpin for example_api::StructV2,
+        impl UnwindSafe for example_api::StructV2,
+        pub struct example_api::StructV2,
+        pub struct field example_api::Struct::v2_field: usize,
+        pub struct field example_api::StructV2::field: usize,
+    ],
+}

--- a/public-api/tests/expected-output/diff_with_removed_items.txt
+++ b/public-api/tests/expected-output/diff_with_removed_items.txt
@@ -1,0 +1,23 @@
+PublicItemsDiff {
+    removed: [
+        impl RefUnwindSafe for example_api::StructV2,
+        impl Send for example_api::StructV2,
+        impl Sync for example_api::StructV2,
+        impl Unpin for example_api::StructV2,
+        impl UnwindSafe for example_api::StructV2,
+        pub struct example_api::StructV2,
+        pub struct field example_api::Struct::v2_field: usize,
+        pub struct field example_api::StructV2::field: usize,
+    ],
+    changed: [
+        ChangedPublicItem {
+            old: #[non_exhaustive] pub struct example_api::Struct,
+            new: pub struct example_api::Struct,
+        },
+        ChangedPublicItem {
+            old: pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize),
+            new: pub fn example_api::function(v1_param: example_api::Struct),
+        },
+    ],
+    added: [],
+}

--- a/public-api/tests/expected-output/no_diff.txt
+++ b/public-api/tests/expected-output/no_diff.txt
@@ -1,0 +1,5 @@
+PublicItemsDiff {
+    removed: [],
+    changed: [],
+    added: [],
+}

--- a/public-api/tests/expected-output/print_diff.txt
+++ b/public-api/tests/expected-output/print_diff.txt
@@ -1,0 +1,19 @@
+Removed:
+(nothing)
+
+Changed:
+-pub fn example_api::function(v1_param: example_api::Struct)
++pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize)
+-pub struct example_api::Struct
++#[non_exhaustive] pub struct example_api::Struct
+
+Added:
++impl RefUnwindSafe for example_api::StructV2
++impl Send for example_api::StructV2
++impl Sync for example_api::StructV2
++impl Unpin for example_api::StructV2
++impl UnwindSafe for example_api::StructV2
++pub struct example_api::StructV2
++pub struct field example_api::Struct::v2_field: usize
++pub struct field example_api::StructV2::field: usize
+

--- a/public-api/tests/expected-output/print_diff_reversed.txt
+++ b/public-api/tests/expected-output/print_diff_reversed.txt
@@ -1,0 +1,19 @@
+Removed:
+-impl RefUnwindSafe for example_api::StructV2
+-impl Send for example_api::StructV2
+-impl Sync for example_api::StructV2
+-impl Unpin for example_api::StructV2
+-impl UnwindSafe for example_api::StructV2
+-pub struct example_api::StructV2
+-pub struct field example_api::Struct::v2_field: usize
+-pub struct field example_api::StructV2::field: usize
+
+Changed:
+-#[non_exhaustive] pub struct example_api::Struct
++pub struct example_api::Struct
+-pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize)
++pub fn example_api::function(v1_param: example_api::Struct)
+
+Added:
+(nothing)
+

--- a/public-api/tests/expected-output/print_no_diff.txt
+++ b/public-api/tests/expected-output/print_no_diff.txt
@@ -1,0 +1,9 @@
+Removed:
+(nothing)
+
+Changed:
+(nothing)
+
+Added:
+(nothing)
+

--- a/public-api/tests/public-api-bin-tests.rs
+++ b/public-api/tests/public-api-bin-tests.rs
@@ -16,7 +16,7 @@ use test_utils::rustdoc_json_path_for_crate;
 fn print_public_api() {
     cmd_with_rustdoc_json_args(&["../test-apis/comprehensive_api"], |mut cmd| {
         cmd.assert()
-            .stdout(include_str!("./expected-output/comprehensive_api.txt"))
+            .stdout_or_bless("./tests/expected-output/comprehensive_api.txt")
             .stderr("")
             .success();
     });
@@ -44,28 +44,7 @@ fn print_diff() {
         ],
         |mut cmd| {
             cmd.assert()
-                .stdout(
-                    "Removed:
-(nothing)
-
-Changed:
--pub fn example_api::function(v1_param: example_api::Struct)
-+pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize)
--pub struct example_api::Struct
-+#[non_exhaustive] pub struct example_api::Struct
-
-Added:
-+impl RefUnwindSafe for example_api::StructV2
-+impl Send for example_api::StructV2
-+impl Sync for example_api::StructV2
-+impl Unpin for example_api::StructV2
-+impl UnwindSafe for example_api::StructV2
-+pub struct example_api::StructV2
-+pub struct field example_api::Struct::v2_field: usize
-+pub struct field example_api::StructV2::field: usize
-
-",
-                )
+                .stdout_or_bless("./tests/expected-output/print_diff.txt")
                 .stderr("")
                 .success();
         },
@@ -81,28 +60,7 @@ fn print_diff_reversed() {
         ],
         |mut cmd| {
             cmd.assert()
-                .stdout(
-                    "Removed:
--impl RefUnwindSafe for example_api::StructV2
--impl Send for example_api::StructV2
--impl Sync for example_api::StructV2
--impl Unpin for example_api::StructV2
--impl UnwindSafe for example_api::StructV2
--pub struct example_api::StructV2
--pub struct field example_api::Struct::v2_field: usize
--pub struct field example_api::StructV2::field: usize
-
-Changed:
--#[non_exhaustive] pub struct example_api::Struct
-+pub struct example_api::Struct
--pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize)
-+pub fn example_api::function(v1_param: example_api::Struct)
-
-Added:
-(nothing)
-
-",
-                )
+                .stdout_or_bless("./tests/expected-output/print_diff_reversed.txt")
                 .stderr("")
                 .success();
         },
@@ -118,18 +76,7 @@ fn print_no_diff() {
         ],
         |mut cmd| {
             cmd.assert()
-                .stdout(
-                    "Removed:
-(nothing)
-
-Changed:
-(nothing)
-
-Added:
-(nothing)
-
-",
-                )
+                .stdout_or_bless("./tests/expected-output/print_no_diff.txt")
                 .stderr("")
                 .success();
         },

--- a/public-api/tests/public-api-lib-tests.rs
+++ b/public-api/tests/public-api-lib-tests.rs
@@ -1,21 +1,15 @@
 // deny in CI, only warn here
 #![warn(clippy::all, clippy::pedantic)]
 
-use std::fmt::Display;
+use std::{fmt::Write, path::Path};
 
-use pretty_assertions::assert_eq;
 use public_api::{Error, Options, PublicApi};
 
 // rust-analyzer bug: https://github.com/rust-lang/rust-analyzer/issues/9173
 #[path = "../../test-utils/src/lib.rs"]
 mod test_utils;
+use test_utils::assert_eq_or_bless;
 use test_utils::rustdoc_json_str_for_crate;
-
-struct ExpectedDiff<'a> {
-    removed: &'a [&'a str],
-    changed: &'a [(&'a str, &'a str)],
-    added: &'a [&'a str],
-}
 
 #[test]
 fn with_blanket_implementations() {
@@ -25,7 +19,7 @@ fn with_blanket_implementations() {
 
     assert_public_api_with_blanket_implementations(
         &rustdoc_json_str_for_crate("../test-apis/example_api-v0.2.0"),
-        include_str!("./expected-output/example_api-v0.2.0-with-blanket-implementations.txt"),
+        "./tests/expected-output/example_api-v0.2.0-with-blanket-implementations.txt",
     );
 }
 
@@ -34,29 +28,7 @@ fn diff_with_added_items() {
     assert_public_api_diff(
         &rustdoc_json_str_for_crate("../test-apis/example_api-v0.1.0"),
         &rustdoc_json_str_for_crate("../test-apis/example_api-v0.2.0"),
-        &ExpectedDiff {
-            removed: &[],
-            changed: &[
-                (
-                    "pub fn example_api::function(v1_param: example_api::Struct)",
-                    "pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize)",
-                ),
-                (
-                    "pub struct example_api::Struct",
-                    "#[non_exhaustive] pub struct example_api::Struct",
-                ),
-            ],
-            added: &[
-                "impl RefUnwindSafe for example_api::StructV2",
-                "impl Send for example_api::StructV2",
-                "impl Sync for example_api::StructV2",
-                "impl Unpin for example_api::StructV2",
-                "impl UnwindSafe for example_api::StructV2",
-                "pub struct example_api::StructV2",
-                "pub struct field example_api::Struct::v2_field: usize",
-                "pub struct field example_api::StructV2::field: usize",
-            ],
-        },
+        "./tests/expected-output/diff_with_added_items.txt",
     );
 }
 
@@ -66,11 +38,7 @@ fn no_diff() {
     assert_public_api_diff(
         &rustdoc_json_str_for_crate("../test-apis/comprehensive_api"),
         &rustdoc_json_str_for_crate("../test-apis/comprehensive_api"),
-        &ExpectedDiff {
-            removed: &[],
-            changed: &[],
-            added: &[],
-        },
+        "./tests/expected-output/no_diff.txt",
     );
 }
 
@@ -79,29 +47,7 @@ fn diff_with_removed_items() {
     assert_public_api_diff(
         &rustdoc_json_str_for_crate("../test-apis/example_api-v0.2.0"),
         &rustdoc_json_str_for_crate("../test-apis/example_api-v0.1.0"),
-        &ExpectedDiff {
-            removed: &[
-                "impl RefUnwindSafe for example_api::StructV2",
-                "impl Send for example_api::StructV2",
-                "impl Sync for example_api::StructV2",
-                "impl Unpin for example_api::StructV2",
-                "impl UnwindSafe for example_api::StructV2",
-                "pub struct example_api::StructV2",
-                "pub struct field example_api::Struct::v2_field: usize",
-                "pub struct field example_api::StructV2::field: usize",
-            ],
-            changed: &[
-                (
-                    "#[non_exhaustive] pub struct example_api::Struct",
-                    "pub struct example_api::Struct",
-                ),
-                (
-                    "pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize)",
-                    "pub fn example_api::function(v1_param: example_api::Struct)",
-                ),
-            ],
-            added: &[],
-        },
+        "./tests/expected-output/diff_with_removed_items.txt",
     );
 }
 
@@ -109,7 +55,7 @@ fn diff_with_removed_items() {
 fn comprehensive_api() {
     assert_public_api(
         &rustdoc_json_str_for_crate("../test-apis/comprehensive_api"),
-        include_str!("./expected-output/comprehensive_api.txt"),
+        "./tests/expected-output/comprehensive_api.txt",
     );
 }
 
@@ -117,7 +63,7 @@ fn comprehensive_api() {
 fn comprehensive_api_proc_macro() {
     assert_public_api(
         &rustdoc_json_str_for_crate("../test-apis/comprehensive_api_proc_macro"),
-        include_str!("./expected-output/comprehensive_api_proc_macro.txt"),
+        "./tests/expected-output/comprehensive_api_proc_macro.txt",
     );
 }
 
@@ -164,110 +110,40 @@ fn options() {
     let _ = options.clone();
 }
 
-#[test]
-fn pretty_printed_diff() {
-    let options = Options::default();
-    let old = PublicApi::from_rustdoc_json_str(
-        &rustdoc_json_str_for_crate("../test-apis/example_api-v0.1.0"),
-        options,
-    )
-    .unwrap();
-    let new = PublicApi::from_rustdoc_json_str(
-        &rustdoc_json_str_for_crate("../test-apis/example_api-v0.2.0"),
-        options,
-    )
-    .unwrap();
-
-    let diff = public_api::diff::PublicItemsDiff::between(old.items, new.items);
-    let pretty_printed = format!("{:#?}", diff);
-    assert_eq!(
-        pretty_printed,
-        "PublicItemsDiff {
-    removed: [],
-    changed: [
-        ChangedPublicItem {
-            old: pub fn example_api::function(v1_param: example_api::Struct),
-            new: pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize),
-        },
-        ChangedPublicItem {
-            old: pub struct example_api::Struct,
-            new: #[non_exhaustive] pub struct example_api::Struct,
-        },
-    ],
-    added: [
-        impl RefUnwindSafe for example_api::StructV2,
-        impl Send for example_api::StructV2,
-        impl Sync for example_api::StructV2,
-        impl Unpin for example_api::StructV2,
-        impl UnwindSafe for example_api::StructV2,
-        pub struct example_api::StructV2,
-        pub struct field example_api::Struct::v2_field: usize,
-        pub struct field example_api::StructV2::field: usize,
-    ],
-}"
-    );
-}
-
-fn assert_public_api_diff(old_json: &str, new_json: &str, expected: &ExpectedDiff) {
+fn assert_public_api_diff(old_json: &str, new_json: &str, expected: impl AsRef<Path>) {
     let old = PublicApi::from_rustdoc_json_str(old_json, Options::default()).unwrap();
     let new = PublicApi::from_rustdoc_json_str(new_json, Options::default()).unwrap();
 
     let diff = public_api::diff::PublicItemsDiff::between(old.items, new.items);
-
-    assert_eq!(expected.added, into_strings(diff.added));
-    assert_eq!(expected.removed, into_strings(diff.removed));
-
-    let expected_changed: Vec<_> = expected
-        .changed
-        .iter()
-        .map(|x| (x.0.to_owned(), x.1.to_owned()))
-        .collect();
-    let actual_changed: Vec<_> = diff
-        .changed
-        .iter()
-        .map(|x| (format!("{}", &x.old), format!("{}", &x.new)))
-        .collect();
-    assert_eq!(expected_changed, actual_changed);
+    let pretty_printed = format!("{:#?}", diff);
+    assert_eq_or_bless(&pretty_printed, expected);
 }
 
-fn assert_public_api(json: &str, expected: &str) {
+fn assert_public_api(json: &str, expected: impl AsRef<Path>) {
     assert_public_api_impl(json, expected, false);
 }
 
-fn assert_public_api_with_blanket_implementations(json: &str, expected: &str) {
+fn assert_public_api_with_blanket_implementations(json: &str, expected: impl AsRef<Path>) {
     assert_public_api_impl(json, expected, true);
 }
 
 fn assert_public_api_impl(
     rustdoc_json_str: &str,
-    expected_output: &str,
+    expected_output: impl AsRef<Path>,
     with_blanket_implementations: bool,
 ) {
     let mut options = Options::default();
     options.with_blanket_implementations = with_blanket_implementations;
     options.sorted = true;
 
-    let actual = into_strings(
-        PublicApi::from_rustdoc_json_str(rustdoc_json_str, options)
-            .unwrap()
-            .items,
-    );
+    let api = PublicApi::from_rustdoc_json_str(rustdoc_json_str, options).unwrap();
 
-    let expected = expected_output_to_string_vec(expected_output);
+    let mut actual = String::new();
+    for item in api.items {
+        writeln!(&mut actual, "{}", item).unwrap();
+    }
 
-    assert_eq!(expected, actual);
-}
-
-fn expected_output_to_string_vec(expected_output: &str) -> Vec<String> {
-    expected_output
-        .split('\n')
-        .map(String::from)
-        .filter(|s| !s.is_empty()) // Remove empty entry caused by trailing newline in files
-        .collect()
-}
-
-fn into_strings(items: Vec<impl Display>) -> Vec<String> {
-    items.into_iter().map(|x| format!("{}", x)).collect()
+    assert_eq_or_bless(&actual, expected_output);
 }
 
 /// To be honest this is mostly to get higher code coverage numbers.

--- a/scripts/bless-expected-output-for-tests.sh
+++ b/scripts/bless-expected-output-for-tests.sh
@@ -4,33 +4,4 @@ set -o nounset -o pipefail -o errexit
 # `:-+nightly` means "if unset, use +nightly"
 toolchain=${RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK:-+nightly}
 
-test_git_dir="/tmp/cargo-public-api-test-repo"
-rm -rf "${test_git_dir}"
-cargo run -p test-utils -- "${test_git_dir}" ./test-apis
-
-build_for="
-    comprehensive_api
-    comprehensive_api_proc_macro
-    example_api-v0.2.0
-"
-
-output_for="
-    comprehensive_api
-    comprehensive_api_proc_macro
-"
-
-for crate in $build_for; do
-    cargo ${toolchain} rustdoc --lib --manifest-path "./test-apis/${crate}/Cargo.toml" -- -Z unstable-options --output-format json
-done
-
-for crate in $output_for; do
-    cargo run -p public-api -- "./test-apis/${crate}/target/doc/${crate}.json" > "public-api/tests/expected-output/${crate}.txt"
-done
-
 BLESS=1 RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=${toolchain} cargo test --test '*' -p public-api -p cargo-public-api
-
-# BLESS=1 can't be used yet because this is used in test-invocation-variants.sh
-RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=${toolchain} cargo run -p cargo-public-api -- \
-      --manifest-path "public-api/Cargo.toml" \
-      --color=never > \
-      "cargo-public-api/tests/expected-output/public_api_list.txt"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -5,7 +5,9 @@ edition = "2021"
 
 
 [dependencies]
+anyhow = "1.0.53"
 assert_cmd = "2.0.4"
+pretty_assertions = "1.3.0"
 tempfile = "3.3.0"
 
 [dependencies.rustdoc-json]

--- a/test-utils/src/assert_or_bless.rs
+++ b/test-utils/src/assert_or_bless.rs
@@ -1,9 +1,12 @@
 use std::{
+    fs::read_to_string,
     io::Write,
     path::{Path, PathBuf},
 };
 
+use anyhow::Context;
 use assert_cmd::assert::Assert;
+use pretty_assertions::assert_eq;
 use tempfile::NamedTempFile;
 
 pub trait AssertOrBless {
@@ -13,24 +16,45 @@ pub trait AssertOrBless {
 impl AssertOrBless for Assert {
     fn stdout_or_bless(self, expected_file: impl AsRef<Path>) -> Assert {
         if std::env::var("BLESS").is_ok() {
-            let mut temp_file = NamedTempFile::new_in(&temp_dir()).unwrap();
-            temp_file.write_all(&self.get_output().stdout).unwrap();
-
+            let stdout = &self.get_output().stdout;
             // Write to dest as an atomic operation so that we get the desired
             // outcome even if the presence of concurrently running tests that
             // bless to the same file
-            std::fs::rename(temp_file, expected_file).unwrap();
+            write_to_file_atomically(expected_file, stdout);
             self
         } else {
             // Make into a string to show diff
-            let expected =
-                String::from_utf8(std::fs::read(&expected_file).unwrap_or_else(|_| {
-                    panic!("couldn't read file: {:?}", expected_file.as_ref())
-                }))
-                .unwrap();
-            self.stdout(expected)
+            self.stdout(read_to_string_unwrap(expected_file))
         }
     }
+}
+
+pub fn assert_eq_or_bless(actual: &str, expected_path: impl AsRef<Path>) {
+    if std::env::var("BLESS").is_ok() {
+        // Write to dest as an atomic operation so that we get the desired
+        // outcome even if the presence of concurrently running tests that
+        // bless to the same file
+        write_to_file_atomically(expected_path, actual.as_bytes());
+    } else {
+        // Make into a string to show diff
+        assert_eq!(actual, read_to_string_unwrap(expected_path));
+    }
+}
+
+pub fn write_to_file_atomically(path: impl AsRef<Path>, data: &[u8]) {
+    let mut temp_file = NamedTempFile::new_in(&temp_dir()).unwrap();
+    temp_file.write_all(data).unwrap();
+    std::fs::rename(temp_file, path.as_ref())
+        .with_context(|| format!("Failed to rename {:?}", path.as_ref()))
+        .unwrap();
+}
+
+/// A version of [`std::fs::read_to_string`] that prints the path to the file in
+/// case of errors.
+fn read_to_string_unwrap(path: impl AsRef<Path>) -> String {
+    read_to_string(&path)
+        .with_context(|| format!("Failed to read {:?}", path.as_ref()))
+        .unwrap()
 }
 
 fn temp_dir() -> PathBuf {

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -9,6 +9,8 @@ mod create_test_git_repo;
 pub use create_test_git_repo::create_test_git_repo;
 
 pub mod assert_or_bless;
+pub use assert_or_bless::assert_eq_or_bless;
+pub use assert_or_bless::write_to_file_atomically;
 
 /// Helper to get the path to a freshly built rustdoc JSON file for the given
 /// test-crate.


### PR DESCRIPTION
Remove test `pretty_printed_diff()` which now becomes the same as `diff_with_added_items()` now that `diff_with_added_items()` also uses pretty-printing for blessable output.

I briefly looked into [snapbox](https://docs.rs/snapbox/0.4.0/snapbox/) and [trycmd](https://docs.rs/trycmd/latest/trycmd/), but their docs weren't great IMHO, so it was too much of a hurdle for me to start using these. So I continued on the path started in #165.