### PR TITLE
Update clap to v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,32 +124,39 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.1.3"
+version = "4.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f8c0e2a6b902acc18214e24a6935cdaf8a8e34231913d4404dcaee659f65a1"
+checksum = "0eb41c13df48950b20eb4cd0eefa618819469df1bffc49d11e8487c4ba0037e5"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
- "indexmap",
- "lazy_static",
- "os_str_bytes",
+ "clap_lex",
+ "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.1.2"
+version = "4.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d42c94ce7c2252681b5fed4d3627cc807b13dfc033246bd05d5b252399000e"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -242,12 +249,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad2f2cbe74e4752ee67218458df9c8c1c9e534cb514f6725079dc758395b98b3"
 
 [[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,16 +261,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
-dependencies = [
- "autocfg",
- "hashbrown",
 ]
 
 [[package]]
@@ -340,13 +331,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+
+[[package]]
 name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "output_vt100"
@@ -637,12 +631,6 @@ dependencies = [
  "rustdoc-json",
  "tempfile",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thiserror"

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/Enselic/cargo-public-api"
 nu-ansi-term = "0.46.0"
 anyhow = "1.0.53"
 atty = "0.2.14"
-clap = { version = "3.1.2", features = ["derive"] }
+clap = { version = "4.0.23", features = ["derive"] }
 diff = "0.1.12"
 dirs = "4.0.0"
 thiserror = "1.0.29"

--- a/cargo-public-api/src/arg_types.rs
+++ b/cargo-public-api/src/arg_types.rs
@@ -1,5 +1,5 @@
-#[derive(Copy, Clone, Debug, Eq, PartialEq, clap::ArgEnum)]
-#[clap(rename_all = "lower")]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, clap::ValueEnum)]
+#[value(rename_all = "lower")]
 pub enum DenyMethod {
     /// All forms of API diffs are denied: additions, changes, deletions.
     All,
@@ -28,8 +28,8 @@ impl DenyMethod {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, clap::ArgEnum)]
-#[clap(rename_all = "lower")]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, clap::ValueEnum)]
+#[value(rename_all = "lower")]
 pub enum Color {
     Auto,
     Never,

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -21,11 +21,11 @@ mod published_crate;
 mod toolchain;
 
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct Args {
     /// Path to `Cargo.toml`.
-    #[clap(long, name = "PATH", default_value = "Cargo.toml", parse(from_os_str))]
+    #[arg(long, value_name = "PATH", default_value = "Cargo.toml")]
     manifest_path: PathBuf,
 
     /// Raise this flag to make items part of blanket implementations such as
@@ -37,11 +37,9 @@ pub struct Args {
     /// majority of users will find the presence of these items to just
     /// constitute noise, even if they formally are part of the public API of a
     /// crate.
-    #[clap(long)]
+    #[arg(long)]
     with_blanket_implementations: bool,
 
-    /// Usage: --diff-git-checkouts <COMMIT_1> <COMMIT_2>
-    ///
     /// Allows to diff the public API across two different commits. The
     /// following steps are performed:
     ///
@@ -66,28 +64,26 @@ pub struct Args {
     /// build to succeed. If we e.g. were to git clone a temporary copy of a
     /// commit ourselves, the risk is high that additional steps are needed
     /// before a build can succeed. Such as the need to set up git submodules.
-    #[clap(long, min_values = 2, max_values = 2)]
+    #[arg(long, num_args = 2, value_names = ["COMMIT_1", "COMMIT_2"])]
     diff_git_checkouts: Option<Vec<String>>,
 
     /// Raise this flag to discard working tree changes during git checkouts when
     /// `--diff-git-checkouts` is used.
-    #[clap(long)]
+    #[arg(long)]
     force_git_checkouts: bool,
 
-    /// Usage: --diff-rustdoc-json <RUSTDOC_JSON_PATH_1> <RUSTDOC_JSON_PATH_2>
-    ///
     /// Diff the public API across two different rustdoc JSON files.
-    #[clap(long, min_values = 2, max_values = 2)]
+    #[arg(long, num_args = 2, value_names = ["RUSTDOC_JSON_PATH_1", "RUSTDOC_JSON_PATH_2"])]
     diff_rustdoc_json: Option<Vec<String>>,
 
     /// Usage: --diff-published some-crate@1.2.3
     ///
     /// Diff the current API against the API in a published version.
-    #[clap(long)]
+    #[arg(long)]
     diff_published: Option<String>,
 
     /// Automatically resolves to either `--diff-git-checkouts` or
-    /// `--diff-rustdoc-json` or `--diff-rustdoc-json` depending on if args ends
+    /// `--diff-rustdoc-json` depending on if args ends
     /// in `.json` or not, or if they contain `@`.
     ///
     /// Examples:
@@ -114,11 +110,9 @@ pub struct Args {
     ///
     ///   cargo public-api --diff-published some-crate@1.2.3
     ///
-    #[clap(long, min_values = 1, max_values = 2)]
+    #[arg(long, num_args = 1..=2, value_name = "TARGET")]
     diff: Option<Vec<String>>,
 
-    /// Usage: --rustdoc-json <RUSTDOC_JSON_PATH>
-    ///
     /// List the public API based on the given rustdoc JSON file. Try for example
     ///
     ///     rustup component add rust-docs-json --toolchain  nightly
@@ -127,7 +121,7 @@ pub struct Args {
     ///
     ///     cargo public-api --rustdoc-json ~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/share/doc/rust/json/std.json
     ///
-    #[clap(long)]
+    #[arg(long, value_name = "RUSTDOC_JSON_PATH")]
     rustdoc_json: Option<String>,
 
     /// Exit with failure if the specified API diff is detected.
@@ -142,23 +136,23 @@ pub struct Args {
     ///
     /// They can also be combined. For example, to only allow additions to the
     /// API, use `--deny=added --deny=changed`.
-    #[clap(long, arg_enum)]
+    #[arg(long, value_enum)]
     deny: Option<Vec<DenyMethod>>,
 
     /// Whether or not to use colors. You can select between "auto", "never", "always".
     /// If "auto" (the default), colors will be used if stdout is a terminal. If you pipe
     /// the output to a file, colors will be disabled by default.
-    #[clap(long, arg_enum, default_value = "auto")]
+    #[arg(long, value_enum, default_value_t = Color::Auto)]
     color: Color,
 
     /// Show detailed info about processing. For debugging purposes. The output
     /// is not stable and can change across patch versions.
-    #[clap(long, hide = true)]
+    #[arg(long, hide = true)]
     verbose: bool,
 
     /// If `true`, item paths include the so called "sorting prefix" that makes
     /// them grouped in a nice way. Only intended for debugging this tool.
-    #[clap(long, hide = true)]
+    #[arg(long, hide = true)]
     debug_sorting: bool,
 
     /// Allows you to build rustdoc JSON with a toolchain other than `nightly`.
@@ -167,31 +161,31 @@ pub struct Args {
     ///
     /// Useful if you have built a toolchain from source for example, or if you
     /// want to use a fixed toolchain in CI.
-    #[clap(long, validator = |s: &str| if !s.starts_with('+') { Ok(()) } else { Err("toolchain must not start with a `+`")} )]
+    #[arg(long, value_parser = parse_toolchain)]
     toolchain: Option<String>,
 
     /// Build for the target triple
-    #[clap(long)]
+    #[arg(long)]
     target: Option<String>,
 
     /// Space or comma separated list of features to activate
-    #[clap(long, short = 'F', min_values = 1)]
+    #[arg(long, short = 'F', num_args = 1..)]
     features: Vec<String>,
 
-    #[clap(long)]
+    #[arg(long)]
     /// Activate all available features
     all_features: bool,
 
-    #[clap(long)]
+    #[arg(long)]
     /// Do not activate the `default` feature
     no_default_features: bool,
 
     /// Package to document
-    #[clap(long, short)]
+    #[arg(long, short)]
     package: Option<String>,
 
     /// Forwarded to rustdoc JSON build command
-    #[clap(long, hide = true)]
+    #[arg(long, hide = true)]
     cap_lints: Option<String>,
 }
 
@@ -205,6 +199,15 @@ pub enum Action {
     /// Afterwards, we want to restore the original branch the user was on, to
     /// not mess up their work tree.
     RestoreBranch(String),
+}
+
+// Validate that the toolchain does not start with a `+` character.
+fn parse_toolchain(s: &str) -> Result<String, &'static str> {
+    if s.starts_with('+') {
+        Err("toolchain must not start with a `+`")
+    } else {
+        Ok(s.to_owned())
+    }
 }
 
 fn main_() -> Result<()> {
@@ -546,5 +549,16 @@ fn main() -> Result<()> {
             _ => Err(e),
         },
         result => result,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Args;
+
+    #[test]
+    fn verify_cli() {
+        use clap::CommandFactory;
+        Args::command().debug_assert();
     }
 }

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -374,7 +374,7 @@ fn deny_with_invalid_arg() {
     cmd.arg("v0.3.0");
     cmd.arg("--deny=invalid");
     cmd.assert()
-        .stderr(contains("\"invalid\" isn't a valid value"))
+        .stderr(contains("'invalid' isn't a valid value"))
         .failure();
 }
 
@@ -496,9 +496,7 @@ fn diff_public_items_missing_one_arg() {
     cmd.arg("--diff-git-checkouts");
     cmd.arg("v0.2.0");
     cmd.assert()
-        .stderr(contains(
-            "requires at least 2 values but only 1 was provided",
-        ))
+        .stderr(contains("requires 2 values, but 1 was provided"))
         .failure();
 }
 


### PR DESCRIPTION
Noticed that the project is still using clap v3, and tried updating it to v4. I hope I captured all the special configs right, some local tests all worked out fine.