### PR TITLE
Add `PublicApi::from_rustdoc_json(...)` that takes a rustdoc JSON file `Path`

### DIFF
--- a/cargo-public-api/tests/expected-output/public_api_list.txt
+++ b/cargo-public-api/tests/expected-output/public_api_list.txt
@@ -38,6 +38,7 @@ impl UnwindSafe for public_api::diff::PublicApiDiff
 impl UnwindSafe for public_api::tokens::Token
 pub const public_api::MINIMUM_RUSTDOC_JSON_VERSION: &'static str
 pub enum public_api::tokens::Token
+pub enum variant public_api::Error::IoError(std::io::Error)
 pub enum variant public_api::Error::SerdeJsonError(serde_json::Error)
 pub enum variant public_api::tokens::Token::Annotation(String)
 pub enum variant public_api::tokens::Token::Function(String)
@@ -55,12 +56,14 @@ pub enum variant public_api::tokens::Token::Whitespace
 pub fn public_api::Error::fmt(&self, __formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result
 pub fn public_api::Error::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
 pub fn public_api::Error::from(source: serde_json::Error) -> Self
+pub fn public_api::Error::from(source: std::io::Error) -> Self
 pub fn public_api::Error::source(&self) -> std::option::Option<&(dyn std::error::Error + 'static)>
 pub fn public_api::Options::clone(&self) -> public_api::Options
 pub fn public_api::Options::default() -> Self
 pub fn public_api::Options::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
 pub fn public_api::PublicApi::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
-pub fn public_api::PublicApi::from_rustdoc_json_str(rustdoc_json_str: &str, options: public_api::Options) -> public_api::Result<public_api::PublicApi>
+pub fn public_api::PublicApi::from_rustdoc_json(path: impl AsRef<Path>, options: public_api::Options) -> public_api::Result<public_api::PublicApi>
+pub fn public_api::PublicApi::from_rustdoc_json_str(rustdoc_json_str: impl AsRef<str>, options: public_api::Options) -> public_api::Result<public_api::PublicApi>
 pub fn public_api::PublicApi::into_items(self) -> impl Iterator<Item = public_api::PublicItem>
 pub fn public_api::PublicApi::items(&self) -> impl Iterator<Item = &public_api::PublicItem>
 pub fn public_api::PublicApi::missing_item_ids(&self) -> impl Iterator<Item = &String>

--- a/public-api/examples/diff_public_api.rs
+++ b/public-api/examples/diff_public_api.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, fs::read_to_string};
+use std::error::Error;
 
 use public_api::{diff::PublicApiDiff, Options, PublicApi};
 
@@ -9,13 +9,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         .toolchain(String::from("nightly"))
         .manifest_path("test-apis/example_api-v0.1.0/Cargo.toml")
         .build()?;
-    let old = PublicApi::from_rustdoc_json_str(&read_to_string(old_json)?, options)?;
+    let old = PublicApi::from_rustdoc_json(old_json, options)?;
 
     let new_json = rustdoc_json::Builder::default()
         .toolchain(String::from("nightly"))
         .manifest_path("test-apis/example_api-v0.2.0/Cargo.toml")
         .build()?;
-    let new = PublicApi::from_rustdoc_json_str(&read_to_string(new_json)?, options)?;
+    let new = PublicApi::from_rustdoc_json(new_json, options)?;
 
     let diff = PublicApiDiff::between(old, new);
     println!("{:#?}", diff);

--- a/public-api/examples/list_public_api.rs
+++ b/public-api/examples/list_public_api.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, fs::read_to_string};
+use std::error::Error;
 
 use public_api::{Options, PublicApi};
 
@@ -8,8 +8,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .manifest_path("test-apis/example_api-v0.2.0/Cargo.toml")
         .build()?;
 
