### PR TITLE
Make `--toolchain` take toolchain name without `+`

### DIFF
--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -102,13 +102,13 @@ pub struct Args {
     #[clap(long, hide = true)]
     verbose: bool,
 
-    /// Allows you to build rustdoc JSON with a toolchain other than `+nightly`.
+    /// Allows you to build rustdoc JSON with a toolchain other than `nightly`.
     ///
     /// Consider using `cargo +toolchain public-api` instead.
     ///
     /// Useful if you have built a toolchain from source for example, or if you
     /// want to use a fixed toolchain in CI.
-    #[clap(long, validator = |s: &str| if s.starts_with('+') { Ok(()) } else { Err("toolchain must start with a `+`")} )]
+    #[clap(long, validator = |s: &str| if !s.starts_with('+') { Ok(()) } else { Err("toolchain must not start with a `+`")} )]
     toolchain: Option<String>,
 
     /// Build for the target triple
@@ -160,7 +160,7 @@ fn main_() -> Result<()> {
         {
             eprintln!("Warning: using the `{toolchain}` toolchain for gathering the public api is not possible, switching to `nightly`");
         }
-        args.toolchain = Some("+nightly".to_owned());
+        args.toolchain = Some("nightly".to_owned());
     }
 
     let post_processing = if let Some(commits) = &args.diff_git_checkouts {
@@ -184,7 +184,7 @@ fn active_toolchain_is_probably_stable(toolchain: Option<&str>) -> bool {
         || std::process::Command::new("cargo"),
         |toolchain| {
             let mut cmd = std::process::Command::new("rustup");
-            cmd.args(["run", toolchain.trim_start_matches('+'), "cargo"]);
+            cmd.args(["run", toolchain, "cargo"]);
             cmd
         },
     );

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -52,7 +52,7 @@ fn list_public_items_with_lint_error() {
 fn custom_toolchain() {
     let mut cmd = TestCmd::new();
     cmd.arg("--toolchain");
-    cmd.arg("+nightly");
+    cmd.arg("nightly");
     cmd.assert()
         .stdout_or_bless("./tests/expected-output/example_api-v0.3.0.txt")
         .success();

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -73,7 +73,7 @@ cargo +custom public-api
 
 Another option is the `RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK` env var. Use it like this:
 ```
-RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=+custom ./scripts/run-ci-locally.sh
+RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=custom ./scripts/run-ci-locally.sh
 ```
 
 # Automated tests

--- a/public-api/examples/diff_public_api.rs
+++ b/public-api/examples/diff_public_api.rs
@@ -6,13 +6,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     let options = Options::default();
 
     let old_json = rustdoc_json::Builder::default()
-        .toolchain(String::from("+nightly"))
+        .toolchain(String::from("nightly"))
         .manifest_path("test-apis/example_api-v0.1.0/Cargo.toml")
         .build()?;
     let old = PublicApi::from_rustdoc_json_str(&read_to_string(old_json)?, options)?;
 
     let new_json = rustdoc_json::Builder::default()
-        .toolchain(String::from("+nightly"))
+        .toolchain(String::from("nightly"))
         .manifest_path("test-apis/example_api-v0.2.0/Cargo.toml")
         .build()?;
     let new = PublicApi::from_rustdoc_json_str(&read_to_string(new_json)?, options)?;

--- a/public-api/examples/list_public_api.rs
+++ b/public-api/examples/list_public_api.rs
@@ -4,7 +4,7 @@ use public_api::{Options, PublicApi};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let json_path = rustdoc_json::Builder::default()
-        .toolchain(String::from("+nightly"))
+        .toolchain(String::from("nightly"))
         .manifest_path("test-apis/example_api-v0.2.0/Cargo.toml")
         .build()?;
 

--- a/rustdoc-json/examples/build-rustdoc-json.rs
+++ b/rustdoc-json/examples/build-rustdoc-json.rs
@@ -5,7 +5,7 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Build it
     let json_path = rustdoc_json::Builder::default()
-        .toolchain("+nightly".to_owned())
+        .toolchain("nightly".to_owned())
         .manifest_path(&std::env::args().nth(1).unwrap())
         .build()?;
     println!("Built and wrote rustdoc JSON to {:?}", &json_path);

--- a/rustdoc-json/src/build.rs
+++ b/rustdoc-json/src/build.rs
@@ -9,7 +9,7 @@ use std::{
 /// For development purposes only. Sometimes when you work on this project you
 /// want to quickly use a different toolchain to build rustdoc JSON. You can
 /// specify what toolchain, by temporarily changing this.
-const OVERRIDDEN_TOOLCHAIN: Option<&str> = option_env!("RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK"); // Some("+nightly-2022-07-16");
+const OVERRIDDEN_TOOLCHAIN: Option<&str> = option_env!("RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK"); // Some("nightly-2022-07-16");
 
 /// Run `cargo rustdoc` to produce rustdoc JSON and return the path to the built
 /// file.
@@ -55,7 +55,7 @@ fn cargo_rustdoc_command(options: &Builder) -> Command {
             || Command::new("cargo"),
             |toolchain| {
                 let mut cmd = Command::new("rustup");
-                cmd.args(["run", toolchain.trim_start_matches('+'), "cargo"]);
+                cmd.args(["run", toolchain, "cargo"]);
                 cmd
             },
         );
@@ -153,7 +153,7 @@ impl Default for Builder {
 impl Builder {
     /// Set the toolchain. Default: `None`.
     /// Until rustdoc JSON has stabilized, you will want to set this to
-    /// be `"+nightly"` or similar.
+    /// be `"nightly"` or similar.
     ///
     /// If the toolchain is set as `None`, the current active toolchain will be used.
     ///

--- a/rustdoc-json/src/lib.rs
+++ b/rustdoc-json/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! ```
 //! let json_path = rustdoc_json::Builder::default()
-//!     .toolchain("+nightly".to_owned())
+//!     .toolchain("nightly".to_owned())
 //!     .manifest_path("Cargo.toml")
 //!     .build()
 //!     .unwrap();

--- a/scripts/bless-expected-output-for-tests.sh
+++ b/scripts/bless-expected-output-for-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -o nounset -o pipefail -o errexit
 
-# `:-+nightly` means "if unset, use +nightly"
-toolchain=${RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK:-+nightly}
+# `:-nightly` means "if unset, use nightly"
+toolchain=${RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK:-nightly}
 
 BLESS=1 RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=${toolchain} cargo test --test '*' -p public-api -p cargo-public-api

--- a/scripts/test-invocation-variants.sh
+++ b/scripts/test-invocation-variants.sh
@@ -124,7 +124,7 @@ assert_progress_and_output \
 # test uses a too old nightly toolchain, which should make the tool fail if it's used.
 # Test against comprehensive_api, because we want any rustdoc JSON format
 # incompatibilities to be detected
-cmd="cargo public-api --toolchain +${unusable_toolchain} --manifest-path test-apis/comprehensive_api/Cargo.toml"
+cmd="cargo public-api --toolchain ${unusable_toolchain} --manifest-path test-apis/comprehensive_api/Cargo.toml"
 echo -n "${cmd} ... "
 if ${cmd} >/dev/null 2>/dev/null; then
     echo "FAIL: Using '${unusable_toolchain}' to build rustdoc JSON should have failed!"

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -21,7 +21,7 @@ pub fn rustdoc_json_path_for_crate(test_crate: &str) -> PathBuf {
     // so build quietly to make running tests much less noisy
 
     rustdoc_json::Builder::default()
-        .toolchain("+nightly".to_owned())
+        .toolchain("nightly".to_owned())
         .manifest_path(&format!("{}/Cargo.toml", test_crate))
         .quiet(true)
         .build()


### PR DESCRIPTION
A Rust "toolchain" is actually referred to without a `+`. The `+` comes from the proxy mechanism of rustup, but `+` is not actually part of the toolchain name.

See for example https://rust-lang.github.io/rustup/concepts/toolchains.html:

```
rustup toolchain install stable-x86_64-pc-windows-msvc
```

There is no `+` there.

Closes #161 