### PR TITLE
Hide `PublicApi::items` behind `PublicApi::items()` iterator

### DIFF
--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -253,7 +253,7 @@ fn print_public_items(
     public_api: &PublicApi,
     branch_to_restore: Option<String>,
 ) -> Result<PostProcessing> {
-    Plain::print_items(&mut stdout(), args, &public_api.items)?;
+    Plain::print_items(&mut stdout(), args, public_api.items())?;
 
     Ok(PostProcessing {
         diff_to_check: None,
@@ -444,7 +444,7 @@ fn public_api_from_rustdoc_json_path<T: AsRef<Path>>(
     })?;
 
     if args.verbose {
-        public_api.missing_item_ids.iter().for_each(|i| {
+        public_api.missing_item_ids().for_each(|i| {
             println!("NOTE: rustdoc JSON missing referenced item with ID \"{i}\"");
         });
     }

--- a/cargo-public-api/src/plain.rs
+++ b/cargo-public-api/src/plain.rs
@@ -8,7 +8,11 @@ use crate::Args;
 pub struct Plain;
 
 impl Plain {
-    pub fn print_items(w: &mut dyn Write, args: &Args, items: &[PublicItem]) -> Result<()> {
+    pub fn print_items<'a>(
+        w: &mut dyn Write,
+        args: &Args,
+        items: impl Iterator<Item = &'a PublicItem>,
+    ) -> Result<()> {
         for item in items {
             print_item(args, w, item)?;
         }

--- a/cargo-public-api/tests/expected-output/public_api_list.txt
+++ b/cargo-public-api/tests/expected-output/public_api_list.txt
@@ -61,6 +61,9 @@ pub fn public_api::Options::default() -> Self
 pub fn public_api::Options::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
 pub fn public_api::PublicApi::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
 pub fn public_api::PublicApi::from_rustdoc_json_str(rustdoc_json_str: &str, options: public_api::Options) -> public_api::Result<public_api::PublicApi>
+pub fn public_api::PublicApi::into_items(self) -> impl Iterator<Item = public_api::PublicItem>
+pub fn public_api::PublicApi::items(&self) -> impl Iterator<Item = &public_api::PublicItem>
+pub fn public_api::PublicApi::missing_item_ids(&self) -> impl Iterator<Item = &String>
 pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
 pub fn public_api::PublicItem::cmp(&self, other: &Self) -> std::cmp::Ordering
 pub fn public_api::PublicItem::eq(&self, other: &public_api::PublicItem) -> bool
@@ -93,8 +96,6 @@ pub mod public_api::diff
 pub mod public_api::tokens
 pub struct field public_api::Options::sorted: bool
 pub struct field public_api::Options::with_blanket_implementations: bool
-pub struct field public_api::PublicApi::items: Vec<public_api::PublicItem>
-pub struct field public_api::PublicApi::missing_item_ids: Vec<String>
 pub struct field public_api::diff::ChangedPublicItem::new: public_api::PublicItem
 pub struct field public_api::diff::ChangedPublicItem::old: public_api::PublicItem
 pub struct field public_api::diff::PublicApiDiff::added: Vec<public_api::PublicItem>

--- a/public-api/examples/list_public_api.rs
+++ b/public-api/examples/list_public_api.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let public_api =
         PublicApi::from_rustdoc_json_str(&read_to_string(&json_path)?, Options::default())?;
 
-    for public_item in public_api.items {
+    for public_item in public_api.items() {
         println!("{}", public_item);
     }
 

--- a/public-api/public-api.txt
+++ b/public-api/public-api.txt
@@ -61,6 +61,9 @@ pub fn public_api::Options::default() -> Self
 pub fn public_api::Options::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
 pub fn public_api::PublicApi::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
 pub fn public_api::PublicApi::from_rustdoc_json_str(rustdoc_json_str: &str, options: public_api::Options) -> public_api::Result<public_api::PublicApi>
+pub fn public_api::PublicApi::into_items(self) -> impl Iterator<Item = public_api::PublicItem>
+pub fn public_api::PublicApi::items(&self) -> impl Iterator<Item = &public_api::PublicItem>
+pub fn public_api::PublicApi::missing_item_ids(&self) -> impl Iterator<Item = &String>
 pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
 pub fn public_api::PublicItem::cmp(&self, other: &Self) -> std::cmp::Ordering
 pub fn public_api::PublicItem::eq(&self, other: &public_api::PublicItem) -> bool
@@ -93,8 +96,6 @@ pub mod public_api::diff
 pub mod public_api::tokens
 pub struct field public_api::Options::sorted: bool
 pub struct field public_api::Options::with_blanket_implementations: bool
-pub struct field public_api::PublicApi::items: Vec<public_api::PublicItem>
-pub struct field public_api::PublicApi::missing_item_ids: Vec<String>
 pub struct field public_api::diff::ChangedPublicItem::new: public_api::PublicItem
 pub struct field public_api::diff::ChangedPublicItem::old: public_api::PublicItem
 pub struct field public_api::diff::PublicApiDiff::added: Vec<public_api::PublicItem>

--- a/public-api/src/diff.rs
+++ b/public-api/src/diff.rs
@@ -56,8 +56,8 @@ impl PublicApiDiff {
         // We must use a HashBag, because with a HashSet we would lose public
         // items that happen to have the same representation due to limitations
         // or bugs
-        let old = old.items.into_iter().collect::<HashBag<_>>();
-        let new = new.items.into_iter().collect::<HashBag<_>>();
+        let old = old.into_items().collect::<HashBag<_>>();
+        let new = new.into_items().collect::<HashBag<_>>();
 
         // First figure out what items have been removed and what have been
         // added. Later we will match added and removed items with the same path

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -127,7 +127,7 @@ impl Default for Options {
 /// // Gather the rustdoc content as described in this crates top-level documentation.
 /// let public_api = PublicApi::from_rustdoc_json_str(&rustdoc_json_str, options)?;
 ///
-/// for public_item in public_api.items {
+/// for public_item in public_api.items() {
 ///     // here we print the items to stdout, we could also write to a string or a file.
 ///     println!("{}", public_item);
 /// }
@@ -139,20 +139,10 @@ pub struct PublicApi {
     /// The items that constitutes the public API. An "item" is for example a
     /// function, a struct, a struct field, an enum, an enum variant, a module,
     /// etc...
-    pub items: Vec<PublicItem>,
+    pub(crate) items: Vec<PublicItem>,
 
-    /// The rustdoc JSON IDs of missing but referenced items. Intended for use
-    /// with `--verbose` flags or similar.
-    ///
-    /// In some cases, a public item might be referenced from another public
-    /// item (e.g. a `mod`), but is missing from the rustdoc JSON file. This
-    /// occurs for example in the case of re-exports of external modules (see
-    /// <https://github.com/Enselic/cargo-public-api/issues/103>). The entries
-    /// in this Vec are what IDs that could not be found.
-    ///
-    /// The exact format of IDs are to be considered an implementation detail
-    /// and must not be be relied on.
-    pub missing_item_ids: Vec<String>,
+    /// See [`Self::missing_item_ids()`]
+    pub(crate) missing_item_ids: Vec<String>,
 }
 
 impl PublicApi {
@@ -190,6 +180,32 @@ impl PublicApi {
         }
 
         Ok(public_api)
+    }
+
+    /// Returns an iterator over all public items in the public API
+    pub fn items(&self) -> impl Iterator<Item = &'_ PublicItem> {
+        self.items.iter()
+    }
+
+    /// Like [`Self::items()`], but ownership of all `PublicItem`s are
+    /// transferred to the caller.
+    pub fn into_items(self) -> impl Iterator<Item = PublicItem> {
+        self.items.into_iter()
+    }
+
+    /// The rustdoc JSON IDs of missing but referenced items. Intended for use
+    /// with `--verbose` flags or similar.
+    ///
+    /// In some cases, a public item might be referenced from another public
+    /// item (e.g. a `mod`), but is missing from the rustdoc JSON file. This
+    /// occurs for example in the case of re-exports of external modules (see
+    /// <https://github.com/Enselic/cargo-public-api/issues/103>). The entries
+    /// in this Vec are what IDs that could not be found.
+    ///
+    /// The exact format of IDs are to be considered an implementation detail
+    /// and must not be be relied on.
+    pub fn missing_item_ids(&self) -> impl Iterator<Item = &String> {
+        self.missing_item_ids.iter()
     }
 }
 

--- a/public-api/src/main.rs
+++ b/public-api/src/main.rs
@@ -57,7 +57,7 @@ fn main_() -> Result<()> {
 fn print_public_api(path: &Path, options: Options) -> Result<()> {
     let json = &std::fs::read_to_string(path)?;
 
-    for public_item in PublicApi::from_rustdoc_json_str(json, options)?.items {
+    for public_item in PublicApi::from_rustdoc_json_str(json, options)?.items() {
         writeln!(std::io::stdout(), "{}", public_item)?;
     }
 

--- a/public-api/tests/public-api-lib-tests.rs
+++ b/public-api/tests/public-api-lib-tests.rs
@@ -77,14 +77,14 @@ fn public_item_ord() {
     .unwrap();
 
     let generic_arg = public_api
-        .items
-        .clone()
+        .items()
+        .cloned()
         .into_iter()
         .find(|x| format!("{}", x).contains("generic_arg"))
         .unwrap();
 
     let generic_bound = public_api
-        .items
+        .into_items()
         .into_iter()
         .find(|x| format!("{}", x).contains("generic_bound"))
         .unwrap();
@@ -139,7 +139,7 @@ fn assert_public_api_impl(
     let api = PublicApi::from_rustdoc_json_str(rustdoc_json_str, options).unwrap();
 
     let mut actual = String::new();
-    for item in api.items {
+    for item in api.items() {
         writeln!(&mut actual, "{}", item).unwrap();
     }
 


### PR DESCRIPTION
So that we later can iterate over all items in a `PublicApi`, even if not all items are top-level items. The plan is to make `impl`s and long term also stuff like struct fields some kind of children to top-level `PublicItem`s. This prepares the API for that.

NOTE: Target branch is not `main` yet