### PR TITLE
Bump `cargo_toml` to `0.13.0-alpha.1` to not crash on `version.workspace = true`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,12 +117,11 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.11.5"
+version = "0.13.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5809dd3e6444651fd1cdd3dbec71eca438c439a0fcc8081674a14da0afe50185"
+checksum = "f5448cb54abe0479b30b1f25f51a83768ae351f924d8f85d193a1b3940b64094"
 dependencies = [
  "serde",
- "serde_derive",
  "toml",
 ]
 
@@ -410,11 +409,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -519,18 +518,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -556,13 +555,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.85"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
+checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -641,10 +640,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "unicode-ident"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "version_check"

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -143,6 +143,18 @@ fn virtual_manifest_error() {
 }
 
 #[test]
+fn workspace_version_does_not_crash() {
+    let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();
+    cmd.arg("--manifest-path");
+    cmd.arg(current_dir_and(
+        "tests/virtual-manifest/workspace-version/Cargo.toml",
+    ));
+    cmd.assert()
+        .stdout_or_bless("./tests/expected-output/workspace-version.txt")
+        .success();
+}
+
+#[test]
 fn diff_public_items() {
     let mut cmd = TestCmd::new();
     let test_repo_path = cmd.test_repo_path().to_owned();

--- a/cargo-public-api/tests/expected-output/workspace-version.txt
+++ b/cargo-public-api/tests/expected-output/workspace-version.txt
@@ -1,0 +1,2 @@
+pub fn workspace_version::something()
+pub mod workspace_version

--- a/cargo-public-api/tests/virtual-manifest/Cargo.toml
+++ b/cargo-public-api/tests/virtual-manifest/Cargo.toml
@@ -1,4 +1,8 @@
 [workspace]
 members = [
     "specific-crate",
+    "workspace-version",
 ]
+
+[workspace.package]
+version = "100.0.0"

--- a/cargo-public-api/tests/virtual-manifest/workspace-version/Cargo.toml
+++ b/cargo-public-api/tests/virtual-manifest/workspace-version/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "workspace-version"
+version.workspace = true

--- a/cargo-public-api/tests/virtual-manifest/workspace-version/src/lib.rs
+++ b/cargo-public-api/tests/virtual-manifest/workspace-version/src/lib.rs
@@ -1,0 +1,1 @@
+pub fn something() {}

--- a/rustdoc-json/Cargo.toml
+++ b/rustdoc-json/Cargo.toml
@@ -11,5 +11,5 @@ repository = "https://github.com/Enselic/cargo-public-api/tree/main/rustdoc-json
 
 [dependencies]
 cargo_metadata = "0.14.2"
-cargo_toml = "0.11.4"
+cargo_toml = "0.13.0-alpha.1"
 thiserror = "1.0.29"


### PR DESCRIPTION
Not crashing is more important than not depending on alphas IMHO, even if it feels a bit awkward to depend on alphas. Curious to hear what others thinks about this.

Closes #175
