### PR TITLE
Allow to specify `--target-dir` when building rustdoc JSON

### DIFF
--- a/cargo-public-api/tests/expected-output/rustdoc_json_list.txt
+++ b/cargo-public-api/tests/expected-output/rustdoc_json_list.txt
@@ -34,6 +34,7 @@ pub fn rustdoc_json::BuildOptions::fmt(&self, f: &mut $crate::fmt::Formatter<'_>
 pub fn rustdoc_json::BuildOptions::manifest_path(self, manifest_path: impl AsRef<Path>) -> Self
 pub fn rustdoc_json::BuildOptions::package(self, package: impl AsRef<str>) -> Self
 pub fn rustdoc_json::BuildOptions::target(self, target: String) -> Self
+pub fn rustdoc_json::BuildOptions::target_dir(self, target_dir: impl AsRef<Path>) -> Self
 pub fn rustdoc_json::BuildOptions::toolchain(self, toolchain: impl Into<Option<String>>) -> Self
 pub fn rustdoc_json::Builder::build(self) -> Result<PathBuf, rustdoc_json::BuildError>
 pub fn rustdoc_json::Builder::cap_lints(self, cap_lints: Option<impl AsRef<str>>) -> Self
@@ -43,6 +44,7 @@ pub fn rustdoc_json::Builder::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> 
 pub fn rustdoc_json::Builder::manifest_path(self, manifest_path: impl AsRef<Path>) -> Self
 pub fn rustdoc_json::Builder::package(self, package: impl AsRef<str>) -> Self
 pub fn rustdoc_json::Builder::target(self, target: String) -> Self
+pub fn rustdoc_json::Builder::target_dir(self, target_dir: impl AsRef<Path>) -> Self
 pub fn rustdoc_json::Builder::toolchain(self, toolchain: impl Into<Option<String>>) -> Self
 pub fn rustdoc_json::build(options: rustdoc_json::Builder) -> Result<PathBuf, rustdoc_json::BuildError>
 pub mod rustdoc_json

--- a/public-api/tests/public-api-bin-tests.rs
+++ b/public-api/tests/public-api-bin-tests.rs
@@ -202,8 +202,8 @@ fn cmd_with_rustdoc_json_args(crates: &[&str], final_steps: impl FnOnce(Command)
     let mut temp_dirs = vec![];
 
     for crate_ in crates {
-        // Put output in a temp dir so that concurrently running tests do not
-        // concurrently write and read the same JSON, which causes tests to fail
+        // Put output in a temp dir to ensure concurrently running tests do not
+        // write and read the same JSON simultaneously, which causes tests to fail
         // sporadically.
         let temp_dir = TempDir::new().unwrap();
 

--- a/public-api/tests/public-api-bin-tests.rs
+++ b/public-api/tests/public-api-bin-tests.rs
@@ -215,13 +215,12 @@ fn cmd_with_rustdoc_json_args(crates: &[&str], final_steps: impl FnOnce(Command)
         // We need one dir per crate, because in the case of example_api-v0.1.0 and
         // example_api-v0.2.0 for example, the same JSON file name example_api.json
         // is used, so using the same dir for all would cause JSON files to be
-        // overwitten.
+        // overwritten.
         temp_dirs.push(temp_dir);
     }
 
     final_steps(cmd);
 
     // Here temp_dirs are dropped/removed. To prevent that for debugging
-    // purposes, wrap `TempDir::new().unwrap()` in
-    // `std::mem::ManuallyDrop::new()`, but never drop.
+    // purposes, use `TempDir::into_path()`.
 }

--- a/rustdoc-json/CHANGELOG.md
+++ b/rustdoc-json/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.4.2
+* Add `Builder::target_dir()`
+
 ## v0.4.1
 * rename `BuildOptions` to `Builder`, a new insta-deprecated alias `BuildOptions` is available
 * deprecate `build()`, replaced with `Builder::build()`

--- a/rustdoc-json/public-api.txt
+++ b/rustdoc-json/public-api.txt
@@ -34,6 +34,7 @@ pub fn rustdoc_json::BuildOptions::fmt(&self, f: &mut $crate::fmt::Formatter<'_>
 pub fn rustdoc_json::BuildOptions::manifest_path(self, manifest_path: impl AsRef<Path>) -> Self
 pub fn rustdoc_json::BuildOptions::package(self, package: impl AsRef<str>) -> Self
 pub fn rustdoc_json::BuildOptions::target(self, target: String) -> Self
+pub fn rustdoc_json::BuildOptions::target_dir(self, target_dir: impl AsRef<Path>) -> Self
 pub fn rustdoc_json::BuildOptions::toolchain(self, toolchain: impl Into<Option<String>>) -> Self
 pub fn rustdoc_json::Builder::build(self) -> Result<PathBuf, rustdoc_json::BuildError>
 pub fn rustdoc_json::Builder::cap_lints(self, cap_lints: Option<impl AsRef<str>>) -> Self
@@ -43,6 +44,7 @@ pub fn rustdoc_json::Builder::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> 
 pub fn rustdoc_json::Builder::manifest_path(self, manifest_path: impl AsRef<Path>) -> Self
 pub fn rustdoc_json::Builder::package(self, package: impl AsRef<str>) -> Self
 pub fn rustdoc_json::Builder::target(self, target: String) -> Self
+pub fn rustdoc_json::Builder::target_dir(self, target_dir: impl AsRef<Path>) -> Self
 pub fn rustdoc_json::Builder::toolchain(self, toolchain: impl Into<Option<String>>) -> Self
 pub fn rustdoc_json::build(options: rustdoc_json::Builder) -> Result<PathBuf, rustdoc_json::BuildError>
 pub mod rustdoc_json

--- a/rustdoc-json/src/build.rs
+++ b/rustdoc-json/src/build.rs
@@ -189,7 +189,7 @@ impl Builder {
 
     /// Set what `--target-dir` to pass to `cargo`. Typically only needed if you
     /// want to be able to build rustdoc JSON for the same crate concurerntly,
-    /// for example to paralellize regression tests.
+    /// for example to parallelize regression tests.
     #[must_use]
     pub fn target_dir(mut self, target_dir: impl AsRef<Path>) -> Self {
         self.target_dir = Some(target_dir.as_ref().to_owned());

--- a/rustdoc-json/src/build.rs
+++ b/rustdoc-json/src/build.rs
@@ -188,7 +188,7 @@ impl Builder {
     }
 
     /// Set what `--target-dir` to pass to `cargo`. Typically only needed if you
-    /// want to be able to build rustdoc JSON for the same crate concurerntly,
+    /// want to be able to build rustdoc JSON for the same crate concurrently,
     /// for example to parallelize regression tests.
     #[must_use]
     pub fn target_dir(mut self, target_dir: impl AsRef<Path>) -> Self {

--- a/rustdoc-json/src/lib.rs
+++ b/rustdoc-json/src/lib.rs
@@ -58,7 +58,8 @@ pub enum BuildError {
 #[derive(Debug)]
 pub struct Builder {
     toolchain: Option<String>,
-    manifest_path: std::path::PathBuf,
+    manifest_path: PathBuf,
+    target_dir: Option<PathBuf>,
     target: Option<String>,
     quiet: bool,
     no_default_features: bool,

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::missing_panics_doc)]
 #![allow(dead_code)]
 
+use std::path::Path;
 use std::path::PathBuf;
 
 mod create_test_git_repo;
@@ -12,19 +13,36 @@ pub mod assert_or_bless;
 pub use assert_or_bless::assert_eq_or_bless;
 pub use assert_or_bless::write_to_file_atomically;
 
+#[must_use]
+pub fn rustdoc_json_path_for_crate(test_crate: &str) -> PathBuf {
+    rustdoc_json_path_for_crate_impl(test_crate, None)
+}
+
+#[must_use]
+pub fn rustdoc_json_path_for_crate_with_target_dir(
+    test_crate: &str,
+    target_dir: impl AsRef<Path>,
+) -> PathBuf {
+    rustdoc_json_path_for_crate_impl(test_crate, Some(target_dir.as_ref()))
+}
+
 /// Helper to get the path to a freshly built rustdoc JSON file for the given
 /// test-crate.
 #[must_use]
-pub fn rustdoc_json_path_for_crate(test_crate: &str) -> PathBuf {
-    rustdoc_json::Builder::default()
+fn rustdoc_json_path_for_crate_impl(test_crate: &str, target_dir: Option<&Path>) -> PathBuf {
+    let mut builder = rustdoc_json::Builder::default()
         .toolchain("nightly".to_owned())
         .manifest_path(&format!("{}/Cargo.toml", test_crate))
         // The test framework is unable to capture output from child processes (see
         // https://users.rust-lang.org/t/cargo-doesnt-capture-stderr-in-tests/67045/4),
         // so build quietly to make running tests much less noisy
-        .quiet(true)
-        .build()
-        .unwrap()
+        .quiet(true);
+
+    if let Some(target_dir) = target_dir {
+        builder = builder.target_dir(target_dir);
+    }
+
+    builder.build().unwrap()
 }
 
 /// Helper to get a String of freshly built rustdoc JSON for the given


### PR DESCRIPTION
Mostly to fix flaky tests caused by rustdoc JSON buliding race conditions, reproducible for me with:

    while true; do cargo clean -p public-api ; cargo test -p public-api; sleep 1; done 2>&1 | grep 'test result'

I got a test failure approximately 2% of the time before the fix.