### PR TITLE
public_api: Remove deprecated `fn public_api_from_rustdoc_json_str()`

### DIFF
--- a/cargo-public-api/tests/expected-output/public_api_list.txt
+++ b/cargo-public-api/tests/expected-output/public_api_list.txt
@@ -132,7 +132,6 @@ pub fn public_api::diff::PublicApiDiff::clone(&self) -> public_api::diff::Public
 pub fn public_api::diff::PublicApiDiff::eq(&self, other: &public_api::diff::PublicApiDiff) -> bool
 pub fn public_api::diff::PublicApiDiff::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
 pub fn public_api::diff::PublicApiDiff::is_empty(&self) -> bool
-pub fn public_api::public_api_from_rustdoc_json_str(rustdoc_json_str: &str, options: public_api::Options) -> public_api::Result<public_api::PublicApi>
 pub fn public_api::tokens::Token::clone(&self) -> public_api::tokens::Token
 pub fn public_api::tokens::Token::cmp(&self, other: &public_api::tokens::Token) -> $crate::cmp::Ordering
 pub fn public_api::tokens::Token::eq(&self, other: &public_api::tokens::Token) -> bool

--- a/public-api/public-api.txt
+++ b/public-api/public-api.txt
@@ -132,7 +132,6 @@ pub fn public_api::diff::PublicApiDiff::clone(&self) -> public_api::diff::Public
 pub fn public_api::diff::PublicApiDiff::eq(&self, other: &public_api::diff::PublicApiDiff) -> bool
 pub fn public_api::diff::PublicApiDiff::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
 pub fn public_api::diff::PublicApiDiff::is_empty(&self) -> bool
-pub fn public_api::public_api_from_rustdoc_json_str(rustdoc_json_str: &str, options: public_api::Options) -> public_api::Result<public_api::PublicApi>
 pub fn public_api::tokens::Token::clone(&self) -> public_api::tokens::Token
 pub fn public_api::tokens::Token::cmp(&self, other: &public_api::tokens::Token) -> $crate::cmp::Ordering
 pub fn public_api::tokens::Token::eq(&self, other: &public_api::tokens::Token) -> bool

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -113,7 +113,7 @@ impl Default for Options {
 
 /// The public API of a crate
 ///
-/// Return type of [`public_api_from_rustdoc_json_str`].
+/// Create an instance with [`PublicApi::from_rustdoc_json()`].
 ///
 /// ## Rendering the items
 ///
@@ -224,17 +224,6 @@ impl PublicApi {
     pub fn missing_item_ids(&self) -> impl Iterator<Item = &String> {
         self.missing_item_ids.iter()
     }
-}
-
-#[allow(clippy::missing_errors_doc, missing_docs)]
-#[deprecated(
-    note = "use `PublicApi::from_rustdoc_json` or `PublicApi::from_rustdoc_json_str` instead"
-)]
-pub fn public_api_from_rustdoc_json_str(
-    rustdoc_json_str: &str,
-    options: Options,
-) -> Result<PublicApi> {
-    PublicApi::from_rustdoc_json_str(rustdoc_json_str, options)
 }
 
 /// Helper to deserialize the JSON with `serde_json`, but with the recursion


### PR DESCRIPTION
It has been deprecated for over a month/since v0.20.0. We are still a young library and clients have to expect we move quite fast.