### PR TITLE
Support `std` and `core` pre-built JSON via new `--rustdoc-json` option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "rustdoc-types"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61fb498f838b7da375722c088e3c2571c3fbe7fe38c8fa208a6de1a6fdc3907"
+checksum = "7745b68b43d89a088d2d270be09f54f948e587fc540cb15e3d3b75cb327a01c3"
 dependencies = [
  "serde",
 ]

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -76,6 +76,19 @@ pub struct Args {
     #[clap(long, min_values = 2, max_values = 2)]
     diff_rustdoc_json: Option<Vec<String>>,
 
+    /// Usage: --rustdoc-json <RUSTDOC_JSON_PATH>
+    ///
+    /// List the public API based on the given rustdoc JSON file. Try for example
+    ///
+    ///     rustup component add rust-docs-json --toolchain  nightly
+    ///
+    /// and then
+    ///
+    ///     cargo public-api --rustdoc-json ~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/share/doc/rust/json/std.json
+    ///
+    #[clap(long)]
+    rustdoc_json: Option<String>,
+
     /// Exit with failure if the specified API diff is detected.
     ///
     /// * all = deny added, changed, and removed public items in the API
@@ -167,6 +180,8 @@ fn main_() -> Result<()> {
         print_diff_between_two_commits(&args, commits)?
     } else if let Some(files) = &args.diff_rustdoc_json {
         print_diff_between_two_rustdoc_json_files(&args, files)?
+    } else if let Some(rustdoc_json) = &args.rustdoc_json {
+        print_public_items_from_json(&args, rustdoc_json)?
     } else {
         print_public_items_of_current_commit(&args)?
     };
@@ -258,7 +273,19 @@ fn check_diff(args: &Args, diff: &Option<PublicItemsDiff>) -> Result<()> {
 
 fn print_public_items_of_current_commit(args: &Args) -> Result<PostProcessing> {
     let (public_api, branch_to_restore) = collect_public_api_from_commit(args, None)?;
+    print_public_items(args, &public_api, branch_to_restore)
+}
 
+fn print_public_items_from_json(args: &Args, json_path: &str) -> Result<PostProcessing> {
+    let public_api = public_api_from_rustdoc_json_path(json_path, args)?;
+    print_public_items(args, &public_api, None)
+}
+
+fn print_public_items(
+    args: &Args,
+    public_api: &PublicApi,
+    branch_to_restore: Option<String>,
+) -> Result<PostProcessing> {
     Plain::print_items(&mut stdout(), args, &public_api.items)?;
 
     Ok(PostProcessing {

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -389,6 +389,17 @@ fn diff_public_items_from_files() {
 }
 
 #[test]
+fn list_public_items_from_json_file() {
+    let json_file = rustdoc_json_path_for_crate("../test-apis/example_api-v0.3.0");
+    let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();
+    cmd.arg("--rustdoc-json");
+    cmd.arg(json_file);
+    cmd.assert()
+        .stdout_or_bless("./tests/expected-output/example_api-v0.3.0.txt")
+        .success();
+}
+
+#[test]
 fn diff_public_items_missing_one_arg() {
     let mut cmd = TestCmd::new();
     cmd.arg("--diff-git-checkouts");

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -23,7 +23,7 @@ features = ["unbounded_depth"]
 
 [dependencies.rustdoc-types]
 # path = "/Users/martin/src/rustdoc-types"
-version = "0.17.0"
+version = "0.18.0"
 
 [dev-dependencies]
 anyhow = "1.0.53"

--- a/public-api/src/render.rs
+++ b/public-api/src/render.rs
@@ -176,7 +176,21 @@ impl<'a> RenderingContext<'a> {
                 }
                 output
             }
-            ItemEnum::PrimitiveType(_) => self.render_simple(&["primitive", "type"], &item.path()),
+            ItemEnum::Primitive(primitive) => {
+                // This is hard to write tests for since only Rust `core` is
+                // allowed to define primitives. So you have to test this code
+                // using the pre-built rustdoc JSON for core:
+                //
+                //   rustup component add rust-docs-json --toolchain nightly
+                //   cargo run -- --rustdoc-json ~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/share/doc/rust/json/core.json
+                let mut output = pub_();
+                output.extend([
+                    Token::kind("type"),
+                    ws!(),
+                    Token::primitive(&primitive.name),
+                ]);
+                output
+            }
         };
 
         tokens.extend(inner_tokens);


### PR DESCRIPTION
First install the pre-built rustdoc JSON like this:

    rustup component add rust-docs-json --toolchain nightly

then you can use the new option to list the public API of e.g. `core`:

    cargo public-api --rustdoc-json ~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/share/doc/rust/json/core.json

Closes #91 