-    let public_api =
-        PublicApi::from_rustdoc_json_str(&read_to_string(&json_path)?, Options::default())?;
+    let public_api = PublicApi::from_rustdoc_json(json_path, Options::default())?;
 
     for public_item in public_api.items() {
         println!("{}", public_item);

--- a/public-api/public-api.txt
+++ b/public-api/public-api.txt
@@ -38,6 +38,7 @@ impl UnwindSafe for public_api::diff::PublicApiDiff
 impl UnwindSafe for public_api::tokens::Token
 pub const public_api::MINIMUM_RUSTDOC_JSON_VERSION: &'static str
 pub enum public_api::tokens::Token
+pub enum variant public_api::Error::IoError(std::io::Error)
 pub enum variant public_api::Error::SerdeJsonError(serde_json::Error)
 pub enum variant public_api::tokens::Token::Annotation(String)
 pub enum variant public_api::tokens::Token::Function(String)
@@ -55,12 +56,14 @@ pub enum variant public_api::tokens::Token::Whitespace
 pub fn public_api::Error::fmt(&self, __formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result
 pub fn public_api::Error::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
 pub fn public_api::Error::from(source: serde_json::Error) -> Self
+pub fn public_api::Error::from(source: std::io::Error) -> Self
 pub fn public_api::Error::source(&self) -> std::option::Option<&(dyn std::error::Error + 'static)>
 pub fn public_api::Options::clone(&self) -> public_api::Options
 pub fn public_api::Options::default() -> Self
 pub fn public_api::Options::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
 pub fn public_api::PublicApi::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
-pub fn public_api::PublicApi::from_rustdoc_json_str(rustdoc_json_str: &str, options: public_api::Options) -> public_api::Result<public_api::PublicApi>
+pub fn public_api::PublicApi::from_rustdoc_json(path: impl AsRef<Path>, options: public_api::Options) -> public_api::Result<public_api::PublicApi>
+pub fn public_api::PublicApi::from_rustdoc_json_str(rustdoc_json_str: impl AsRef<str>, options: public_api::Options) -> public_api::Result<public_api::PublicApi>
 pub fn public_api::PublicApi::into_items(self) -> impl Iterator<Item = public_api::PublicItem>
 pub fn public_api::PublicApi::items(&self) -> impl Iterator<Item = &public_api::PublicItem>
 pub fn public_api::PublicApi::missing_item_ids(&self) -> impl Iterator<Item = &String>

--- a/public-api/src/error.rs
+++ b/public-api/src/error.rs
@@ -9,6 +9,11 @@ pub enum Error {
     /// too old. Consult the "Compatibility matrix" in the README.
     #[error(transparent)]
     SerdeJsonError(#[from] serde_json::Error),
+
+    /// Some kind of IO error occurred. For example, we might not have read
+    /// permissions on the rustdoc JSON input file.
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
 }
 
 /// Shorthand for [`std::result::Result<T, public_api::Error>`].

--- a/public-api/src/main.rs
+++ b/public-api/src/main.rs
@@ -55,9 +55,7 @@ fn main_() -> Result<()> {
 }
 
 fn print_public_api(path: &Path, options: Options) -> Result<()> {
-    let json = &std::fs::read_to_string(path)?;
-
-    for public_item in PublicApi::from_rustdoc_json_str(json, options)?.items() {
+    for public_item in PublicApi::from_rustdoc_json(path, options)?.items() {
         writeln!(std::io::stdout(), "{}", public_item)?;
     }
 
@@ -65,11 +63,8 @@ fn print_public_api(path: &Path, options: Options) -> Result<()> {
 }
 
 fn print_public_api_diff(old: &Path, new: &Path, options: Options) -> Result<()> {
-    let old_json = std::fs::read_to_string(old)?;
-    let old = PublicApi::from_rustdoc_json_str(&old_json, options)?;
-
-    let new_json = std::fs::read_to_string(new)?;
-    let new = PublicApi::from_rustdoc_json_str(&new_json, options)?;
+    let old = PublicApi::from_rustdoc_json(old, options)?;
+    let new = PublicApi::from_rustdoc_json(new, options)?;
 
     let diff = PublicApiDiff::between(old, new);
     print_diff_with_headers(&diff, &mut stdout(), "Removed:", "Changed:", "Added:")?;

--- a/public-api/tests/public-api-lib-tests.rs
+++ b/public-api/tests/public-api-lib-tests.rs
@@ -9,7 +9,7 @@ use public_api::{Error, Options, PublicApi};
 #[path = "../../test-utils/src/lib.rs"]
 mod test_utils;
 use test_utils::assert_eq_or_bless;
-use test_utils::rustdoc_json_str_for_crate;
+use test_utils::rustdoc_json_path_for_crate;
 
 #[test]
 fn with_blanket_implementations() {
@@ -18,7 +18,7 @@ fn with_blanket_implementations() {
     }
 
     assert_public_api_with_blanket_implementations(
-        &rustdoc_json_str_for_crate("../test-apis/example_api-v0.2.0"),
+        rustdoc_json_path_for_crate("../test-apis/example_api-v0.2.0"),
         "./tests/expected-output/example_api-v0.2.0-with-blanket-implementations.txt",
     );
 }
@@ -26,8 +26,8 @@ fn with_blanket_implementations() {
 #[test]
 fn diff_with_added_items() {
     assert_public_api_diff(
-        &rustdoc_json_str_for_crate("../test-apis/example_api-v0.1.0"),
-        &rustdoc_json_str_for_crate("../test-apis/example_api-v0.2.0"),
+        rustdoc_json_path_for_crate("../test-apis/example_api-v0.1.0"),
+        rustdoc_json_path_for_crate("../test-apis/example_api-v0.2.0"),
         "./tests/expected-output/diff_with_added_items.txt",
     );
 }
@@ -36,8 +36,8 @@ fn diff_with_added_items() {
 fn no_diff() {
     // No change to the public API
     assert_public_api_diff(
-        &rustdoc_json_str_for_crate("../test-apis/comprehensive_api"),
-        &rustdoc_json_str_for_crate("../test-apis/comprehensive_api"),
+        rustdoc_json_path_for_crate("../test-apis/comprehensive_api"),
+        rustdoc_json_path_for_crate("../test-apis/comprehensive_api"),
         "./tests/expected-output/no_diff.txt",
     );
 }
@@ -45,8 +45,8 @@ fn no_diff() {
 #[test]
 fn diff_with_removed_items() {
     assert_public_api_diff(
-        &rustdoc_json_str_for_crate("../test-apis/example_api-v0.2.0"),
-        &rustdoc_json_str_for_crate("../test-apis/example_api-v0.1.0"),
+        rustdoc_json_path_for_crate("../test-apis/example_api-v0.2.0"),
+        rustdoc_json_path_for_crate("../test-apis/example_api-v0.1.0"),
         "./tests/expected-output/diff_with_removed_items.txt",
     );
 }
@@ -54,7 +54,7 @@ fn diff_with_removed_items() {
 #[test]
 fn comprehensive_api() {
     assert_public_api(
-        &rustdoc_json_str_for_crate("../test-apis/comprehensive_api"),
+        rustdoc_json_path_for_crate("../test-apis/comprehensive_api"),
         "./tests/expected-output/comprehensive_api.txt",
     );
 }
@@ -62,7 +62,7 @@ fn comprehensive_api() {
 #[test]
 fn comprehensive_api_proc_macro() {
     assert_public_api(
-        &rustdoc_json_str_for_crate("../test-apis/comprehensive_api_proc_macro"),
+        rustdoc_json_path_for_crate("../test-apis/comprehensive_api_proc_macro"),
         "./tests/expected-output/comprehensive_api_proc_macro.txt",
     );
 }
@@ -70,8 +70,8 @@ fn comprehensive_api_proc_macro() {
 /// I confess: this test is mainly to get function code coverage on Ord
 #[test]
 fn public_item_ord() {
-    let public_api = PublicApi::from_rustdoc_json_str(
-        &rustdoc_json_str_for_crate("../test-apis/comprehensive_api"),
+    let public_api = PublicApi::from_rustdoc_json(
+        rustdoc_json_path_for_crate("../test-apis/comprehensive_api"),
         Options::default(),
     )
     .unwrap();
@@ -110,25 +110,32 @@ fn options() {
     let _ = options.clone();
 }
 
-fn assert_public_api_diff(old_json: &str, new_json: &str, expected: impl AsRef<Path>) {
-    let old = PublicApi::from_rustdoc_json_str(old_json, Options::default()).unwrap();
-    let new = PublicApi::from_rustdoc_json_str(new_json, Options::default()).unwrap();
+fn assert_public_api_diff(
+    old_json: impl AsRef<Path>,
+    new_json: impl AsRef<Path>,
+    expected: impl AsRef<Path>,
+) {
+    let old = PublicApi::from_rustdoc_json(old_json, Options::default()).unwrap();
+    let new = PublicApi::from_rustdoc_json(new_json, Options::default()).unwrap();
 
     let diff = public_api::diff::PublicApiDiff::between(old, new);
     let pretty_printed = format!("{:#?}", diff);
     assert_eq_or_bless(&pretty_printed, expected);
 }
 
-fn assert_public_api(json: &str, expected: impl AsRef<Path>) {
+fn assert_public_api(json: impl AsRef<Path>, expected: impl AsRef<Path>) {
     assert_public_api_impl(json, expected, false);
 }
 
-fn assert_public_api_with_blanket_implementations(json: &str, expected: impl AsRef<Path>) {
+fn assert_public_api_with_blanket_implementations(
+    json: impl AsRef<Path>,
+    expected: impl AsRef<Path>,
+) {
     assert_public_api_impl(json, expected, true);
 }
 
 fn assert_public_api_impl(
-    rustdoc_json_str: &str,
+    rustdoc_json: impl AsRef<Path>,
     expected_output: impl AsRef<Path>,
     with_blanket_implementations: bool,
 ) {
@@ -136,7 +143,7 @@ fn assert_public_api_impl(
     options.with_blanket_implementations = with_blanket_implementations;
     options.sorted = true;
 
-    let api = PublicApi::from_rustdoc_json_str(rustdoc_json_str, options).unwrap();
+    let api = PublicApi::from_rustdoc_json(rustdoc_json, options).unwrap();
 
     let mut actual = String::new();
     for item in api.items() {

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -44,11 +44,3 @@ fn rustdoc_json_path_for_crate_impl(test_crate: &str, target_dir: Option<&Path>)
 
     builder.build().unwrap()
 }
-
-/// Helper to get a String of freshly built rustdoc JSON for the given
-/// test-crate.
-#[must_use]
-#[allow(dead_code)]
-pub fn rustdoc_json_str_for_crate(test_crate: &str) -> String {
-    std::fs::read_to_string(rustdoc_json_path_for_crate(test_crate)).unwrap()
-}


### PR DESCRIPTION


Because in 95% of the use cases of this library, the user has a rustdoc JSON file to work with rather than a `&str`.

I have refrained from adding this helper up until now, because I wanted the API surface to be minimal, but I think this is a safe and future-proof API addition by now.

Also make `from_rustdoc_json_str()` more generic while we're at it.