### PR TITLE
rustdoc-json: Remove most of `BuildOptions`, only leave deprecation message

### DIFF
--- a/cargo-public-api/tests/expected-output/rustdoc_json_list.txt
+++ b/cargo-public-api/tests/expected-output/rustdoc_json_list.txt
@@ -1,16 +1,18 @@
 impl !RefUnwindSafe for rustdoc_json::BuildError
 impl !UnwindSafe for rustdoc_json::BuildError
+impl RefUnwindSafe for rustdoc_json::BuildOptions
 impl RefUnwindSafe for rustdoc_json::Builder
 impl Send for rustdoc_json::BuildError
+impl Send for rustdoc_json::BuildOptions
 impl Send for rustdoc_json::Builder
 impl Sync for rustdoc_json::BuildError
+impl Sync for rustdoc_json::BuildOptions
 impl Sync for rustdoc_json::Builder
 impl Unpin for rustdoc_json::BuildError
+impl Unpin for rustdoc_json::BuildOptions
 impl Unpin for rustdoc_json::Builder
+impl UnwindSafe for rustdoc_json::BuildOptions
 impl UnwindSafe for rustdoc_json::Builder
-pub const fn rustdoc_json::BuildOptions::all_features(self, all_features: bool) -> Self
-pub const fn rustdoc_json::BuildOptions::no_default_features(self, no_default_features: bool) -> Self
-pub const fn rustdoc_json::BuildOptions::quiet(self, quiet: bool) -> Self
 pub const fn rustdoc_json::Builder::all_features(self, all_features: bool) -> Self
 pub const fn rustdoc_json::Builder::no_default_features(self, no_default_features: bool) -> Self
 pub const fn rustdoc_json::Builder::quiet(self, quiet: bool) -> Self
