### PR TITLE
`public_api`: Introduce private `mod public_item`

### DIFF
--- a/public-api/src/diff.rs
+++ b/public-api/src/diff.rs
@@ -3,7 +3,7 @@
 //! public-api`](https://github.com/Enselic/cargo-public-api) contains
 //! additional helpers for that.
 
-use crate::{item_iterator::PublicItemPath, PublicItem};
+use crate::public_item::{PublicItem, PublicItemPath};
 use hashbag::HashBag;
 use std::collections::HashMap;
 

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -45,6 +45,7 @@
 mod error;
 mod intermediate_public_item;
 mod item_iterator;
+mod public_item;
 mod render;
 pub mod tokens;
 
@@ -54,7 +55,7 @@ pub mod diff;
 pub use error::{Error, Result};
 
 // Documented at the definition site so cargo doc picks it up
-pub use item_iterator::PublicItem;
+pub use public_item::PublicItem;
 
 /// This constant defines the minimum version of nightly that is required in
 /// order for the rustdoc JSON output to be parsable by this library. Note that

--- a/public-api/src/public_item.rs
+++ b/public-api/src/public_item.rs
@@ -1,0 +1,75 @@
+use std::fmt::Display;
+use std::rc::Rc;
+
+use crate::intermediate_public_item::IntermediatePublicItem;
+use crate::render::RenderingContext;
+use crate::tokens::tokens_to_string;
+use crate::tokens::Token;
+
+/// Each public item (except `impl`s) have a path that is displayed like
+/// `first::second::third`. Internally we represent that with a `vec!["first",
+/// "second", "third"]`. This is a type alias for that internal representation
+/// to make the code easier to read.
+pub(crate) type PublicItemPath = Vec<String>;
+
+/// Represent a public item of an analyzed crate, i.e. an item that forms part
+/// of the public API of a crate. Implements [`Display`] so it can be printed. It
+/// also implements [`Ord`], but how items are ordered are not stable yet, and
+/// will change in later versions.
+#[derive(Clone, Eq, PartialEq, Hash)]
+pub struct PublicItem {
+    /// The "your_crate::mod_a::mod_b" part of an item. Split by "::"
+    pub(crate) path: PublicItemPath,
+
+    /// The rendered item as a stream of [`Token`]s
+    pub(crate) tokens: Vec<Token>,
+}
+
+impl PublicItem {
+    pub(crate) fn from_intermediate_public_item(
+        context: &RenderingContext,
+        public_item: &Rc<IntermediatePublicItem<'_>>,
+    ) -> PublicItem {
+        PublicItem {
+            path: public_item
+                .path()
+                .iter()
+                .map(|i| i.name().to_owned())
+                .collect::<PublicItemPath>(),
+            tokens: public_item.render_token_stream(context),
+        }
+    }
+
+    /// The rendered item as a stream of [`Token`]s
+    pub fn tokens(&self) -> impl Iterator<Item = &Token> {
+        self.tokens.iter()
+    }
+}
+
+/// We want pretty-printing (`"{:#?}"`) of [`crate::diff::PublicItemsDiff`] to print
+/// each public item as `Display`, so implement `Debug` with `Display`.
+impl std::fmt::Debug for PublicItem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, f)
+    }
+}
+
+/// One of the basic uses cases is printing a sorted `Vec` of `PublicItem`s. So
+/// we implement `Display` for it.
+impl Display for PublicItem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", tokens_to_string(&self.tokens))
+    }
+}
+
+impl PartialOrd for PublicItem {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PublicItem {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.to_string().cmp(&other.to_string())
+    }
+}

--- a/public-api/src/render.rs
+++ b/public-api/src/render.rs
@@ -1319,7 +1319,7 @@ mod test {
 
         assert_eq!(actual, expected);
         assert_eq!(
-            crate::item_iterator::tokens_to_string(&actual),
+            crate::tokens::tokens_to_string(&actual),
             expected_string.to_string()
         );
     }

--- a/public-api/src/tokens.rs
+++ b/public-api/src/tokens.rs
@@ -1,6 +1,6 @@
 //! The module tp contain all token handling logic.
 #[cfg(doc)]
-use crate::item_iterator::PublicItem;
+use crate::public_item::PublicItem;
 
 /// A token in a rendered [`PublicItem`], used to apply syntax colouring in downstream applications.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -103,4 +103,8 @@ impl Token {
             Self::Whitespace => " ",
         }
     }
+}
+
+pub(crate) fn tokens_to_string(tokens: &[Token]) -> String {
+    tokens.iter().map(Token::text).collect()
 }


### PR DESCRIPTION
When working on improved support for rendering `impl`s, I found item_iterator.rs to be inconveniently big. So move `PublicItem` and friends out to a new `mod public_item`.