### PR TITLE
Print -h and --help as part of CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: RUSTDOCFLAGS='--deny warnings' cargo doc --locked --no-deps --document-private-items
+      - run: cargo run --locked -- -h
+      - run: cargo run --locked -- --help
 
   cargo-clippy:
     name: cargo clippy -- --deny clippy::all --deny clippy::pedantic ...

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v2
       - run: RUSTDOCFLAGS='--deny warnings' cargo doc --locked --no-deps --document-private-items
       - run: cargo run --locked -- -h
       - run: cargo run --locked -- --help
@@ -39,6 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v2
       - run: scripts/cargo-clippy.sh
 
   cargo-test:
@@ -70,6 +72,7 @@ jobs:
         with:
           toolchain: nightly
           profile: minimal
+      - uses: Swatinem/rust-cache@v2
       - run: |
           scripts/check-public-apis.sh
 


### PR DESCRIPTION
So that it is easier to review the impact an PR has on the help texts.