### PR TITLE
Rename `PublicItemsDiff` to `PublicApiDiff`

### DIFF
--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{anyhow, Context, Result};
 use arg_types::{Color, DenyMethod};
 use plain::Plain;
-use public_api::diff::PublicItemsDiff;
+use public_api::diff::PublicApiDiff;
 use public_api::{Options, PublicApi, PublicItem, MINIMUM_RUSTDOC_JSON_VERSION};
 
 use clap::Parser;
@@ -182,7 +182,7 @@ pub struct Args {
 struct PostProcessing {
     /// The `--deny` arg allows the user to disallow the occurrence of API
     /// changes. If this field is set, we are to check that the diff is allowed.
-    diff_to_check: Option<PublicItemsDiff>,
+    diff_to_check: Option<PublicApiDiff>,
 
     /// Doing a `--diff-git-checkouts` involves doing `git checkout`s.
     /// Afterwards, we want to restore the original branch the user was on, to
@@ -206,7 +206,7 @@ fn main_() -> Result<()> {
     post_processing.perform(&args)
 }
 
-fn check_diff(args: &Args, diff: &Option<PublicItemsDiff>) -> Result<()> {
+fn check_diff(args: &Args, diff: &Option<PublicApiDiff>) -> Result<()> {
     match (&args.deny, diff) {
         // We were requested to deny diffs, so make sure there is no diff
         (Some(deny), Some(diff)) => {
@@ -294,8 +294,8 @@ fn print_diff_between_two_rustdoc_json_files(
     })
 }
 
-fn print_diff(args: &Args, old: Vec<PublicItem>, new: Vec<PublicItem>) -> Result<PublicItemsDiff> {
-    let diff = PublicItemsDiff::between(old, new);
+fn print_diff(args: &Args, old: Vec<PublicItem>, new: Vec<PublicItem>) -> Result<PublicApiDiff> {
+    let diff = PublicApiDiff::between(old, new);
     Plain::print_diff(&mut stdout(), args, &diff)?;
 
     Ok(diff)

--- a/cargo-public-api/src/plain.rs
+++ b/cargo-public-api/src/plain.rs
@@ -1,7 +1,7 @@
 use std::io::{Result, Write};
 
 use nu_ansi_term::{AnsiString, AnsiStrings, Color, Style};
-use public_api::{diff::PublicItemsDiff, tokens::Token, PublicItem};
+use public_api::{diff::PublicApiDiff, tokens::Token, PublicItem};
 
 use crate::Args;
 
@@ -16,7 +16,7 @@ impl Plain {
         Ok(())
     }
 
-    pub fn print_diff(w: &mut dyn Write, args: &Args, diff: &PublicItemsDiff) -> Result<()> {
+    pub fn print_diff(w: &mut dyn Write, args: &Args, diff: &PublicApiDiff) -> Result<()> {
         let use_color = args.color.active();
 
         print_items_with_header(

--- a/cargo-public-api/tests/expected-output/public_api_list.txt
+++ b/cargo-public-api/tests/expected-output/public_api_list.txt
@@ -7,34 +7,34 @@ impl RefUnwindSafe for public_api::Options
 impl RefUnwindSafe for public_api::PublicApi
 impl RefUnwindSafe for public_api::PublicItem
 impl RefUnwindSafe for public_api::diff::ChangedPublicItem
-impl RefUnwindSafe for public_api::diff::PublicItemsDiff
+impl RefUnwindSafe for public_api::diff::PublicApiDiff
 impl RefUnwindSafe for public_api::tokens::Token
 impl Send for public_api::Error
 impl Send for public_api::Options
 impl Send for public_api::PublicApi
 impl Send for public_api::PublicItem
 impl Send for public_api::diff::ChangedPublicItem
-impl Send for public_api::diff::PublicItemsDiff
+impl Send for public_api::diff::PublicApiDiff
 impl Send for public_api::tokens::Token
 impl Sync for public_api::Error
 impl Sync for public_api::Options
 impl Sync for public_api::PublicApi
 impl Sync for public_api::PublicItem
 impl Sync for public_api::diff::ChangedPublicItem
-impl Sync for public_api::diff::PublicItemsDiff
+impl Sync for public_api::diff::PublicApiDiff
 impl Sync for public_api::tokens::Token
 impl Unpin for public_api::Error
 impl Unpin for public_api::Options
 impl Unpin for public_api::PublicApi
 impl Unpin for public_api::PublicItem
 impl Unpin for public_api::diff::ChangedPublicItem
-impl Unpin for public_api::diff::PublicItemsDiff
+impl Unpin for public_api::diff::PublicApiDiff
 impl Unpin for public_api::tokens::Token
 impl UnwindSafe for public_api::Options
 impl UnwindSafe for public_api::PublicApi
 impl UnwindSafe for public_api::PublicItem
 impl UnwindSafe for public_api::diff::ChangedPublicItem
-impl UnwindSafe for public_api::diff::PublicItemsDiff
+impl UnwindSafe for public_api::diff::PublicApiDiff
 impl UnwindSafe for public_api::tokens::Token
 pub const public_api::MINIMUM_RUSTDOC_JSON_VERSION: &'static str
 pub enum public_api::tokens::Token
@@ -74,11 +74,11 @@ pub fn public_api::diff::ChangedPublicItem::cmp(&self, other: &public_api::diff:
 pub fn public_api::diff::ChangedPublicItem::eq(&self, other: &public_api::diff::ChangedPublicItem) -> bool
 pub fn public_api::diff::ChangedPublicItem::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
 pub fn public_api::diff::ChangedPublicItem::partial_cmp(&self, other: &public_api::diff::ChangedPublicItem) -> $crate::option::Option<$crate::cmp::Ordering>
-pub fn public_api::diff::PublicItemsDiff::between(old_items: Vec<public_api::PublicItem>, new_items: Vec<public_api::PublicItem>) -> Self
-pub fn public_api::diff::PublicItemsDiff::clone(&self) -> public_api::diff::PublicItemsDiff
-pub fn public_api::diff::PublicItemsDiff::eq(&self, other: &public_api::diff::PublicItemsDiff) -> bool
-pub fn public_api::diff::PublicItemsDiff::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
-pub fn public_api::diff::PublicItemsDiff::is_empty(&self) -> bool
+pub fn public_api::diff::PublicApiDiff::between(old_items: Vec<public_api::PublicItem>, new_items: Vec<public_api::PublicItem>) -> Self
+pub fn public_api::diff::PublicApiDiff::clone(&self) -> public_api::diff::PublicApiDiff
+pub fn public_api::diff::PublicApiDiff::eq(&self, other: &public_api::diff::PublicApiDiff) -> bool
+pub fn public_api::diff::PublicApiDiff::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
+pub fn public_api::diff::PublicApiDiff::is_empty(&self) -> bool
 pub fn public_api::public_api_from_rustdoc_json_str(rustdoc_json_str: &str, options: public_api::Options) -> public_api::Result<public_api::PublicApi>
 pub fn public_api::tokens::Token::clone(&self) -> public_api::tokens::Token
 pub fn public_api::tokens::Token::cmp(&self, other: &public_api::tokens::Token) -> $crate::cmp::Ordering
@@ -97,10 +97,10 @@ pub struct field public_api::PublicApi::items: Vec<public_api::PublicItem>
 pub struct field public_api::PublicApi::missing_item_ids: Vec<String>
 pub struct field public_api::diff::ChangedPublicItem::new: public_api::PublicItem
 pub struct field public_api::diff::ChangedPublicItem::old: public_api::PublicItem
-pub struct field public_api::diff::PublicItemsDiff::added: Vec<public_api::PublicItem>
-pub struct field public_api::diff::PublicItemsDiff::changed: Vec<public_api::diff::ChangedPublicItem>
-pub struct field public_api::diff::PublicItemsDiff::removed: Vec<public_api::PublicItem>
+pub struct field public_api::diff::PublicApiDiff::added: Vec<public_api::PublicItem>
+pub struct field public_api::diff::PublicApiDiff::changed: Vec<public_api::diff::ChangedPublicItem>
+pub struct field public_api::diff::PublicApiDiff::removed: Vec<public_api::PublicItem>
 pub struct public_api::PublicItem
 pub struct public_api::diff::ChangedPublicItem
-pub struct public_api::diff::PublicItemsDiff
+pub struct public_api::diff::PublicApiDiff
 pub type public_api::Result<T> = std::result::Result<T, public_api::Error>

--- a/public-api/examples/diff_public_api.rs
+++ b/public-api/examples/diff_public_api.rs
@@ -1,6 +1,6 @@
 use std::{error::Error, fs::read_to_string};
 
-use public_api::{diff::PublicItemsDiff, Options, PublicApi};
+use public_api::{diff::PublicApiDiff, Options, PublicApi};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let options = Options::default();
@@ -17,7 +17,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .build()?;
     let new = PublicApi::from_rustdoc_json_str(&read_to_string(new_json)?, options)?;
 
-    let diff = PublicItemsDiff::between(old.items, new.items);
+    let diff = PublicApiDiff::between(old.items, new.items);
     println!("{:#?}", diff);
 
     Ok(())

--- a/public-api/public-api.txt
+++ b/public-api/public-api.txt
@@ -7,34 +7,34 @@ impl RefUnwindSafe for public_api::Options
 impl RefUnwindSafe for public_api::PublicApi
 impl RefUnwindSafe for public_api::PublicItem
 impl RefUnwindSafe for public_api::diff::ChangedPublicItem
-impl RefUnwindSafe for public_api::diff::PublicItemsDiff
+impl RefUnwindSafe for public_api::diff::PublicApiDiff
 impl RefUnwindSafe for public_api::tokens::Token
 impl Send for public_api::Error
 impl Send for public_api::Options
 impl Send for public_api::PublicApi
 impl Send for public_api::PublicItem
 impl Send for public_api::diff::ChangedPublicItem
-impl Send for public_api::diff::PublicItemsDiff
+impl Send for public_api::diff::PublicApiDiff
 impl Send for public_api::tokens::Token
 impl Sync for public_api::Error
 impl Sync for public_api::Options
 impl Sync for public_api::PublicApi
 impl Sync for public_api::PublicItem
 impl Sync for public_api::diff::ChangedPublicItem
-impl Sync for public_api::diff::PublicItemsDiff
+impl Sync for public_api::diff::PublicApiDiff
 impl Sync for public_api::tokens::Token
 impl Unpin for public_api::Error
 impl Unpin for public_api::Options
 impl Unpin for public_api::PublicApi
 impl Unpin for public_api::PublicItem
 impl Unpin for public_api::diff::ChangedPublicItem
-impl Unpin for public_api::diff::PublicItemsDiff
+impl Unpin for public_api::diff::PublicApiDiff
 impl Unpin for public_api::tokens::Token
 impl UnwindSafe for public_api::Options
 impl UnwindSafe for public_api::PublicApi
 impl UnwindSafe for public_api::PublicItem
 impl UnwindSafe for public_api::diff::ChangedPublicItem
-impl UnwindSafe for public_api::diff::PublicItemsDiff
+impl UnwindSafe for public_api::diff::PublicApiDiff
 impl UnwindSafe for public_api::tokens::Token
 pub const public_api::MINIMUM_RUSTDOC_JSON_VERSION: &'static str
 pub enum public_api::tokens::Token
@@ -74,11 +74,11 @@ pub fn public_api::diff::ChangedPublicItem::cmp(&self, other: &public_api::diff:
 pub fn public_api::diff::ChangedPublicItem::eq(&self, other: &public_api::diff::ChangedPublicItem) -> bool
 pub fn public_api::diff::ChangedPublicItem::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
 pub fn public_api::diff::ChangedPublicItem::partial_cmp(&self, other: &public_api::diff::ChangedPublicItem) -> $crate::option::Option<$crate::cmp::Ordering>
-pub fn public_api::diff::PublicItemsDiff::between(old_items: Vec<public_api::PublicItem>, new_items: Vec<public_api::PublicItem>) -> Self
-pub fn public_api::diff::PublicItemsDiff::clone(&self) -> public_api::diff::PublicItemsDiff
-pub fn public_api::diff::PublicItemsDiff::eq(&self, other: &public_api::diff::PublicItemsDiff) -> bool
-pub fn public_api::diff::PublicItemsDiff::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
-pub fn public_api::diff::PublicItemsDiff::is_empty(&self) -> bool
+pub fn public_api::diff::PublicApiDiff::between(old_items: Vec<public_api::PublicItem>, new_items: Vec<public_api::PublicItem>) -> Self
+pub fn public_api::diff::PublicApiDiff::clone(&self) -> public_api::diff::PublicApiDiff
+pub fn public_api::diff::PublicApiDiff::eq(&self, other: &public_api::diff::PublicApiDiff) -> bool
+pub fn public_api::diff::PublicApiDiff::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
+pub fn public_api::diff::PublicApiDiff::is_empty(&self) -> bool
 pub fn public_api::public_api_from_rustdoc_json_str(rustdoc_json_str: &str, options: public_api::Options) -> public_api::Result<public_api::PublicApi>
 pub fn public_api::tokens::Token::clone(&self) -> public_api::tokens::Token
 pub fn public_api::tokens::Token::cmp(&self, other: &public_api::tokens::Token) -> $crate::cmp::Ordering
@@ -97,10 +97,10 @@ pub struct field public_api::PublicApi::items: Vec<public_api::PublicItem>
 pub struct field public_api::PublicApi::missing_item_ids: Vec<String>
 pub struct field public_api::diff::ChangedPublicItem::new: public_api::PublicItem
 pub struct field public_api::diff::ChangedPublicItem::old: public_api::PublicItem
-pub struct field public_api::diff::PublicItemsDiff::added: Vec<public_api::PublicItem>
-pub struct field public_api::diff::PublicItemsDiff::changed: Vec<public_api::diff::ChangedPublicItem>
-pub struct field public_api::diff::PublicItemsDiff::removed: Vec<public_api::PublicItem>
+pub struct field public_api::diff::PublicApiDiff::added: Vec<public_api::PublicItem>
+pub struct field public_api::diff::PublicApiDiff::changed: Vec<public_api::diff::ChangedPublicItem>
+pub struct field public_api::diff::PublicApiDiff::removed: Vec<public_api::PublicItem>
 pub struct public_api::PublicItem
 pub struct public_api::diff::ChangedPublicItem
-pub struct public_api::diff::PublicItemsDiff
+pub struct public_api::diff::PublicApiDiff
 pub type public_api::Result<T> = std::result::Result<T, public_api::Error>

--- a/public-api/src/diff.rs
+++ b/public-api/src/diff.rs
@@ -27,7 +27,7 @@ pub struct ChangedPublicItem {
 /// ```
 #[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct PublicItemsDiff {
+pub struct PublicApiDiff {
     /// Items that have been removed from the public API. A MAJOR change, in
     /// semver terminology. Sorted.
     pub removed: Vec<PublicItem>,
@@ -43,7 +43,7 @@ pub struct PublicItemsDiff {
     pub added: Vec<PublicItem>,
 }
 
-impl PublicItemsDiff {
+impl PublicApiDiff {
     /// Allows you to diff the public API between two arbitrary versions of a
     /// library, e.g. different releases. The input parameters `old` and `new`
     /// is the output of two different invocations of
@@ -138,8 +138,8 @@ mod tests {
         let old = vec![item_with_path("foo")];
         let new = vec![];
 
-        let actual = PublicItemsDiff::between(old, new);
-        let expected = PublicItemsDiff {
+        let actual = PublicApiDiff::between(old, new);
+        let expected = PublicApiDiff {
             removed: vec![item_with_path("foo")],
             changed: vec![],
             added: vec![],
@@ -153,8 +153,8 @@ mod tests {
         let old = vec![];
         let new = vec![item_with_path("foo")];
 
-        let actual = PublicItemsDiff::between(old, new);
-        let expected = PublicItemsDiff {
+        let actual = PublicApiDiff::between(old, new);
+        let expected = PublicApiDiff {
             removed: vec![],
             changed: vec![],
             added: vec![item_with_path("foo")],
@@ -172,8 +172,8 @@ mod tests {
             item_with_path("3"),
         ];
 
-        let actual = PublicItemsDiff::between(old, new);
-        let expected = PublicItemsDiff {
+        let actual = PublicApiDiff::between(old, new);
+        let expected = PublicApiDiff {
             removed: vec![],
             changed: vec![],
             added: vec![item_with_path("2")],
@@ -191,8 +191,8 @@ mod tests {
         ];
         let new = vec![item_with_path("1"), item_with_path("3")];
 
-        let actual = PublicItemsDiff::between(old, new);
-        let expected = PublicItemsDiff {
+        let actual = PublicApiDiff::between(old, new);
+        let expected = PublicApiDiff {
             removed: vec![item_with_path("2")],
             changed: vec![],
             added: vec![],
@@ -223,8 +223,8 @@ mod tests {
             fn_with_param_type(&["a", "b"], "i64"),
         ];
 
-        let actual = PublicItemsDiff::between(old, new);
-        let expected = PublicItemsDiff {
+        let actual = PublicApiDiff::between(old, new);
+        let expected = PublicApiDiff {
             removed: vec![
                 item_with_path("2"),
                 item_with_path("3"),
@@ -264,12 +264,12 @@ mod tests {
             fn_with_param_type(&["a", "b"], "i32"),
             fn_with_param_type(&["a", "b"], "i64"),
         ];
-        let expected = PublicItemsDiff {
+        let expected = PublicApiDiff {
             removed: vec![],
             changed: vec![],
             added: vec![fn_with_param_type(&["a", "b"], "u8")],
         };
-        let actual = PublicItemsDiff::between(old, new);
+        let actual = PublicApiDiff::between(old, new);
         assert_eq!(actual, expected);
         assert!(!actual.is_empty());
     }
@@ -279,8 +279,8 @@ mod tests {
         let old = vec![item_with_path("foo")];
         let new = vec![item_with_path("foo")];
 
-        let actual = PublicItemsDiff::between(old, new);
-        let expected = PublicItemsDiff {
+        let actual = PublicApiDiff::between(old, new);
+        let expected = PublicApiDiff {
             removed: vec![],
             changed: vec![],
             added: vec![],

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -81,7 +81,7 @@ pub struct Options {
     pub with_blanket_implementations: bool,
 
     /// If `true`, items will be sorted before being returned. If you will pass
-    /// on the return value to [`diff::PublicItemsDiff::between`], it is
+    /// on the return value to [`diff::PublicApiDiff::between`], it is
     /// currently unnecessary to sort first, because the sorting will be
     /// performed/ensured inside of that function.
     ///

--- a/public-api/src/main.rs
+++ b/public-api/src/main.rs
@@ -7,7 +7,7 @@
 use std::io::{stdout, ErrorKind, Write};
 use std::path::{Path, PathBuf};
 
-use public_api::diff::PublicItemsDiff;
+use public_api::diff::PublicApiDiff;
 use public_api::{Options, PublicApi, MINIMUM_RUSTDOC_JSON_VERSION};
 
 #[derive(thiserror::Error, Debug)]
@@ -71,14 +71,14 @@ fn print_public_api_diff(old: &Path, new: &Path, options: Options) -> Result<()>
     let new_json = std::fs::read_to_string(new)?;
     let new = PublicApi::from_rustdoc_json_str(&new_json, options)?;
 
-    let diff = PublicItemsDiff::between(old.items, new.items);
+    let diff = PublicApiDiff::between(old.items, new.items);
     print_diff_with_headers(&diff, &mut stdout(), "Removed:", "Changed:", "Added:")?;
 
     Ok(())
 }
 
 fn print_diff_with_headers(
-    diff: &PublicItemsDiff,
+    diff: &PublicApiDiff,
     w: &mut impl std::io::Write,
     header_removed: &str,
     header_changed: &str,

--- a/public-api/src/public_item.rs
+++ b/public-api/src/public_item.rs
@@ -46,7 +46,7 @@ impl PublicItem {
     }
 }
 
-/// We want pretty-printing (`"{:#?}"`) of [`crate::diff::PublicItemsDiff`] to print
+/// We want pretty-printing (`"{:#?}"`) of [`crate::diff::PublicApiDiff`] to print
 /// each public item as `Display`, so implement `Debug` with `Display`.
 impl std::fmt::Debug for PublicItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/public-api/tests/expected-output/diff_with_added_items.txt
+++ b/public-api/tests/expected-output/diff_with_added_items.txt
@@ -1,4 +1,4 @@
-PublicItemsDiff {
+PublicApiDiff {
     removed: [],
     changed: [
         ChangedPublicItem {

--- a/public-api/tests/expected-output/diff_with_removed_items.txt
+++ b/public-api/tests/expected-output/diff_with_removed_items.txt
@@ -1,4 +1,4 @@
-PublicItemsDiff {
+PublicApiDiff {
     removed: [
         impl RefUnwindSafe for example_api::StructV2,
         impl Send for example_api::StructV2,

--- a/public-api/tests/expected-output/no_diff.txt
+++ b/public-api/tests/expected-output/no_diff.txt
@@ -1,4 +1,4 @@
-PublicItemsDiff {
+PublicApiDiff {
     removed: [],
     changed: [],
     added: [],

--- a/public-api/tests/public-api-lib-tests.rs
+++ b/public-api/tests/public-api-lib-tests.rs
@@ -114,7 +114,7 @@ fn assert_public_api_diff(old_json: &str, new_json: &str, expected: impl AsRef<P
     let old = PublicApi::from_rustdoc_json_str(old_json, Options::default()).unwrap();
     let new = PublicApi::from_rustdoc_json_str(new_json, Options::default()).unwrap();
 
-    let diff = public_api::diff::PublicItemsDiff::between(old.items, new.items);
+    let diff = public_api::diff::PublicApiDiff::between(old.items, new.items);
     let pretty_printed = format!("{:#?}", diff);
     assert_eq_or_bless(&pretty_printed, expected);
 }


### PR DESCRIPTION
For two reasons:

* The associated function `between()` will be changed in a follow-up commit to take two `PublicApi`s instead of two `Vec<PublicItem>`, to make the API more abstract and less dependent on exactly how a public API is represented.

* Ever since I renamed the project from `public_items` to `public-api` have I been annoyed with that I forgot to rename this particular struct.