@@ -26,16 +28,6 @@ pub fn rustdoc_json::BuildError::from(source: cargo_metadata::Error) -> Self
 pub fn rustdoc_json::BuildError::from(source: cargo_toml::Error) -> Self
 pub fn rustdoc_json::BuildError::from(source: std::io::Error) -> Self
 pub fn rustdoc_json::BuildError::source(&self) -> std::option::Option<&(dyn std::error::Error + 'static)>
-pub fn rustdoc_json::BuildOptions::build(self) -> Result<PathBuf, rustdoc_json::BuildError>
-pub fn rustdoc_json::BuildOptions::cap_lints(self, cap_lints: Option<impl AsRef<str>>) -> Self
-pub fn rustdoc_json::BuildOptions::default() -> Self
-pub fn rustdoc_json::BuildOptions::features<I: IntoIterator<Item = S>, S: AsRef<str>>(self, features: I) -> Self
-pub fn rustdoc_json::BuildOptions::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
-pub fn rustdoc_json::BuildOptions::manifest_path(self, manifest_path: impl AsRef<Path>) -> Self
-pub fn rustdoc_json::BuildOptions::package(self, package: impl AsRef<str>) -> Self
-pub fn rustdoc_json::BuildOptions::target(self, target: String) -> Self
-pub fn rustdoc_json::BuildOptions::target_dir(self, target_dir: impl AsRef<Path>) -> Self
-pub fn rustdoc_json::BuildOptions::toolchain(self, toolchain: impl Into<Option<String>>) -> Self
 pub fn rustdoc_json::Builder::build(self) -> Result<PathBuf, rustdoc_json::BuildError>
 pub fn rustdoc_json::Builder::cap_lints(self, cap_lints: Option<impl AsRef<str>>) -> Self
 pub fn rustdoc_json::Builder::default() -> Self

--- a/rustdoc-json/CHANGELOG.md
+++ b/rustdoc-json/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.5.0
+* Remove most of `BuildOptions`, only leave deprecation message
+
 ## v0.4.2
 * Add `Builder::target_dir()`
 

--- a/rustdoc-json/README.md
+++ b/rustdoc-json/README.md
@@ -4,6 +4,10 @@ Utilities for working with [rustdoc JSON](https://github.com/rust-lang/rust/issu
 
 Originally developed for use by [`public-api`](https://crates.io/crates/public-api) and [`cargo-public-api`](https://crates.io/crates/cargo-public-api), but should be useful for any Rust code that wants to build rustdoc JSON.
 
+## Changelog
+
+Please refer to [CHANGELOG.md](CHANGELOG.md).
+
 ## Testing
 
 This library is indirectly tested through the [`public-api`](https://crates.io/crates/public-api) and [`cargo-public-api`](https://crates.io/crates/cargo-public-api) test suites. Their tests heavily depend on this library, so if all of their tests pass, then this library works as it should. All tests are of course ensured to pass before a new release is made.

--- a/rustdoc-json/public-api.txt
+++ b/rustdoc-json/public-api.txt
@@ -1,16 +1,18 @@
 impl !RefUnwindSafe for rustdoc_json::BuildError
 impl !UnwindSafe for rustdoc_json::BuildError
+impl RefUnwindSafe for rustdoc_json::BuildOptions
 impl RefUnwindSafe for rustdoc_json::Builder
 impl Send for rustdoc_json::BuildError
+impl Send for rustdoc_json::BuildOptions
 impl Send for rustdoc_json::Builder
 impl Sync for rustdoc_json::BuildError
+impl Sync for rustdoc_json::BuildOptions
 impl Sync for rustdoc_json::Builder
 impl Unpin for rustdoc_json::BuildError
+impl Unpin for rustdoc_json::BuildOptions
 impl Unpin for rustdoc_json::Builder
+impl UnwindSafe for rustdoc_json::BuildOptions
 impl UnwindSafe for rustdoc_json::Builder
-pub const fn rustdoc_json::BuildOptions::all_features(self, all_features: bool) -> Self
-pub const fn rustdoc_json::BuildOptions::no_default_features(self, no_default_features: bool) -> Self
-pub const fn rustdoc_json::BuildOptions::quiet(self, quiet: bool) -> Self
 pub const fn rustdoc_json::Builder::all_features(self, all_features: bool) -> Self
 pub const fn rustdoc_json::Builder::no_default_features(self, no_default_features: bool) -> Self
 pub const fn rustdoc_json::Builder::quiet(self, quiet: bool) -> Self
@@ -26,16 +28,6 @@ pub fn rustdoc_json::BuildError::from(source: cargo_metadata::Error) -> Self
 pub fn rustdoc_json::BuildError::from(source: cargo_toml::Error) -> Self
 pub fn rustdoc_json::BuildError::from(source: std::io::Error) -> Self
 pub fn rustdoc_json::BuildError::source(&self) -> std::option::Option<&(dyn std::error::Error + 'static)>
-pub fn rustdoc_json::BuildOptions::build(self) -> Result<PathBuf, rustdoc_json::BuildError>
-pub fn rustdoc_json::BuildOptions::cap_lints(self, cap_lints: Option<impl AsRef<str>>) -> Self
-pub fn rustdoc_json::BuildOptions::default() -> Self
-pub fn rustdoc_json::BuildOptions::features<I: IntoIterator<Item = S>, S: AsRef<str>>(self, features: I) -> Self
-pub fn rustdoc_json::BuildOptions::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
-pub fn rustdoc_json::BuildOptions::manifest_path(self, manifest_path: impl AsRef<Path>) -> Self
-pub fn rustdoc_json::BuildOptions::package(self, package: impl AsRef<str>) -> Self
-pub fn rustdoc_json::BuildOptions::target(self, target: String) -> Self
-pub fn rustdoc_json::BuildOptions::target_dir(self, target_dir: impl AsRef<Path>) -> Self
-pub fn rustdoc_json::BuildOptions::toolchain(self, toolchain: impl Into<Option<String>>) -> Self
 pub fn rustdoc_json::Builder::build(self) -> Result<PathBuf, rustdoc_json::BuildError>
 pub fn rustdoc_json::Builder::cap_lints(self, cap_lints: Option<impl AsRef<str>>) -> Self
 pub fn rustdoc_json::Builder::default() -> Self

--- a/rustdoc-json/src/lib.rs
+++ b/rustdoc-json/src/lib.rs
@@ -24,8 +24,11 @@ use std::path::PathBuf;
 
 mod build;
 
-#[deprecated(note = "this struct has been renamed to `rustdoc_json::Builder`")]
-pub use Builder as BuildOptions;
+/// replace `rustdoc_json::build(BuildOptions::default().option1().option2().build())` with `rustdoc_json::Builder::default().option1().option2().build()`
+#[deprecated(
+    note = "replace `rustdoc_json::build(BuildOptions::default().option1().option2().build())` with `rustdoc_json::Builder::default().option1().option2().build()`"
+)]
+pub struct BuildOptions;
 
 /// Represents all errors that can occur when using [`Builder::build()`].
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
Our current deprecation setup is not aggressive enough, because this code compiles without warning:

https://github.com/SUPERCILEX/ftzz/blob/23c80a1c3c3372254311d9798409ad82f2564676/tests/api.rs#L9-L10

I have created a PR with a fix: https://github.com/SUPERCILEX/ftzz/pull/5

But I think it is time now to remove BuildOptions. But still keep it around for the sake of a deprecation message.

I could not figure out a way to keep the v0.4.x API while still getting a deprecation message. There is already a deprecation message, but it does not work due to https://github.com/rust-lang/rust/issues/30827. So prepare bump to v0.5.0.