### PR TITLE
Validate and resolve CLI commit references

### DIFF
--- a/cargo-public-api/src/git_utils.rs
+++ b/cargo-public-api/src/git_utils.rs
@@ -84,3 +84,10 @@ fn trimmed_stdout(mut cmd: Command) -> Result<String> {
         Err(anyhow!("Failure: {:?}", output))
     }
 }
+
+/// Resolves a git reference provided at the CLI to an actual commit, allowing
+/// us to validate refs and use "relative" values like HEAD and more.
+#[allow(unused)] // It IS used!
+pub fn resolve_ref(path: impl AsRef<Path>, committish: &str) -> Result<String> {
+    trimmed_git_stdout(path, &["rev-parse", committish])
+}

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -60,9 +60,6 @@ pub struct Args {
     /// If you have local changes, git will refuse to do `git checkout`, so your
     /// work will not be discarded.
     ///
-    /// Do not use non-fixed commit references such as `HEAD^` since the meaning
-    /// of `HEAD^` is different depending on what commit is the current commit.
-    ///
     /// Using the current git repo has the benefit of making it likely for the
     /// build to succeed. If we e.g. were to git clone a temporary copy of a
     /// commit ourselves, the risk is high that additional steps are needed

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -301,10 +301,14 @@ fn print_public_items(
 
 fn print_diff_between_two_commits(args: &Args, commits: &[String]) -> Result<PostProcessing> {
     let old_commit = commits.get(0).expect("clap makes sure first commit exist");
-    let (old, branch_to_restore) = collect_public_api_from_commit(args, Some(old_commit))?;
-
     let new_commit = commits.get(1).expect("clap makes sure second commit exist");
-    let (new, _) = collect_public_api_from_commit(args, Some(new_commit))?;
+
+    // Validate provided commits and resolve relative refs like HEAD to actual commits
+    let old_commit = git_utils::resolve_ref(&args.git_root()?, old_commit)?;
+    let new_commit = git_utils::resolve_ref(&args.git_root()?, new_commit)?;
+
+    let (old, branch_to_restore) = collect_public_api_from_commit(args, Some(&old_commit))?;
+    let (new, _) = collect_public_api_from_commit(args, Some(&new_commit))?;
 
     let diff_to_check = Some(print_diff(args, old.items, new.items)?);
 


### PR DESCRIPTION
Validate the existence of provided commits and resolve "relative" git refs or committish values to their absolute equivalents.

Allows values like `HEAD` to be used in specifying commits to diff.

Closes #180.