### PR TITLE
Support `--diff-published your-crate@1.2.3` to diff against crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,7 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "diff",
+ "dirs",
  "nu-ansi-term",
  "predicates",
  "pretty_assertions",
@@ -184,6 +185,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +232,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -282,9 +314,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.119"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "memchr"
@@ -449,6 +481,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534cfe58d6a18cc17120fbf4635d53d14691c1fe4d951064df9bd326178d7d5a"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -659,6 +702,12 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ which will print the diff of your public API changes compared to `origin/main`.
 
 This tool can be put to good use in CI pipelines to e.g. help you make sure your public API is not unexpectedly changed. Please see [CI-EXAMPLES.md](./docs/CI-EXAMPLES.md) for CI job configuration examples and use cases.
 
+### … Against Published Version
+
+Before you `cargo publish` a new version of your crate, you can diff the public API of your local code against the public API of the version you last published. Use the `--diff-published` arg for that. Like this:
+
+```bash
+cargo public-api --diff-published regex@0.2.2
+```
+
 ## Expected Output
 
 Output aims to be character-by-character identical to the textual parts of the regular `cargo doc` HTML output. For example, [this item](https://docs.rs/bat/0.20.0/bat/struct.PrettyPrinter.html#method.input_files) has the following textual representation in the rendered HTML:

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0.53"
 atty = "0.2.14"
 clap = { version = "3.1.2", features = ["derive"] }
 diff = "0.1.12"
+dirs = "4.0.0"
 thiserror = "1.0.29"
 
 [dependencies.rustdoc-json]

--- a/cargo-public-api/src/published_crate.rs
+++ b/cargo-public-api/src/published_crate.rs
@@ -1,0 +1,110 @@
+//! Creates a dummy project with a dependency on the crate we want to build
+//! rustdoc JSON for. We then build rustdoc JSON for the crate using this dummy
+//! project.
+
+use crate::Args;
+use anyhow::{anyhow, Result};
+use std::{fmt::Display, path::PathBuf};
+
+pub fn build_rustdoc_json(package_spec_str: &str, args: &Args) -> Result<PathBuf> {
+    let spec = PackageSpec::try_from(package_spec_str)?;
+
+    let build_dir = build_dir(&spec);
+    std::fs::create_dir_all(&build_dir)?;
+
+    let write_file = |name: &str, contents: &str| -> std::io::Result<PathBuf> {
+        let mut path = build_dir.clone();
+        path.push(name);
+        std::fs::write(&path, contents)?;
+        Ok(path)
+    };
+
+    write_file("lib.rs", "// empty lib")?;
+    let manifest = write_file("Cargo.toml", &manifest_for(&spec))?;
+
+    let builder = crate::builder_from_args(args)
+        .manifest_path(&manifest)
+        .package(&spec.name);
+    crate::build_rustdoc_json(builder)
+}
+
+/// Prefer a non-temporary dir so repeated builds can be incremental.
+fn build_dir(spec: &PackageSpec) -> PathBuf {
+    let mut build_dir = dirs::cache_dir().unwrap_or_else(std::env::temp_dir);
+    build_dir.push("cargo-public-api");
+    build_dir.push("build-root-for-published-crates");
+    build_dir.push(spec.as_dir_name());
+    build_dir
+}
+
+fn manifest_for(spec: &PackageSpec) -> String {
+    format!(
+        "\
+        [package]\n\
+        name = \"crate-downloader\"\n\
+        version = \"0.1.0\"\n\
+        edition = \"2021\"\n\
+        [lib]\n\
+        path = \"lib.rs\"\n\
+        [dependencies]\n\
+        {} = \"={}\"\n
+        ",
+        spec.name, spec.version
+    )
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct PackageSpec {
+    name: String,
+    version: String,
+}
+
+impl PackageSpec {
+    fn as_dir_name(&self) -> PathBuf {
+        PathBuf::from(format!("{}-{}", self.name, self.version))
+    }
+}
+
+impl Display for PackageSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}@{}", &self.name, &self.version)
+    }
+}
+
+impl TryFrom<&str> for PackageSpec {
+    type Error = anyhow::Error;
+
+    fn try_from(spec_str: &str) -> Result<Self, Self::Error> {
+        let mut split = spec_str.split('@');
+        let name = split.next().map(str::to_owned);
+        let version = split.next().map(str::to_owned);
+
+        match (name, version) {
+            (Some(name), Some(version)) if !name.is_empty() && !version.is_empty() => Ok(Self {
+                name,
+                version,
+            }),
+            _ => Err(anyhow!("Invalid format of package spec string. Use `crate-name@version`, e.g. `rustdoc-json@0.4.0`")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_spec() {
+        assert!(PackageSpec::try_from("").is_err());
+        assert!(PackageSpec::try_from("@").is_err());
+        assert!(PackageSpec::try_from("foo@").is_err());
+        assert!(PackageSpec::try_from("@1.0.0").is_err());
+        assert_eq!(
+            PackageSpec::try_from("foo@1.0.0").unwrap(),
+            PackageSpec {
+                name: String::from("foo"),
+                version: String::from("1.0.0")
+            }
+        );
+    }
+}

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -469,6 +469,29 @@ fn diff_public_items_from_files_impl(diff_arg: &str) {
 }
 
 #[test]
+fn diff_published() {
+    diff_published_impl("--diff-published");
+}
+
+#[test]
+fn diff_published_smart_diff() {
+    diff_published_impl("--diff");
+}
+
+/// Diff against a published crate. Note that we diff two completely unrelated
+/// libraries. But for testing purposes, we only need to test that there IS a
+/// diff. It does not matter how it looks.
+fn diff_published_impl(diff_arg: &str) {
+    let mut cmd = TestCmd::new();
+    cmd.arg("--color=never");
+    cmd.arg(diff_arg);
+    cmd.arg("rustdoc-json@0.2.0");
+    cmd.assert()
+        .stdout_or_bless("./tests/expected-output/diff_published.txt")
+        .success();
+}
+
+#[test]
 fn list_public_items_from_json_file() {
     let json_file = rustdoc_json_path_for_crate("../test-apis/example_api-v0.3.0");
     let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();

--- a/cargo-public-api/tests/expected-output/diff_published.txt
+++ b/cargo-public-api/tests/expected-output/diff_published.txt
@@ -1,0 +1,54 @@
+Removed items from the public API
+=================================
+-impl !RefUnwindSafe for rustdoc_json::BuildError
+-impl !UnwindSafe for rustdoc_json::BuildError
+-impl Debug for rustdoc_json::BuildError
+-impl Display for rustdoc_json::BuildError
+-impl Error for rustdoc_json::BuildError
+-impl From<Error> for rustdoc_json::BuildError
+-impl From<Error> for rustdoc_json::BuildError
+-impl From<Error> for rustdoc_json::BuildError
+-impl Send for rustdoc_json::BuildError
+-impl Sync for rustdoc_json::BuildError
+-impl Unpin for rustdoc_json::BuildError
+-pub enum rustdoc_json::BuildError
+-pub enum variant rustdoc_json::BuildError::CargoMetadataError(cargo_metadata::Error)
+-pub enum variant rustdoc_json::BuildError::CargoTomlError(cargo_toml::Error)
+-pub enum variant rustdoc_json::BuildError::General(String)
+-pub enum variant rustdoc_json::BuildError::IoError(std::io::Error)
+-pub enum variant rustdoc_json::BuildError::VirtualManifest(PathBuf)
+-pub fn rustdoc_json::BuildError::fmt(&self, __formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result
+-pub fn rustdoc_json::BuildError::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
+-pub fn rustdoc_json::BuildError::from(source: cargo_metadata::Error) -> Self
+-pub fn rustdoc_json::BuildError::from(source: cargo_toml::Error) -> Self
+-pub fn rustdoc_json::BuildError::from(source: std::io::Error) -> Self
+-pub fn rustdoc_json::BuildError::source(&self) -> std::option::Option<&(dyn std::error::Error + 'static)>
+-pub fn rustdoc_json::build(toolchain: impl AsRef<OsStr>, manifest_path: impl AsRef<Path>) -> Result<PathBuf, rustdoc_json::BuildError>
+-pub fn rustdoc_json::build_quietly(toolchain: impl AsRef<OsStr>, manifest_path: impl AsRef<Path>) -> Result<PathBuf, rustdoc_json::BuildError>
+-pub mod rustdoc_json
+
+Changed items in the public API
+===============================
+(none)
+
+Added items to the public API
+=============================
++#[non_exhaustive] pub struct example_api::Struct
++impl Debug for example_api::Struct
++impl RefUnwindSafe for example_api::Struct
++impl RefUnwindSafe for example_api::StructV2
++impl Send for example_api::Struct
++impl Send for example_api::StructV2
++impl Sync for example_api::Struct
++impl Sync for example_api::StructV2
++impl Unpin for example_api::Struct
++impl Unpin for example_api::StructV2
++impl UnwindSafe for example_api::Struct
++impl UnwindSafe for example_api::StructV2
++pub fn example_api::Struct::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
++pub mod example_api
++pub struct example_api::StructV2
++pub struct field example_api::Struct::v1_field: usize
++pub struct field example_api::Struct::v2_field: usize
++pub struct field example_api::StructV2::field: usize
+


### PR DESCRIPTION
Closes #124 

Example usage in our own git (note how it handles a crate part of a workspace) (output shortened for brevity):

```
$ cargo run -- -p rustdoc-json --diff-published rustdoc-json@0.4.2 --verbose         
Processing "/Users/martin/.cargo/cargo-public-api_build-root-for-published-crates/rustdoc-json-0.4.2/target/doc/rustdoc_json.json"
Processing "/Users/martin/src/cargo-public-api/target/doc/rustdoc_json.json"
Removed items from the public API
=================================
-pub const fn rustdoc_json::BuildOptions::all_features(self, all_features: bool) -> Self
-pub fn rustdoc_json::BuildOptions::target_dir(self, target_dir: impl AsRef<Path>) -> Self
-pub fn rustdoc_json::BuildOptions::toolchain(self, toolchain: impl Into<Option<String>>) -> Self

Changed items in the public API
===============================
(none)

Added items to the public API
=============================
+impl Unpin for rustdoc_json::BuildOptions
+impl UnwindSafe for rustdoc_json::BuildOptions
```