### PR TITLE
Allow omitting package name when diffing against crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "atty",
+ "cargo-manifest",
  "cargo_metadata",
  "clap",
  "diff",

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -15,6 +15,7 @@ repository = "https://github.com/Enselic/cargo-public-api"
 nu-ansi-term = "0.46.0"
 anyhow = "1.0.53"
 atty = "0.2.14"
+cargo-manifest = "0.4.0"
 clap = { version = "4.0.23", features = ["derive", "wrap_help"] }
 diff = "0.1.12"
 dirs = "4.0.0"

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -467,22 +467,43 @@ fn diff_public_items_from_files_impl(diff_arg: &str) {
 
 #[test]
 fn diff_published() {
-    diff_published_impl("--diff-published");
+    diff_published_impl("--diff-published", "example_api@0.1.0");
 }
 
 #[test]
 fn diff_published_smart_diff() {
-    diff_published_impl("--diff");
+    diff_published_impl("--diff", "example_api@0.1.0");
 }
 
-/// Diff against a published crate. Note that we diff two completely unrelated
-/// libraries. But for testing purposes, we only need to test that there IS a
-/// diff. It does not matter how it looks.
-fn diff_published_impl(diff_arg: &str) {
+#[test]
+fn diff_published_fallback() {
+    diff_published_impl("--diff-published", "@0.1.0");
+}
+
+#[test]
+fn diff_published_smart_diff_fallback() {
+    diff_published_impl("--diff", "@0.1.0");
+}
+
+/// Diff against a published crate.
+fn diff_published_impl(diff_arg: &str, spec: &str) {
     let mut cmd = TestCmd::new();
     cmd.arg("--color=never");
     cmd.arg(diff_arg);
-    cmd.arg("example_api@0.1.0");
+    cmd.arg(spec);
+    cmd.assert()
+        .stdout_or_bless("./tests/expected-output/diff_published.txt")
+        .success();
+}
+
+#[test]
+fn diff_published_explicit_package() {
+    let mut cmd = TestCmd::new();
+    cmd.arg("--color=never");
+    cmd.arg("-p");
+    cmd.arg("example_api");
+    cmd.arg("--diff-published");
+    cmd.arg("@0.1.0");
     cmd.assert()
         .stdout_or_bless("./tests/expected-output/diff_published.txt")
         .success();


### PR DESCRIPTION
So instead of `--diff-published crate-name@1.2.3` you can now just do `--diff-published @1.2.3`. The `crate-name` part will be taken from `Cargo.toml` (or `--package ...` arg).