### PR TITLE
cargo-public-api: Introduce `toolchain` mod

### DIFF
--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -17,6 +17,7 @@ mod arg_types;
 mod error;
 mod git_utils;
 mod plain;
+mod toolchain;
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -183,56 +184,6 @@ fn main_() -> Result<()> {
     post_processing.perform(&args)
 }
 
-/// Returns true if it seems like the currently active toolchain is the stable
-/// toolchain.
-///
-/// See <https://rust-lang.github.io/rustup/overrides.html> for some
-/// more info of how different toolchains can be activated.
-fn active_toolchain_is_probably_stable(toolchain: Option<&str>) -> bool {
-    let mut cmd = toolchain.map_or_else(
-        || std::process::Command::new("cargo"),
-        |toolchain| {
-            let mut cmd = std::process::Command::new("rustup");
-            cmd.args(["run", toolchain, "cargo"]);
-            cmd
-        },
-    );
-    cmd.arg("--version");
-
-    let output = match cmd.output() {
-        Ok(output) => output,
-        Err(_) => return false,
-    };
-
-    let version = match String::from_utf8(output.stdout) {
-        Ok(version) => version,
-        Err(_) => return false,
-    };
-
-    version.starts_with("cargo 1") && !version.contains("nightly")
-}
-
-/// returns the current toolchain if it was overriden by environment
-fn active_toolchain_is_environment_override() -> Option<String> {
-    let mut cmd = std::process::Command::new("rustup");
-    cmd.args(["show", "active-toolchain"]);
-    cmd.env_remove("RUSTUP_TOOLCHAIN");
-
-    let output = String::from_utf8(cmd.output().ok()?.stdout).ok()?;
-
-    output
-        .split(char::is_whitespace)
-        .next()
-        .and_then(|default| {
-            let toolchain = std::env::var("RUSTUP_TOOLCHAIN").ok();
-            if toolchain.as_deref() == Some(default) {
-                None
-            } else {
-                toolchain
-            }
-        })
-}
-
 fn check_diff(args: &Args, diff: &Option<PublicItemsDiff>) -> Result<()> {
     match (&args.deny, diff) {
         // We were requested to deny diffs, so make sure there is no diff
@@ -361,11 +312,8 @@ fn get_args() -> Args {
     let mut args = Args::parse_from(args_os);
 
     // check if using a stable compiler, and use nightly if it is.
-    if active_toolchain_is_probably_stable(args.toolchain.as_deref()) {
-        if let Some(toolchain) = args
-            .toolchain
-            .or_else(active_toolchain_is_environment_override)
-        {
+    if toolchain::is_probably_stable(args.toolchain.as_deref()) {
+        if let Some(toolchain) = args.toolchain.or_else(toolchain::from_rustup) {
             eprintln!("Warning: using the `{toolchain}` toolchain for gathering the public api is not possible, switching to `nightly`");
         }
         args.toolchain = Some("nightly".to_owned());

--- a/cargo-public-api/src/toolchain.rs
+++ b/cargo-public-api/src/toolchain.rs
@@ -1,0 +1,51 @@
+/// Returns true if it seems like the currently active toolchain is the stable
+/// toolchain.
+///
+/// See <https://rust-lang.github.io/rustup/overrides.html> for some
+/// more info of how different toolchains can be activated.
+pub fn is_probably_stable(toolchain: Option<&str>) -> bool {
+    let mut cmd = toolchain.map_or_else(
+        || std::process::Command::new("cargo"),
+        |toolchain| {
+            let mut cmd = std::process::Command::new("rustup");
+            cmd.args(["run", toolchain, "cargo"]);
+            cmd
+        },
+    );
+    cmd.arg("--version");
+
+    let output = match cmd.output() {
+        Ok(output) => output,
+        Err(_) => return false,
+    };
+
+    let version = match String::from_utf8(output.stdout) {
+        Ok(version) => version,
+        Err(_) => return false,
+    };
+
+    version.starts_with("cargo 1") && !version.contains("nightly")
+}
+
+/// Returns the current toolchain if it is overridden by the environment
+/// variable `RUSTUP_TOOLCHAIN` which `rustup` sets when its proxies are invoked
+/// with the `+toolchain` arg, e.g. `cargo +nightly ...`.
+pub fn from_rustup() -> Option<String> {
+    let mut cmd = std::process::Command::new("rustup");
+    cmd.args(["show", "active-toolchain"]);
+    cmd.env_remove("RUSTUP_TOOLCHAIN");
+
+    let output = String::from_utf8(cmd.output().ok()?.stdout).ok()?;
+
+    output
+        .split(char::is_whitespace)
+        .next()
+        .and_then(|default| {
+            let toolchain = std::env::var("RUSTUP_TOOLCHAIN").ok();
+            if toolchain.as_deref() == Some(default) {
+                None
+            } else {
+                toolchain
+            }
+        })
+}


### PR DESCRIPTION
```
commit a3f91e4512552c6b7aae708cc2acc53ccbc50f30 (HEAD -> toolchain-mod, origin/toolchain-mod)
Author: Martin Nordholts <enselic@gmail.com>
Date:   Sun Oct 16 06:53:50 2022 +0200

    cargo-public-api: Introduce toolchain mod
    
    So that the somewhat advanced toolchain code is not "in the way" for
    someone that casually looks at main.rs the first time.

commit 6d040bdf7e018eeef21e1c81e2bdf39c180d7e5e
Author: Martin Nordholts <enselic@gmail.com>
Date:   Sun Oct 16 06:40:56 2022 +0200

    Move `active_toolchain_is_probably_stable()` into `get_args()`
    
    So that the code in `fn main()` becomes easier to follow for someone
    that is new to the code. Besides, if we ever add another call to
    `get_args()`, we would need to do this change anyway.

```