### PR TITLE
Bump min nightly to nightly-2022-09-28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-public-api"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "public-api"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ List and diff the public API of Rust library crates between releases and commits
 # Install cargo-public-api with a recent regular stable Rust toolchain
 cargo install cargo-public-api
 
-# Ensure nightly-2022-09-08 or later is installed so cargo-public-api can build rustdoc JSON for you
+# Ensure nightly-2022-09-28 or later is installed so cargo-public-api can build rustdoc JSON for you
 rustup install nightly
 ```
 
@@ -96,7 +96,8 @@ cargo public-api --with-blanket-implementations
 
 | cargo-public-api | Understands the rustdoc JSON output of  |
 | ---------------- | --------------------------------------- |
-| 0.19.x           | nightly-2022-09-08 —                    |
+| 0.20.x           | nightly-2022-09-28 —                    |
+| 0.19.x           | nightly-2022-09-08 — nightly-2022-09-27 |
 | 0.18.x           | nightly-2022-09-07                      |
 | 0.17.x           | nightly-2022-09-06                      |
 | 0.15.x — 0.16.x  | nightly-2022-08-15 — nightly-2022-09-05 |

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "cargo-public-api"
-version = "0.19.0"
+version = "0.20.0"
 default-run = "cargo-public-api"
 description = "List and diff the public API of Rust library crates between releases and commits. Detect breaking API changes and semver violations."
 homepage = "https://github.com/Enselic/cargo-public-api"
@@ -24,7 +24,7 @@ version = "0.4.1"
 
 [dependencies.public-api]
 path = "../public-api"
-version = "0.19.0"
+version = "0.20.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "public-api"
-version = "0.19.0"
+version = "0.20.0"
 description = "List and diff the public API of Rust library crates. Relies on rustdoc JSON output from the nightly toolchain."
 homepage = "https://github.com/Enselic/cargo-public-api/tree/main/rustdoc-json"
 documentation = "https://docs.rs/public-api"

--- a/public-api/README.md
+++ b/public-api/README.md
@@ -16,7 +16,7 @@ The library comes with a thin bin wrapper that can be used to explore the capabi
 # Build and install the thin bin wrapper with a recent stable Rust toolchain
 cargo install public-api
 
-# Install nightly-2022-09-08 or later so you can build up-to-date rustdoc JSON files
+# Install nightly-2022-09-28 or later so you can build up-to-date rustdoc JSON files
 rustup install nightly
 ```
 

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -64,7 +64,7 @@ pub use item_iterator::PublicItem;
 /// The rustdoc JSON format is still changing, so every now and then we update
 /// this library to support the latest format. If you use this version of
 /// nightly or later, you should be fine.
-pub const MINIMUM_RUSTDOC_JSON_VERSION: &str = "nightly-2022-09-08";
+pub const MINIMUM_RUSTDOC_JSON_VERSION: &str = "nightly-2022-09-28";
 
 /// Contains various options that you can pass to [`PublicApi::from_rustdoc_json_str`].
 #[derive(Copy, Clone, Debug)]


### PR DESCRIPTION
And prepare for v0.20.0 release.

The bump comes from https://github.com/rust-lang/rust/pull/102321, but probably will never affect crates in the wild. But I want to bump anyway since it is a format change after all.

I plan to release this tomorrow after also merging https://github.com/Enselic/cargo-public-api/pull/168 since that change also warrants a 0.x.0 bump.