### PR TITLE
Make `PublicApiDiff::between(...)` take `PublicApi`s instead of `Vec<PublicItem>`s

### DIFF
--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, Context, Result};
 use arg_types::{Color, DenyMethod};
 use plain::Plain;
 use public_api::diff::PublicApiDiff;
-use public_api::{Options, PublicApi, PublicItem, MINIMUM_RUSTDOC_JSON_VERSION};
+use public_api::{Options, PublicApi, MINIMUM_RUSTDOC_JSON_VERSION};
 
 use clap::Parser;
 use rustdoc_json::BuildError;
@@ -268,7 +268,7 @@ fn print_diff_between_two_commits(args: &Args, commits: &[String]) -> Result<Pos
     let new_commit = commits.get(1).expect("clap makes sure second commit exist");
     let (new, _) = collect_public_api_from_commit(args, Some(new_commit))?;
 
-    let diff_to_check = Some(print_diff(args, old.items, new.items)?);
+    let diff_to_check = Some(print_diff(args, old, new)?);
 
     Ok(PostProcessing {
         diff_to_check,
@@ -286,7 +286,7 @@ fn print_diff_between_two_rustdoc_json_files(
     let new_file = files.get(1).expect("clap makes sure second file exists");
     let new = public_api_from_rustdoc_json_path(new_file, args)?;
 
-    let diff_to_check = Some(print_diff(args, old.items, new.items)?);
+    let diff_to_check = Some(print_diff(args, old, new)?);
 
     Ok(PostProcessing {
         diff_to_check,
@@ -294,7 +294,7 @@ fn print_diff_between_two_rustdoc_json_files(
     })
 }
 
-fn print_diff(args: &Args, old: Vec<PublicItem>, new: Vec<PublicItem>) -> Result<PublicApiDiff> {
+fn print_diff(args: &Args, old: PublicApi, new: PublicApi) -> Result<PublicApiDiff> {
     let diff = PublicApiDiff::between(old, new);
     Plain::print_diff(&mut stdout(), args, &diff)?;
 

--- a/cargo-public-api/tests/expected-output/public_api_list.txt
+++ b/cargo-public-api/tests/expected-output/public_api_list.txt
@@ -74,7 +74,7 @@ pub fn public_api::diff::ChangedPublicItem::cmp(&self, other: &public_api::diff:
 pub fn public_api::diff::ChangedPublicItem::eq(&self, other: &public_api::diff::ChangedPublicItem) -> bool
 pub fn public_api::diff::ChangedPublicItem::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
 pub fn public_api::diff::ChangedPublicItem::partial_cmp(&self, other: &public_api::diff::ChangedPublicItem) -> $crate::option::Option<$crate::cmp::Ordering>
-pub fn public_api::diff::PublicApiDiff::between(old_items: Vec<public_api::PublicItem>, new_items: Vec<public_api::PublicItem>) -> Self
+pub fn public_api::diff::PublicApiDiff::between(old: public_api::PublicApi, new: public_api::PublicApi) -> Self
 pub fn public_api::diff::PublicApiDiff::clone(&self) -> public_api::diff::PublicApiDiff
 pub fn public_api::diff::PublicApiDiff::eq(&self, other: &public_api::diff::PublicApiDiff) -> bool
 pub fn public_api::diff::PublicApiDiff::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result

--- a/public-api/examples/diff_public_api.rs
+++ b/public-api/examples/diff_public_api.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .build()?;
     let new = PublicApi::from_rustdoc_json_str(&read_to_string(new_json)?, options)?;
 
-    let diff = PublicApiDiff::between(old.items, new.items);
+    let diff = PublicApiDiff::between(old, new);
     println!("{:#?}", diff);
 
     Ok(())

--- a/public-api/public-api.txt
+++ b/public-api/public-api.txt
@@ -74,7 +74,7 @@ pub fn public_api::diff::ChangedPublicItem::cmp(&self, other: &public_api::diff:
 pub fn public_api::diff::ChangedPublicItem::eq(&self, other: &public_api::diff::ChangedPublicItem) -> bool
 pub fn public_api::diff::ChangedPublicItem::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
 pub fn public_api::diff::ChangedPublicItem::partial_cmp(&self, other: &public_api::diff::ChangedPublicItem) -> $crate::option::Option<$crate::cmp::Ordering>
-pub fn public_api::diff::PublicApiDiff::between(old_items: Vec<public_api::PublicItem>, new_items: Vec<public_api::PublicItem>) -> Self
+pub fn public_api::diff::PublicApiDiff::between(old: public_api::PublicApi, new: public_api::PublicApi) -> Self
 pub fn public_api::diff::PublicApiDiff::clone(&self) -> public_api::diff::PublicApiDiff
 pub fn public_api::diff::PublicApiDiff::eq(&self, other: &public_api::diff::PublicApiDiff) -> bool
 pub fn public_api::diff::PublicApiDiff::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result

--- a/public-api/src/main.rs
+++ b/public-api/src/main.rs
@@ -71,7 +71,7 @@ fn print_public_api_diff(old: &Path, new: &Path, options: Options) -> Result<()>
     let new_json = std::fs::read_to_string(new)?;
     let new = PublicApi::from_rustdoc_json_str(&new_json, options)?;
 
-    let diff = PublicApiDiff::between(old.items, new.items);
+    let diff = PublicApiDiff::between(old, new);
     print_diff_with_headers(&diff, &mut stdout(), "Removed:", "Changed:", "Added:")?;
 
     Ok(())

--- a/public-api/tests/public-api-lib-tests.rs
+++ b/public-api/tests/public-api-lib-tests.rs
@@ -114,7 +114,7 @@ fn assert_public_api_diff(old_json: &str, new_json: &str, expected: impl AsRef<P
     let old = PublicApi::from_rustdoc_json_str(old_json, Options::default()).unwrap();
     let new = PublicApi::from_rustdoc_json_str(new_json, Options::default()).unwrap();
 
-    let diff = public_api::diff::PublicApiDiff::between(old.items, new.items);
+    let diff = public_api::diff::PublicApiDiff::between(old, new);
     let pretty_printed = format!("{:#?}", diff);
     assert_eq_or_bless(&pretty_printed, expected);
 }


### PR DESCRIPTION
To make the API more abstract and less dependent on exactly how a public API is represented.

This will become useful as we add support for rendering `impl`s in-band, for example, which will require a different way to iterate over all `PublicItem`s in a `PublicApi`.

NOTE: target branch is not `main` yet!