### PR TITLE
List `impl`s directly after corresponding items

### DIFF
--- a/cargo-public-api/tests/expected-output/example_api-v0.3.0.txt
+++ b/cargo-public-api/tests/expected-output/example_api-v0.3.0.txt
@@ -1,17 +1,17 @@
 #[non_exhaustive] pub struct example_api::Struct
 impl RefUnwindSafe for example_api::Struct
-impl RefUnwindSafe for example_api::StructV2
 impl Send for example_api::Struct
-impl Send for example_api::StructV2
 impl Sync for example_api::Struct
-impl Sync for example_api::StructV2
 impl Unpin for example_api::Struct
-impl Unpin for example_api::StructV2
 impl UnwindSafe for example_api::Struct
-impl UnwindSafe for example_api::StructV2
 pub fn example_api::Struct::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
 pub mod example_api
 pub struct example_api::StructV2
+impl RefUnwindSafe for example_api::StructV2
+impl Send for example_api::StructV2
+impl Sync for example_api::StructV2
+impl Unpin for example_api::StructV2
+impl UnwindSafe for example_api::StructV2
 pub struct field example_api::Struct::v1_field: usize
 pub struct field example_api::Struct::v2_field: usize
 pub struct field example_api::StructV2::field: usize

--- a/cargo-public-api/tests/expected-output/example_api_v0.3.0_colored.txt
+++ b/cargo-public-api/tests/expected-output/example_api_v0.3.0_colored.txt
@@ -1,17 +1,17 @@
 #[non_exhaustive] [34mpub[0m [34mstruct[0m [36mexample_api[0m::[32mStruct[0m
 [34mimpl[0m [36mRefUnwindSafe[0m [34mfor[0m [36mexample_api[0m::[32mStruct[0m
-[34mimpl[0m [36mRefUnwindSafe[0m [34mfor[0m [36mexample_api[0m::[32mStructV2[0m
 [34mimpl[0m [36mSend[0m [34mfor[0m [36mexample_api[0m::[32mStruct[0m
-[34mimpl[0m [36mSend[0m [34mfor[0m [36mexample_api[0m::[32mStructV2[0m
 [34mimpl[0m [36mSync[0m [34mfor[0m [36mexample_api[0m::[32mStruct[0m
-[34mimpl[0m [36mSync[0m [34mfor[0m [36mexample_api[0m::[32mStructV2[0m
 [34mimpl[0m [36mUnpin[0m [34mfor[0m [36mexample_api[0m::[32mStruct[0m
-[34mimpl[0m [36mUnpin[0m [34mfor[0m [36mexample_api[0m::[32mStructV2[0m
 [34mimpl[0m [36mUnwindSafe[0m [34mfor[0m [36mexample_api[0m::[32mStruct[0m
-[34mimpl[0m [36mUnwindSafe[0m [34mfor[0m [36mexample_api[0m::[32mStructV2[0m
 [34mpub[0m [34mfn[0m [36mexample_api[0m::[32mStruct[0m::[33mfmt[0m(&[34mself[0m, [36mf[0m: &[34mmut[0m [36m$crate[0m::[36mfmt[0m::[32mFormatter[0m<[34m'_[0m>) -> [36m$crate[0m::[36mfmt[0m::[32mResult[0m
 [34mpub[0m [34mmod[0m [36mexample_api[0m
 [34mpub[0m [34mstruct[0m [36mexample_api[0m::[32mStructV2[0m
+[34mimpl[0m [36mRefUnwindSafe[0m [34mfor[0m [36mexample_api[0m::[32mStructV2[0m
+[34mimpl[0m [36mSend[0m [34mfor[0m [36mexample_api[0m::[32mStructV2[0m
+[34mimpl[0m [36mSync[0m [34mfor[0m [36mexample_api[0m::[32mStructV2[0m
+[34mimpl[0m [36mUnpin[0m [34mfor[0m [36mexample_api[0m::[32mStructV2[0m
+[34mimpl[0m [36mUnwindSafe[0m [34mfor[0m [36mexample_api[0m::[32mStructV2[0m
 [34mpub[0m [34mstruct[0m [34mfield[0m [36mexample_api[0m::[32mStruct[0m::[36mv1_field[0m: [32musize[0m
 [34mpub[0m [34mstruct[0m [34mfield[0m [36mexample_api[0m::[32mStruct[0m::[36mv2_field[0m: [32musize[0m
 [34mpub[0m [34mstruct[0m [34mfield[0m [36mexample_api[0m::[32mStructV2[0m::[36mfield[0m: [32musize[0m

--- a/cargo-public-api/tests/expected-output/lint_error_list.txt
+++ b/cargo-public-api/tests/expected-output/lint_error_list.txt
@@ -1,8 +1,8 @@
+pub mod lint_error
+pub struct lint_error::MissingDocs
 impl RefUnwindSafe for lint_error::MissingDocs
 impl Send for lint_error::MissingDocs
 impl Sync for lint_error::MissingDocs
 impl Unpin for lint_error::MissingDocs
 impl UnwindSafe for lint_error::MissingDocs
-pub mod lint_error
-pub struct lint_error::MissingDocs
 pub use lint_error::example_api

--- a/cargo-public-api/tests/expected-output/public_api_list.txt
+++ b/cargo-public-api/tests/expected-output/public_api_list.txt
@@ -1,43 +1,28 @@
 #[non_exhaustive] pub enum public_api::Error
-#[non_exhaustive] pub struct public_api::Options
-#[non_exhaustive] pub struct public_api::PublicApi
 impl !RefUnwindSafe for public_api::Error
 impl !UnwindSafe for public_api::Error
-impl RefUnwindSafe for public_api::Options
-impl RefUnwindSafe for public_api::PublicApi
-impl RefUnwindSafe for public_api::PublicItem
-impl RefUnwindSafe for public_api::diff::ChangedPublicItem
-impl RefUnwindSafe for public_api::diff::PublicApiDiff
-impl RefUnwindSafe for public_api::tokens::Token
 impl Send for public_api::Error
-impl Send for public_api::Options
-impl Send for public_api::PublicApi
-impl Send for public_api::PublicItem
-impl Send for public_api::diff::ChangedPublicItem
-impl Send for public_api::diff::PublicApiDiff
-impl Send for public_api::tokens::Token
 impl Sync for public_api::Error
-impl Sync for public_api::Options
-impl Sync for public_api::PublicApi
-impl Sync for public_api::PublicItem
-impl Sync for public_api::diff::ChangedPublicItem
-impl Sync for public_api::diff::PublicApiDiff
-impl Sync for public_api::tokens::Token
 impl Unpin for public_api::Error
+#[non_exhaustive] pub struct public_api::Options
+impl RefUnwindSafe for public_api::Options
+impl Send for public_api::Options
+impl Sync for public_api::Options
 impl Unpin for public_api::Options
-impl Unpin for public_api::PublicApi
-impl Unpin for public_api::PublicItem
-impl Unpin for public_api::diff::ChangedPublicItem
-impl Unpin for public_api::diff::PublicApiDiff
-impl Unpin for public_api::tokens::Token
 impl UnwindSafe for public_api::Options
+#[non_exhaustive] pub struct public_api::PublicApi
+impl RefUnwindSafe for public_api::PublicApi
+impl Send for public_api::PublicApi
+impl Sync for public_api::PublicApi
+impl Unpin for public_api::PublicApi
 impl UnwindSafe for public_api::PublicApi
-impl UnwindSafe for public_api::PublicItem
-impl UnwindSafe for public_api::diff::ChangedPublicItem
-impl UnwindSafe for public_api::diff::PublicApiDiff
-impl UnwindSafe for public_api::tokens::Token
 pub const public_api::MINIMUM_RUSTDOC_JSON_VERSION: &'static str
 pub enum public_api::tokens::Token
+impl RefUnwindSafe for public_api::tokens::Token
+impl Send for public_api::tokens::Token
+impl Sync for public_api::tokens::Token
+impl Unpin for public_api::tokens::Token
+impl UnwindSafe for public_api::tokens::Token
 pub enum variant public_api::Error::SerdeJsonError(serde_json::Error)
 pub enum variant public_api::tokens::Token::Annotation(String)
 pub enum variant public_api::tokens::Token::Function(String)
@@ -70,6 +55,7 @@ pub fn public_api::PublicItem::eq(&self, other: &public_api::PublicItem) -> bool
 pub fn public_api::PublicItem::fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result
 pub fn public_api::PublicItem::fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result
 pub fn public_api::PublicItem::hash<__H: $crate::hash::Hasher>(&self, state: &mut __H) -> ()
+pub fn public_api::PublicItem::impls(&self) -> impl Iterator<Item = &public_api::PublicItem>
 pub fn public_api::PublicItem::partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering>
 pub fn public_api::PublicItem::tokens(&self) -> impl Iterator<Item = &public_api::tokens::Token>
 pub fn public_api::diff::ChangedPublicItem::clone(&self) -> public_api::diff::ChangedPublicItem
@@ -102,6 +88,21 @@ pub struct field public_api::diff::PublicApiDiff::added: Vec<public_api::PublicI
 pub struct field public_api::diff::PublicApiDiff::changed: Vec<public_api::diff::ChangedPublicItem>
 pub struct field public_api::diff::PublicApiDiff::removed: Vec<public_api::PublicItem>
 pub struct public_api::PublicItem
+impl RefUnwindSafe for public_api::PublicItem
+impl Send for public_api::PublicItem
+impl Sync for public_api::PublicItem
+impl Unpin for public_api::PublicItem
+impl UnwindSafe for public_api::PublicItem
 pub struct public_api::diff::ChangedPublicItem
+impl RefUnwindSafe for public_api::diff::ChangedPublicItem
+impl Send for public_api::diff::ChangedPublicItem
+impl Sync for public_api::diff::ChangedPublicItem
+impl Unpin for public_api::diff::ChangedPublicItem
+impl UnwindSafe for public_api::diff::ChangedPublicItem
 pub struct public_api::diff::PublicApiDiff
+impl RefUnwindSafe for public_api::diff::PublicApiDiff
+impl Send for public_api::diff::PublicApiDiff
+impl Sync for public_api::diff::PublicApiDiff
+impl Unpin for public_api::diff::PublicApiDiff
+impl UnwindSafe for public_api::diff::PublicApiDiff
 pub type public_api::Result<T> = std::result::Result<T, public_api::Error>

--- a/cargo-public-api/tests/expected-output/rustdoc_json_list.txt
+++ b/cargo-public-api/tests/expected-output/rustdoc_json_list.txt
@@ -1,22 +1,12 @@
-impl !RefUnwindSafe for rustdoc_json::BuildError
-impl !UnwindSafe for rustdoc_json::BuildError
-impl RefUnwindSafe for rustdoc_json::BuildOptions
-impl RefUnwindSafe for rustdoc_json::Builder
-impl Send for rustdoc_json::BuildError
-impl Send for rustdoc_json::BuildOptions
-impl Send for rustdoc_json::Builder
-impl Sync for rustdoc_json::BuildError
-impl Sync for rustdoc_json::BuildOptions
-impl Sync for rustdoc_json::Builder
-impl Unpin for rustdoc_json::BuildError
-impl Unpin for rustdoc_json::BuildOptions
-impl Unpin for rustdoc_json::Builder
-impl UnwindSafe for rustdoc_json::BuildOptions
-impl UnwindSafe for rustdoc_json::Builder
 pub const fn rustdoc_json::Builder::all_features(self, all_features: bool) -> Self
 pub const fn rustdoc_json::Builder::no_default_features(self, no_default_features: bool) -> Self
 pub const fn rustdoc_json::Builder::quiet(self, quiet: bool) -> Self
 pub enum rustdoc_json::BuildError
+impl !RefUnwindSafe for rustdoc_json::BuildError
+impl !UnwindSafe for rustdoc_json::BuildError
+impl Send for rustdoc_json::BuildError
+impl Sync for rustdoc_json::BuildError
+impl Unpin for rustdoc_json::BuildError
 pub enum variant rustdoc_json::BuildError::CargoMetadataError(cargo_metadata::Error)
 pub enum variant rustdoc_json::BuildError::CargoTomlError(cargo_toml::Error)
 pub enum variant rustdoc_json::BuildError::General(String)
@@ -41,4 +31,14 @@ pub fn rustdoc_json::Builder::toolchain(self, toolchain: impl Into<Option<String
 pub fn rustdoc_json::build(options: rustdoc_json::Builder) -> Result<PathBuf, rustdoc_json::BuildError>
 pub mod rustdoc_json
 pub struct rustdoc_json::BuildOptions
+impl RefUnwindSafe for rustdoc_json::BuildOptions
+impl Send for rustdoc_json::BuildOptions
+impl Sync for rustdoc_json::BuildOptions
+impl Unpin for rustdoc_json::BuildOptions
+impl UnwindSafe for rustdoc_json::BuildOptions
 pub struct rustdoc_json::Builder
+impl RefUnwindSafe for rustdoc_json::Builder
+impl Send for rustdoc_json::Builder
+impl Sync for rustdoc_json::Builder
+impl Unpin for rustdoc_json::Builder
+impl UnwindSafe for rustdoc_json::Builder

--- a/cargo-public-api/tests/expected-output/test_repo_api_latest.txt
+++ b/cargo-public-api/tests/expected-output/test_repo_api_latest.txt
@@ -1,17 +1,17 @@
 #[non_exhaustive] pub struct example_api::Struct
 impl RefUnwindSafe for example_api::Struct
-impl RefUnwindSafe for example_api::StructV2
 impl Send for example_api::Struct
-impl Send for example_api::StructV2
 impl Sync for example_api::Struct
-impl Sync for example_api::StructV2
 impl Unpin for example_api::Struct
-impl Unpin for example_api::StructV2
 impl UnwindSafe for example_api::Struct
-impl UnwindSafe for example_api::StructV2
 pub fn example_api::Struct::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
 pub mod example_api
 pub struct example_api::StructV2
+impl RefUnwindSafe for example_api::StructV2
+impl Send for example_api::StructV2
+impl Sync for example_api::StructV2
+impl Unpin for example_api::StructV2
+impl UnwindSafe for example_api::StructV2
 pub struct field example_api::Struct::v1_field: usize
 pub struct field example_api::Struct::v2_field: usize
 pub struct field example_api::StructV2::field: usize

--- a/public-api/public-api.txt
+++ b/public-api/public-api.txt
@@ -1,43 +1,28 @@
 #[non_exhaustive] pub enum public_api::Error
-#[non_exhaustive] pub struct public_api::Options
-#[non_exhaustive] pub struct public_api::PublicApi
 impl !RefUnwindSafe for public_api::Error
 impl !UnwindSafe for public_api::Error
-impl RefUnwindSafe for public_api::Options
-impl RefUnwindSafe for public_api::PublicApi
-impl RefUnwindSafe for public_api::PublicItem
-impl RefUnwindSafe for public_api::diff::ChangedPublicItem
-impl RefUnwindSafe for public_api::diff::PublicApiDiff
-impl RefUnwindSafe for public_api::tokens::Token
 impl Send for public_api::Error
-impl Send for public_api::Options
-impl Send for public_api::PublicApi
-impl Send for public_api::PublicItem
-impl Send for public_api::diff::ChangedPublicItem
-impl Send for public_api::diff::PublicApiDiff
-impl Send for public_api::tokens::Token
 impl Sync for public_api::Error
-impl Sync for public_api::Options
-impl Sync for public_api::PublicApi
-impl Sync for public_api::PublicItem
-impl Sync for public_api::diff::ChangedPublicItem
-impl Sync for public_api::diff::PublicApiDiff
-impl Sync for public_api::tokens::Token
 impl Unpin for public_api::Error
+#[non_exhaustive] pub struct public_api::Options
+impl RefUnwindSafe for public_api::Options
+impl Send for public_api::Options
+impl Sync for public_api::Options
 impl Unpin for public_api::Options
-impl Unpin for public_api::PublicApi
-impl Unpin for public_api::PublicItem
-impl Unpin for public_api::diff::ChangedPublicItem
-impl Unpin for public_api::diff::PublicApiDiff
-impl Unpin for public_api::tokens::Token
 impl UnwindSafe for public_api::Options
+#[non_exhaustive] pub struct public_api::PublicApi
+impl RefUnwindSafe for public_api::PublicApi
+impl Send for public_api::PublicApi
+impl Sync for public_api::PublicApi
+impl Unpin for public_api::PublicApi
 impl UnwindSafe for public_api::PublicApi
-impl UnwindSafe for public_api::PublicItem
-impl UnwindSafe for public_api::diff::ChangedPublicItem
-impl UnwindSafe for public_api::diff::PublicApiDiff
-impl UnwindSafe for public_api::tokens::Token
 pub const public_api::MINIMUM_RUSTDOC_JSON_VERSION: &'static str
 pub enum public_api::tokens::Token
+impl RefUnwindSafe for public_api::tokens::Token
+impl Send for public_api::tokens::Token
+impl Sync for public_api::tokens::Token
+impl Unpin for public_api::tokens::Token
+impl UnwindSafe for public_api::tokens::Token
 pub enum variant public_api::Error::SerdeJsonError(serde_json::Error)
 pub enum variant public_api::tokens::Token::Annotation(String)
 pub enum variant public_api::tokens::Token::Function(String)
@@ -70,6 +55,7 @@ pub fn public_api::PublicItem::eq(&self, other: &public_api::PublicItem) -> bool
 pub fn public_api::PublicItem::fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result
 pub fn public_api::PublicItem::fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result
 pub fn public_api::PublicItem::hash<__H: $crate::hash::Hasher>(&self, state: &mut __H) -> ()
+pub fn public_api::PublicItem::impls(&self) -> impl Iterator<Item = &public_api::PublicItem>
 pub fn public_api::PublicItem::partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering>
 pub fn public_api::PublicItem::tokens(&self) -> impl Iterator<Item = &public_api::tokens::Token>
 pub fn public_api::diff::ChangedPublicItem::clone(&self) -> public_api::diff::ChangedPublicItem
@@ -102,6 +88,21 @@ pub struct field public_api::diff::PublicApiDiff::added: Vec<public_api::PublicI
 pub struct field public_api::diff::PublicApiDiff::changed: Vec<public_api::diff::ChangedPublicItem>
 pub struct field public_api::diff::PublicApiDiff::removed: Vec<public_api::PublicItem>
 pub struct public_api::PublicItem
+impl RefUnwindSafe for public_api::PublicItem
+impl Send for public_api::PublicItem
+impl Sync for public_api::PublicItem
+impl Unpin for public_api::PublicItem
+impl UnwindSafe for public_api::PublicItem
 pub struct public_api::diff::ChangedPublicItem
+impl RefUnwindSafe for public_api::diff::ChangedPublicItem
+impl Send for public_api::diff::ChangedPublicItem
+impl Sync for public_api::diff::ChangedPublicItem
+impl Unpin for public_api::diff::ChangedPublicItem
+impl UnwindSafe for public_api::diff::ChangedPublicItem
 pub struct public_api::diff::PublicApiDiff
+impl RefUnwindSafe for public_api::diff::PublicApiDiff
+impl Send for public_api::diff::PublicApiDiff
+impl Sync for public_api::diff::PublicApiDiff
+impl Unpin for public_api::diff::PublicApiDiff
+impl UnwindSafe for public_api::diff::PublicApiDiff
 pub type public_api::Result<T> = std::result::Result<T, public_api::Error>

--- a/public-api/src/diff.rs
+++ b/public-api/src/diff.rs
@@ -299,6 +299,7 @@ mod tests {
                 .map(std::string::ToString::to_string)
                 .collect(),
             tokens: vec![crate::tokens::Token::identifier(path)],
+            impls: vec![],
         }
     }
 
@@ -328,7 +329,11 @@ mod tests {
         tokens.extend(vec![q("("), i("x"), s(":"), w(), t(type_), q(")")]);
 
         // End result is e.g. "pub fn a::b(x: usize)"
-        PublicItem { path, tokens }
+        PublicItem {
+            path,
+            tokens,
+            impls: vec![],
+        }
     }
 
     fn s(s: &str) -> Token {

--- a/public-api/src/item_iterator.rs
+++ b/public-api/src/item_iterator.rs
@@ -226,7 +226,10 @@ impl<'a> ItemIterator<'a> {
             .entry(&item.id)
             .or_default()
             .push(public_item.clone());
-        self.items_left.push(public_item);
+
+        if !matches!(item.inner, ItemEnum::Impl(_)) {
+            self.items_left.push(public_item);
+        }
     }
 
     fn add_missing_id(&mut self, id: &'a Id) {

--- a/public-api/src/render.rs
+++ b/public-api/src/render.rs
@@ -899,7 +899,7 @@ impl<'a> RenderingContext<'a> {
         output
     }
 
-    fn best_item_for_id(&self, id: &Id) -> Option<Rc<IntermediatePublicItem<'a>>> {
+    pub fn best_item_for_id(&self, id: &Id) -> Option<Rc<IntermediatePublicItem<'a>>> {
         match self.id_to_items.get(&id) {
             None => None,
             Some(items) => {

--- a/public-api/tests/expected-output/comprehensive_api.txt
+++ b/public-api/tests/expected-output/comprehensive_api.txt
@@ -1,127 +1,17 @@
 #[export_name = "something_arbitrary"] pub fn comprehensive_api::attributes::export_name()
 #[no_mangle] #[link_section = ".custom"] pub static comprehensive_api::attributes::NO_MANGLE_WITH_CUSTOM_LINK_SECTION: usize
 #[non_exhaustive] pub enum comprehensive_api::attributes::NonExhaustive
-#[repr(C)] pub struct comprehensive_api::attributes::C
-impl RefUnwindSafe for comprehensive_api::StructInPrivateMod
-impl RefUnwindSafe for comprehensive_api::attributes::C
 impl RefUnwindSafe for comprehensive_api::attributes::NonExhaustive
-impl RefUnwindSafe for comprehensive_api::enums::DiverseVariants
-impl RefUnwindSafe for comprehensive_api::enums::EnumWithExplicitDiscriminants
-impl RefUnwindSafe for comprehensive_api::enums::EnumWithStrippedTupleVariants
-impl RefUnwindSafe for comprehensive_api::enums::SingleVariant
-impl RefUnwindSafe for comprehensive_api::exports::issue_145::external::External
-impl RefUnwindSafe for comprehensive_api::exports::issue_145::external_2::External
-impl RefUnwindSafe for comprehensive_api::exports::issue_145::external_3::External
-impl RefUnwindSafe for comprehensive_api::structs::Plain
-impl RefUnwindSafe for comprehensive_api::structs::PrivateField
-impl RefUnwindSafe for comprehensive_api::structs::TupleStructDouble
-impl RefUnwindSafe for comprehensive_api::structs::TupleStructDoubleWithHidden
-impl RefUnwindSafe for comprehensive_api::structs::TupleStructDoubleWithPrivate
-impl RefUnwindSafe for comprehensive_api::structs::TupleStructSingle
-impl RefUnwindSafe for comprehensive_api::structs::Unit
-impl RefUnwindSafe for comprehensive_api::unions::Basic
-impl Send for comprehensive_api::StructInPrivateMod
-impl Send for comprehensive_api::attributes::C
 impl Send for comprehensive_api::attributes::NonExhaustive
-impl Send for comprehensive_api::enums::DiverseVariants
-impl Send for comprehensive_api::enums::EnumWithExplicitDiscriminants
-impl Send for comprehensive_api::enums::EnumWithStrippedTupleVariants
-impl Send for comprehensive_api::enums::SingleVariant
-impl Send for comprehensive_api::exports::issue_145::external::External
-impl Send for comprehensive_api::exports::issue_145::external_2::External
-impl Send for comprehensive_api::exports::issue_145::external_3::External
-impl Send for comprehensive_api::structs::Plain
-impl Send for comprehensive_api::structs::PrivateField
-impl Send for comprehensive_api::structs::TupleStructDouble
-impl Send for comprehensive_api::structs::TupleStructDoubleWithHidden
-impl Send for comprehensive_api::structs::TupleStructDoubleWithPrivate
-impl Send for comprehensive_api::structs::TupleStructSingle
-impl Send for comprehensive_api::structs::Unit
-impl Send for comprehensive_api::unions::Basic
-impl Sync for comprehensive_api::StructInPrivateMod
-impl Sync for comprehensive_api::attributes::C
 impl Sync for comprehensive_api::attributes::NonExhaustive
-impl Sync for comprehensive_api::enums::DiverseVariants
-impl Sync for comprehensive_api::enums::EnumWithExplicitDiscriminants
-impl Sync for comprehensive_api::enums::EnumWithStrippedTupleVariants
-impl Sync for comprehensive_api::enums::SingleVariant
-impl Sync for comprehensive_api::exports::issue_145::external::External
-impl Sync for comprehensive_api::exports::issue_145::external_2::External
-impl Sync for comprehensive_api::exports::issue_145::external_3::External
-impl Sync for comprehensive_api::structs::Plain
-impl Sync for comprehensive_api::structs::PrivateField
-impl Sync for comprehensive_api::structs::TupleStructDouble
-impl Sync for comprehensive_api::structs::TupleStructDoubleWithHidden
-impl Sync for comprehensive_api::structs::TupleStructDoubleWithPrivate
-impl Sync for comprehensive_api::structs::TupleStructSingle
-impl Sync for comprehensive_api::structs::Unit
-impl Sync for comprehensive_api::unions::Basic
-impl Unpin for comprehensive_api::StructInPrivateMod
-impl Unpin for comprehensive_api::attributes::C
 impl Unpin for comprehensive_api::attributes::NonExhaustive
-impl Unpin for comprehensive_api::enums::DiverseVariants
-impl Unpin for comprehensive_api::enums::EnumWithExplicitDiscriminants
-impl Unpin for comprehensive_api::enums::EnumWithStrippedTupleVariants
-impl Unpin for comprehensive_api::enums::SingleVariant
-impl Unpin for comprehensive_api::exports::issue_145::external::External
-impl Unpin for comprehensive_api::exports::issue_145::external_2::External
-impl Unpin for comprehensive_api::exports::issue_145::external_3::External
-impl Unpin for comprehensive_api::structs::Plain
-impl Unpin for comprehensive_api::structs::PrivateField
-impl Unpin for comprehensive_api::structs::TupleStructDouble
-impl Unpin for comprehensive_api::structs::TupleStructDoubleWithHidden
-impl Unpin for comprehensive_api::structs::TupleStructDoubleWithPrivate
-impl Unpin for comprehensive_api::structs::TupleStructSingle
-impl Unpin for comprehensive_api::structs::Unit
-impl Unpin for comprehensive_api::unions::Basic
-impl UnwindSafe for comprehensive_api::StructInPrivateMod
-impl UnwindSafe for comprehensive_api::attributes::C
 impl UnwindSafe for comprehensive_api::attributes::NonExhaustive
-impl UnwindSafe for comprehensive_api::enums::DiverseVariants
-impl UnwindSafe for comprehensive_api::enums::EnumWithExplicitDiscriminants
-impl UnwindSafe for comprehensive_api::enums::EnumWithStrippedTupleVariants
-impl UnwindSafe for comprehensive_api::enums::SingleVariant
-impl UnwindSafe for comprehensive_api::exports::issue_145::external::External
-impl UnwindSafe for comprehensive_api::exports::issue_145::external_2::External
-impl UnwindSafe for comprehensive_api::exports::issue_145::external_3::External
-impl UnwindSafe for comprehensive_api::structs::Plain
-impl UnwindSafe for comprehensive_api::structs::PrivateField
-impl UnwindSafe for comprehensive_api::structs::TupleStructDouble
-impl UnwindSafe for comprehensive_api::structs::TupleStructDoubleWithHidden
-impl UnwindSafe for comprehensive_api::structs::TupleStructDoubleWithPrivate
-impl UnwindSafe for comprehensive_api::structs::TupleStructSingle
-impl UnwindSafe for comprehensive_api::structs::Unit
-impl UnwindSafe for comprehensive_api::unions::Basic
-impl<'a, T, D> RefUnwindSafe for comprehensive_api::enums::EnumWithGenerics<'a, T, D> where D: RefUnwindSafe, T: RefUnwindSafe
-impl<'a, T, D> Send for comprehensive_api::enums::EnumWithGenerics<'a, T, D> where D: Send, T: Sync
-impl<'a, T, D> Sync for comprehensive_api::enums::EnumWithGenerics<'a, T, D> where D: Sync, T: Sync
-impl<'a, T, D> Unpin for comprehensive_api::enums::EnumWithGenerics<'a, T, D> where D: Unpin
-impl<'a, T, D> UnwindSafe for comprehensive_api::enums::EnumWithGenerics<'a, T, D> where D: UnwindSafe, T: RefUnwindSafe
-impl<'a, T> RefUnwindSafe for comprehensive_api::structs::WithLifetimeAndGenericParam<'a, T> where T: RefUnwindSafe
-impl<'a, T> Send for comprehensive_api::structs::WithLifetimeAndGenericParam<'a, T> where T: Send
-impl<'a, T> Sync for comprehensive_api::structs::WithLifetimeAndGenericParam<'a, T> where T: Sync
-impl<'a, T> Unpin for comprehensive_api::structs::WithLifetimeAndGenericParam<'a, T> where T: Unpin
-impl<'a, T> UnwindSafe for comprehensive_api::structs::WithLifetimeAndGenericParam<'a, T> where T: UnwindSafe
-impl<'a> !RefUnwindSafe for comprehensive_api::higher_ranked_trait_bounds::Bar<'a>
-impl<'a> !RefUnwindSafe for comprehensive_api::higher_ranked_trait_bounds::Foo<'a>
-impl<'a> !Send for comprehensive_api::higher_ranked_trait_bounds::Bar<'a>
-impl<'a> !Send for comprehensive_api::higher_ranked_trait_bounds::Foo<'a>
-impl<'a> !Sync for comprehensive_api::higher_ranked_trait_bounds::Bar<'a>
-impl<'a> !Sync for comprehensive_api::higher_ranked_trait_bounds::Foo<'a>
-impl<'a> !UnwindSafe for comprehensive_api::higher_ranked_trait_bounds::Bar<'a>
-impl<'a> !UnwindSafe for comprehensive_api::higher_ranked_trait_bounds::Foo<'a>
-impl<'a> Unpin for comprehensive_api::higher_ranked_trait_bounds::Bar<'a>
-impl<'a> Unpin for comprehensive_api::higher_ranked_trait_bounds::Foo<'a>
-impl<T, const N: usize> RefUnwindSafe for comprehensive_api::structs::ConstArg<T, N> where T: RefUnwindSafe
-impl<T, const N: usize> Send for comprehensive_api::structs::ConstArg<T, N> where T: Send
-impl<T, const N: usize> Sync for comprehensive_api::structs::ConstArg<T, N> where T: Sync
-impl<T, const N: usize> Unpin for comprehensive_api::structs::ConstArg<T, N> where T: Unpin
-impl<T, const N: usize> UnwindSafe for comprehensive_api::structs::ConstArg<T, N> where T: UnwindSafe
-impl<T> RefUnwindSafe for comprehensive_api::structs::WithTraitBounds<T> where T: RefUnwindSafe
-impl<T> Send for comprehensive_api::structs::WithTraitBounds<T> where T: Send
-impl<T> Sync for comprehensive_api::structs::WithTraitBounds<T> where T: Sync
-impl<T> Unpin for comprehensive_api::structs::WithTraitBounds<T> where T: Unpin
-impl<T> UnwindSafe for comprehensive_api::structs::WithTraitBounds<T> where T: UnwindSafe
+#[repr(C)] pub struct comprehensive_api::attributes::C
+impl RefUnwindSafe for comprehensive_api::attributes::C
+impl Send for comprehensive_api::attributes::C
+impl Sync for comprehensive_api::attributes::C
+impl Unpin for comprehensive_api::attributes::C
+impl UnwindSafe for comprehensive_api::attributes::C
 pub async fn comprehensive_api::functions::async_fn() -> ()
 pub async fn comprehensive_api::functions::async_fn_ret_bool() -> bool
 pub const comprehensive_api::constants::CONST: &'static str
@@ -129,10 +19,35 @@ pub const comprehensive_api::traits::AssociatedConst::CONST: bool
 pub const comprehensive_api::traits::AssociatedConstDefault::CONST_WITH_DEFAULT: bool
 pub const fn comprehensive_api::functions::const_fn()
 pub enum comprehensive_api::enums::DiverseVariants
+impl RefUnwindSafe for comprehensive_api::enums::DiverseVariants
+impl Send for comprehensive_api::enums::DiverseVariants
+impl Sync for comprehensive_api::enums::DiverseVariants
+impl Unpin for comprehensive_api::enums::DiverseVariants
+impl UnwindSafe for comprehensive_api::enums::DiverseVariants
 pub enum comprehensive_api::enums::EnumWithExplicitDiscriminants
+impl RefUnwindSafe for comprehensive_api::enums::EnumWithExplicitDiscriminants
+impl Send for comprehensive_api::enums::EnumWithExplicitDiscriminants
+impl Sync for comprehensive_api::enums::EnumWithExplicitDiscriminants
+impl Unpin for comprehensive_api::enums::EnumWithExplicitDiscriminants
+impl UnwindSafe for comprehensive_api::enums::EnumWithExplicitDiscriminants
 pub enum comprehensive_api::enums::EnumWithGenerics<'a, T, D: Debug> where T: Display
+impl<'a, T, D> RefUnwindSafe for comprehensive_api::enums::EnumWithGenerics<'a, T, D> where D: RefUnwindSafe, T: RefUnwindSafe
+impl<'a, T, D> Send for comprehensive_api::enums::EnumWithGenerics<'a, T, D> where D: Send, T: Sync
+impl<'a, T, D> Sync for comprehensive_api::enums::EnumWithGenerics<'a, T, D> where D: Sync, T: Sync
+impl<'a, T, D> Unpin for comprehensive_api::enums::EnumWithGenerics<'a, T, D> where D: Unpin
+impl<'a, T, D> UnwindSafe for comprehensive_api::enums::EnumWithGenerics<'a, T, D> where D: UnwindSafe, T: RefUnwindSafe
 pub enum comprehensive_api::enums::EnumWithStrippedTupleVariants
+impl RefUnwindSafe for comprehensive_api::enums::EnumWithStrippedTupleVariants
+impl Send for comprehensive_api::enums::EnumWithStrippedTupleVariants
+impl Sync for comprehensive_api::enums::EnumWithStrippedTupleVariants
+impl Unpin for comprehensive_api::enums::EnumWithStrippedTupleVariants
+impl UnwindSafe for comprehensive_api::enums::EnumWithStrippedTupleVariants
 pub enum comprehensive_api::enums::SingleVariant
+impl RefUnwindSafe for comprehensive_api::enums::SingleVariant
+impl Send for comprehensive_api::enums::SingleVariant
+impl Sync for comprehensive_api::enums::SingleVariant
+impl Unpin for comprehensive_api::enums::SingleVariant
+impl UnwindSafe for comprehensive_api::enums::SingleVariant
 pub enum variant comprehensive_api::attributes::NonExhaustive::MoreToCome
 pub enum variant comprehensive_api::enums::DiverseVariants::Recursive
 pub enum variant comprehensive_api::enums::DiverseVariants::Simple
@@ -243,25 +158,125 @@ pub mut static comprehensive_api::statics::MUT_ANSWER: i8
 pub static comprehensive_api::statics::ANSWER: i8
 pub static comprehensive_api::statics::FUNCTION_POINTER: Option<fn(usize, i8) -> String>
 pub struct comprehensive_api::Plain
+impl RefUnwindSafe for comprehensive_api::structs::Plain
+impl Send for comprehensive_api::structs::Plain
+impl Sync for comprehensive_api::structs::Plain
+impl Unpin for comprehensive_api::structs::Plain
+impl UnwindSafe for comprehensive_api::structs::Plain
 pub struct comprehensive_api::RenamedPlain
+impl RefUnwindSafe for comprehensive_api::structs::Plain
+impl Send for comprehensive_api::structs::Plain
+impl Sync for comprehensive_api::structs::Plain
+impl Unpin for comprehensive_api::structs::Plain
+impl UnwindSafe for comprehensive_api::structs::Plain
 pub struct comprehensive_api::StructInPrivateMod
+impl RefUnwindSafe for comprehensive_api::StructInPrivateMod
+impl Send for comprehensive_api::StructInPrivateMod
+impl Sync for comprehensive_api::StructInPrivateMod
+impl Unpin for comprehensive_api::StructInPrivateMod
+impl UnwindSafe for comprehensive_api::StructInPrivateMod
 pub struct comprehensive_api::exports::issue_145::PubliclyRenamedFromPrivateMod
+impl RefUnwindSafe for comprehensive_api::exports::issue_145::external_3::External
+impl Send for comprehensive_api::exports::issue_145::external_3::External
+impl Sync for comprehensive_api::exports::issue_145::external_3::External
+impl Unpin for comprehensive_api::exports::issue_145::external_3::External
+impl UnwindSafe for comprehensive_api::exports::issue_145::external_3::External
 pub struct comprehensive_api::exports::issue_145::external::External
+impl RefUnwindSafe for comprehensive_api::exports::issue_145::external::External
+impl Send for comprehensive_api::exports::issue_145::external::External
+impl Sync for comprehensive_api::exports::issue_145::external::External
+impl Unpin for comprehensive_api::exports::issue_145::external::External
+impl UnwindSafe for comprehensive_api::exports::issue_145::external::External
 pub struct comprehensive_api::exports::issue_145::external_2::External
+impl RefUnwindSafe for comprehensive_api::exports::issue_145::external_2::External
+impl Send for comprehensive_api::exports::issue_145::external_2::External
+impl Sync for comprehensive_api::exports::issue_145::external_2::External
+impl Unpin for comprehensive_api::exports::issue_145::external_2::External
+impl UnwindSafe for comprehensive_api::exports::issue_145::external_2::External
 pub struct comprehensive_api::exports::issue_145::external_3::External
+impl RefUnwindSafe for comprehensive_api::exports::issue_145::external_3::External
+impl Send for comprehensive_api::exports::issue_145::external_3::External
+impl Sync for comprehensive_api::exports::issue_145::external_3::External
+impl Unpin for comprehensive_api::exports::issue_145::external_3::External
+impl UnwindSafe for comprehensive_api::exports::issue_145::external_3::External
 pub struct comprehensive_api::exports::issue_145::publicly_renamed::External
+impl RefUnwindSafe for comprehensive_api::exports::issue_145::external_2::External
+impl Send for comprehensive_api::exports::issue_145::external_2::External
+impl Sync for comprehensive_api::exports::issue_145::external_2::External
+impl Unpin for comprehensive_api::exports::issue_145::external_2::External
+impl UnwindSafe for comprehensive_api::exports::issue_145::external_2::External
 pub struct comprehensive_api::higher_ranked_trait_bounds::Bar<'a>
+impl<'a> !RefUnwindSafe for comprehensive_api::higher_ranked_trait_bounds::Bar<'a>
+impl<'a> !Send for comprehensive_api::higher_ranked_trait_bounds::Bar<'a>
+impl<'a> !Sync for comprehensive_api::higher_ranked_trait_bounds::Bar<'a>
+impl<'a> !UnwindSafe for comprehensive_api::higher_ranked_trait_bounds::Bar<'a>
+impl<'a> Unpin for comprehensive_api::higher_ranked_trait_bounds::Bar<'a>
 pub struct comprehensive_api::higher_ranked_trait_bounds::Foo<'a>
+impl<'a> !RefUnwindSafe for comprehensive_api::higher_ranked_trait_bounds::Foo<'a>
+impl<'a> !Send for comprehensive_api::higher_ranked_trait_bounds::Foo<'a>
+impl<'a> !Sync for comprehensive_api::higher_ranked_trait_bounds::Foo<'a>
+impl<'a> !UnwindSafe for comprehensive_api::higher_ranked_trait_bounds::Foo<'a>
+impl<'a> Unpin for comprehensive_api::higher_ranked_trait_bounds::Foo<'a>
 pub struct comprehensive_api::structs::ConstArg<T, const N: usize>
+impl<T, const N: usize> RefUnwindSafe for comprehensive_api::structs::ConstArg<T, N> where T: RefUnwindSafe
+impl<T, const N: usize> Send for comprehensive_api::structs::ConstArg<T, N> where T: Send
+impl<T, const N: usize> Sync for comprehensive_api::structs::ConstArg<T, N> where T: Sync
+impl<T, const N: usize> Unpin for comprehensive_api::structs::ConstArg<T, N> where T: Unpin
+impl<T, const N: usize> UnwindSafe for comprehensive_api::structs::ConstArg<T, N> where T: UnwindSafe
 pub struct comprehensive_api::structs::Plain
+impl RefUnwindSafe for comprehensive_api::structs::Plain
+impl Send for comprehensive_api::structs::Plain
+impl Sync for comprehensive_api::structs::Plain
+impl Unpin for comprehensive_api::structs::Plain
+impl UnwindSafe for comprehensive_api::structs::Plain
 pub struct comprehensive_api::structs::PrivateField
+impl RefUnwindSafe for comprehensive_api::structs::PrivateField
+impl Send for comprehensive_api::structs::PrivateField
+impl Sync for comprehensive_api::structs::PrivateField
+impl Unpin for comprehensive_api::structs::PrivateField
+impl UnwindSafe for comprehensive_api::structs::PrivateField
 pub struct comprehensive_api::structs::TupleStructDouble(pub usize, pub bool)
+impl RefUnwindSafe for comprehensive_api::structs::TupleStructDouble
+impl Send for comprehensive_api::structs::TupleStructDouble
+impl Sync for comprehensive_api::structs::TupleStructDouble
+impl Unpin for comprehensive_api::structs::TupleStructDouble
+impl UnwindSafe for comprehensive_api::structs::TupleStructDouble
 pub struct comprehensive_api::structs::TupleStructDoubleWithHidden(_, pub bool)
+impl RefUnwindSafe for comprehensive_api::structs::TupleStructDoubleWithHidden
+impl Send for comprehensive_api::structs::TupleStructDoubleWithHidden
+impl Sync for comprehensive_api::structs::TupleStructDoubleWithHidden
+impl Unpin for comprehensive_api::structs::TupleStructDoubleWithHidden
+impl UnwindSafe for comprehensive_api::structs::TupleStructDoubleWithHidden
 pub struct comprehensive_api::structs::TupleStructDoubleWithPrivate(_, pub bool)
+impl RefUnwindSafe for comprehensive_api::structs::TupleStructDoubleWithPrivate
+impl Send for comprehensive_api::structs::TupleStructDoubleWithPrivate
+impl Sync for comprehensive_api::structs::TupleStructDoubleWithPrivate
+impl Unpin for comprehensive_api::structs::TupleStructDoubleWithPrivate
+impl UnwindSafe for comprehensive_api::structs::TupleStructDoubleWithPrivate
 pub struct comprehensive_api::structs::TupleStructSingle(pub usize)
+impl RefUnwindSafe for comprehensive_api::structs::TupleStructSingle
+impl Send for comprehensive_api::structs::TupleStructSingle
+impl Sync for comprehensive_api::structs::TupleStructSingle
+impl Unpin for comprehensive_api::structs::TupleStructSingle
+impl UnwindSafe for comprehensive_api::structs::TupleStructSingle
 pub struct comprehensive_api::structs::Unit
+impl RefUnwindSafe for comprehensive_api::structs::Unit
+impl Send for comprehensive_api::structs::Unit
+impl Sync for comprehensive_api::structs::Unit
+impl Unpin for comprehensive_api::structs::Unit
+impl UnwindSafe for comprehensive_api::structs::Unit
 pub struct comprehensive_api::structs::WithLifetimeAndGenericParam<'a, T>
+impl<'a, T> RefUnwindSafe for comprehensive_api::structs::WithLifetimeAndGenericParam<'a, T> where T: RefUnwindSafe
+impl<'a, T> Send for comprehensive_api::structs::WithLifetimeAndGenericParam<'a, T> where T: Send
+impl<'a, T> Sync for comprehensive_api::structs::WithLifetimeAndGenericParam<'a, T> where T: Sync
+impl<'a, T> Unpin for comprehensive_api::structs::WithLifetimeAndGenericParam<'a, T> where T: Unpin
+impl<'a, T> UnwindSafe for comprehensive_api::structs::WithLifetimeAndGenericParam<'a, T> where T: UnwindSafe
 pub struct comprehensive_api::structs::WithTraitBounds<T: Display + Debug>
+impl<T> RefUnwindSafe for comprehensive_api::structs::WithTraitBounds<T> where T: RefUnwindSafe
+impl<T> Send for comprehensive_api::structs::WithTraitBounds<T> where T: Send
+impl<T> Sync for comprehensive_api::structs::WithTraitBounds<T> where T: Sync
+impl<T> Unpin for comprehensive_api::structs::WithTraitBounds<T> where T: Unpin
+impl<T> UnwindSafe for comprehensive_api::structs::WithTraitBounds<T> where T: UnwindSafe
 pub struct field comprehensive_api::Plain::x: usize
 pub struct field comprehensive_api::RenamedPlain::x: usize
 pub struct field comprehensive_api::attributes::C::b: bool
@@ -297,6 +312,11 @@ pub type comprehensive_api::traits::TraitWithGenerics::Foo
 pub type comprehensive_api::typedefs::RedefinedResult<T, E> = Result<T, E>
 pub type comprehensive_api::typedefs::TypedefPlain = comprehensive_api::structs::Plain
 pub union comprehensive_api::unions::Basic
+impl RefUnwindSafe for comprehensive_api::unions::Basic
+impl Send for comprehensive_api::unions::Basic
+impl Sync for comprehensive_api::unions::Basic
+impl Unpin for comprehensive_api::unions::Basic
+impl UnwindSafe for comprehensive_api::unions::Basic
 pub unsafe fn comprehensive_api::functions::unsafe_fn()
 pub unsafe trait comprehensive_api::traits::UnsafeTrait
 pub use comprehensive_api::<<example_api::*>>

--- a/public-api/tests/expected-output/example_api-v0.2.0-with-blanket-implementations.txt
+++ b/public-api/tests/expected-output/example_api-v0.2.0-with-blanket-implementations.txt
@@ -1,14 +1,9 @@
 #[non_exhaustive] pub struct example_api::Struct
 impl RefUnwindSafe for example_api::Struct
-impl RefUnwindSafe for example_api::StructV2
 impl Send for example_api::Struct
-impl Send for example_api::StructV2
 impl Sync for example_api::Struct
-impl Sync for example_api::StructV2
 impl Unpin for example_api::Struct
-impl Unpin for example_api::StructV2
 impl UnwindSafe for example_api::Struct
-impl UnwindSafe for example_api::StructV2
 pub fn example_api::Struct::borrow(&self) -> &T
 pub fn example_api::Struct::borrow_mut(&mut self) -> &mut T
 pub fn example_api::Struct::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
@@ -27,6 +22,11 @@ pub fn example_api::StructV2::type_id(&self) -> TypeId
 pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize)
 pub mod example_api
 pub struct example_api::StructV2
+impl RefUnwindSafe for example_api::StructV2
+impl Send for example_api::StructV2
+impl Sync for example_api::StructV2
+impl Unpin for example_api::StructV2
+impl UnwindSafe for example_api::StructV2
 pub struct field example_api::Struct::v1_field: usize
 pub struct field example_api::Struct::v2_field: usize
 pub struct field example_api::StructV2::field: usize

--- a/public-api/tests/public-api-lib-tests.rs
+++ b/public-api/tests/public-api-lib-tests.rs
@@ -84,7 +84,8 @@ fn public_item_ord() {
         .unwrap();
 
     let generic_bound = public_api
-        .into_items()
+        .items()
+        .cloned()
         .into_iter()
         .find(|x| format!("{}", x).contains("generic_bound"))
         .unwrap();

--- a/rustdoc-json/public-api.txt
+++ b/rustdoc-json/public-api.txt
@@ -1,22 +1,12 @@
-impl !RefUnwindSafe for rustdoc_json::BuildError
-impl !UnwindSafe for rustdoc_json::BuildError
-impl RefUnwindSafe for rustdoc_json::BuildOptions
-impl RefUnwindSafe for rustdoc_json::Builder
-impl Send for rustdoc_json::BuildError
-impl Send for rustdoc_json::BuildOptions
-impl Send for rustdoc_json::Builder
-impl Sync for rustdoc_json::BuildError
-impl Sync for rustdoc_json::BuildOptions
-impl Sync for rustdoc_json::Builder
-impl Unpin for rustdoc_json::BuildError
-impl Unpin for rustdoc_json::BuildOptions
-impl Unpin for rustdoc_json::Builder
-impl UnwindSafe for rustdoc_json::BuildOptions
-impl UnwindSafe for rustdoc_json::Builder
 pub const fn rustdoc_json::Builder::all_features(self, all_features: bool) -> Self
 pub const fn rustdoc_json::Builder::no_default_features(self, no_default_features: bool) -> Self
 pub const fn rustdoc_json::Builder::quiet(self, quiet: bool) -> Self
 pub enum rustdoc_json::BuildError
+impl !RefUnwindSafe for rustdoc_json::BuildError
+impl !UnwindSafe for rustdoc_json::BuildError
+impl Send for rustdoc_json::BuildError
+impl Sync for rustdoc_json::BuildError
+impl Unpin for rustdoc_json::BuildError
 pub enum variant rustdoc_json::BuildError::CargoMetadataError(cargo_metadata::Error)
 pub enum variant rustdoc_json::BuildError::CargoTomlError(cargo_toml::Error)
 pub enum variant rustdoc_json::BuildError::General(String)
@@ -41,4 +31,14 @@ pub fn rustdoc_json::Builder::toolchain(self, toolchain: impl Into<Option<String
 pub fn rustdoc_json::build(options: rustdoc_json::Builder) -> Result<PathBuf, rustdoc_json::BuildError>
 pub mod rustdoc_json
 pub struct rustdoc_json::BuildOptions
+impl RefUnwindSafe for rustdoc_json::BuildOptions
+impl Send for rustdoc_json::BuildOptions
+impl Sync for rustdoc_json::BuildOptions
+impl Unpin for rustdoc_json::BuildOptions
+impl UnwindSafe for rustdoc_json::BuildOptions
 pub struct rustdoc_json::Builder
+impl RefUnwindSafe for rustdoc_json::Builder
+impl Send for rustdoc_json::Builder
+impl Sync for rustdoc_json::Builder
+impl Unpin for rustdoc_json::Builder
+impl UnwindSafe for rustdoc_json::Builder


### PR DESCRIPTION
We still only support auto-trait `impl`s, but more `impl`s will be supported later.

This draft illustrates what #189, #190 and #191 enables us to do. Still needs some polish and fixing, but I need to stop for today.

This PR takes us closer to solving #36, #37 and #39.