### PR TITLE
Turn `--diff` into just `diff` (make it a subcommand)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ which will print the public API of `regex` with one line per public item in the 
 
 ## Diff the Public API
 
-To diff the API between say **0.2.2** and **0.2.3** of `regex`, use `--diff-git-checkouts 0.2.2 0.2.3` while standing in the git repo. Like this:
+To diff the API between say **0.2.2** and **0.2.3** of `regex`, use `diff --git-checkouts 0.2.2 0.2.3` while standing in the git repo. Like this:
 
 ```bash
-cargo public-api --diff-git-checkouts 0.2.2 0.2.3
+cargo public-api diff --git-checkouts 0.2.2 0.2.3
 ```
 
 and the API diff will be printed:
@@ -50,7 +50,7 @@ and the API diff will be printed:
 When you make changes to your library you often want to make sure that you do not accidentally change the public API of your library, or that the API change you are making looks like you expect. For this use case, first git commit your work in progress, and then run
 
 ```bash
-cargo public-api --diff-git-checkouts origin/main your-current-branch
+cargo public-api diff --git-checkouts origin/main your-current-branch
 ```
 
 which will print the diff of your public API changes compared to `origin/main`.
@@ -61,10 +61,10 @@ This tool can be put to good use in CI pipelines to e.g. help you make sure your
 
 ### … Against Published Version
 
-Before you `cargo publish` a new version of your crate, you can diff the public API of your local code against the public API of the version you last published. Use the `--diff-published` arg for that. Like this:
+Before you `cargo publish` a new version of your crate, you can diff the public API of your local code against the public API of the version you last published. Use the `diff --published` arg for that. Like this:
 
 ```bash
-cargo public-api --diff-published regex@0.2.2
+cargo public-api diff --published regex@0.2.2
 ```
 
 ## Expected Output

--- a/cargo-public-api/src/published_crate.rs
+++ b/cargo-public-api/src/published_crate.rs
@@ -31,8 +31,8 @@ pub fn build_rustdoc_json(package_spec_str: &str, args: &Args) -> Result<PathBuf
 
 /// When diffing against a published crate, we want to allow the user to not
 /// specify the package name. Instead, we want to support to figure that out for
-/// the user. So instead of doing `--diff-published crate-name@1.2.3` they can
-/// just do `--diff-published @1.2.3`. This helper function figures out what
+/// the user. So instead of doing `diff --published crate-name@1.2.3` they can
+/// just do `diff --published @1.2.3`. This helper function figures out what
 /// package name to use in this case.
 fn package_name_from_args(args: &Args) -> Option<String> {
     if let Some(package) = &args.package {

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -149,20 +149,23 @@ fn virtual_manifest_error() {
 
 #[test]
 fn diff_public_items() {
-    diff_public_items_impl("--diff-git-checkouts");
+    diff_public_items_impl(Some("--git-checkouts"));
 }
 
 #[test]
 fn diff_public_items_smart_diff() {
-    diff_public_items_impl("--diff");
+    diff_public_items_impl(None);
 }
 
-fn diff_public_items_impl(diff_arg: &str) {
+fn diff_public_items_impl(diff_arg: Option<&str>) {
     let mut cmd = TestCmd::new();
     let test_repo_path = cmd.test_repo_path().to_owned();
     let branch_before = git_utils::current_branch(&test_repo_path).unwrap().unwrap();
     cmd.arg("--color=never");
-    cmd.arg(diff_arg);
+    cmd.arg("diff");
+    if let Some(diff_arg) = diff_arg {
+        cmd.arg(diff_arg);
+    }
     cmd.arg("v0.2.0");
     cmd.arg("v0.3.0");
     cmd.assert()
@@ -190,7 +193,8 @@ fn diff_public_items_detached_head() {
     let mut cmd = cargo_public_api_cmd_simplified();
     cmd.current_dir(path);
     cmd.arg("--color=never");
-    cmd.arg("--diff-git-checkouts");
+    cmd.arg("diff");
+    cmd.arg("--git-checkouts");
     cmd.arg("v0.2.0");
     cmd.arg("v0.3.0");
     cmd.assert()
@@ -211,7 +215,8 @@ fn diff_public_items_with_dirty_tree_fails() {
     let mut cmd = cargo_public_api_cmd_simplified();
     cmd.current_dir(&test_repo.path);
     cmd.arg("--color=never");
-    cmd.arg("--diff-git-checkouts");
+    cmd.arg("diff");
+    cmd.arg("--git-checkouts");
     cmd.arg("v0.2.0");
     cmd.arg("v0.3.0");
     cmd.assert()
@@ -231,7 +236,8 @@ fn diff_public_items_with_dirty_tree_succeedes_with_force_option() {
     let mut cmd = cargo_public_api_cmd_simplified();
     cmd.current_dir(&test_repo.path);
     cmd.arg("--color=never");
-    cmd.arg("--diff-git-checkouts");
+    cmd.arg("diff");
+    cmd.arg("--git-checkouts");
     cmd.arg("v0.2.0");
     cmd.arg("v0.3.0");
     cmd.arg("--force-git-checkouts");
@@ -255,7 +261,8 @@ fn diff_public_items_relative_refs() {
     let mut cmd = cargo_public_api_cmd_simplified();
     cmd.current_dir(path);
     cmd.arg("--color=never");
-    cmd.arg("--diff-git-checkouts");
+    cmd.arg("diff");
+    cmd.arg("--git-checkouts");
     cmd.arg("HEAD^");
     cmd.arg("HEAD");
     cmd.assert()
@@ -297,14 +304,15 @@ fn test_deny_not_allowed(args: impl IntoIterator<Item = &'static str>) {
         cmd.arg(arg);
     }
     cmd.assert()
-        .stderr(contains("`--deny` can only be used when diffing"))
+        .stderr(contains("Found argument \'--deny\' which wasn\'t expected"))
         .failure();
 }
 
 #[test]
 fn deny_without_diff() {
     let mut cmd = TestCmd::new();
-    cmd.arg("--diff-git-checkouts");
+    cmd.arg("diff");
+    cmd.arg("--git-checkouts");
     cmd.arg("v0.1.0");
     cmd.arg("v0.1.1");
     cmd.arg("--deny=all");
@@ -314,7 +322,8 @@ fn deny_without_diff() {
 #[test]
 fn deny_with_diff() {
     let mut cmd = TestCmd::new();
-    cmd.arg("--diff-git-checkouts");
+    cmd.arg("diff");
+    cmd.arg("--git-checkouts");
     cmd.arg("v0.1.0");
     cmd.arg("v0.2.0");
     cmd.arg("--deny=all");
@@ -326,7 +335,8 @@ fn deny_with_diff() {
 #[test]
 fn deny_added_with_diff() {
     let mut cmd = TestCmd::new();
-    cmd.arg("--diff-git-checkouts");
+    cmd.arg("diff");
+    cmd.arg("--git-checkouts");
     cmd.arg("v0.1.0");
     cmd.arg("v0.2.0");
     cmd.arg("--deny=added");
@@ -338,7 +348,8 @@ fn deny_added_with_diff() {
 #[test]
 fn deny_changed_with_diff() {
     let mut cmd = TestCmd::new();
-    cmd.arg("--diff-git-checkouts");
+    cmd.arg("diff");
+    cmd.arg("--git-checkouts");
     cmd.arg("v0.1.0");
     cmd.arg("v0.2.0");
     cmd.arg("--deny=changed");
@@ -348,7 +359,8 @@ fn deny_changed_with_diff() {
 #[test]
 fn deny_removed_with_diff() {
     let mut cmd = TestCmd::new();
-    cmd.arg("--diff-git-checkouts");
+    cmd.arg("diff");
+    cmd.arg("--git-checkouts");
     cmd.arg("v0.2.0");
     cmd.arg("v0.3.0");
     cmd.arg("--deny=removed");
@@ -362,7 +374,8 @@ fn deny_removed_with_diff() {
 #[test]
 fn deny_with_invalid_arg() {
     let mut cmd = TestCmd::new();
-    cmd.arg("--diff-git-checkouts");
+    cmd.arg("diff");
+    cmd.arg("--git-checkouts");
     cmd.arg("v0.2.0");
     cmd.arg("v0.3.0");
     cmd.arg("--deny=invalid");
@@ -381,7 +394,8 @@ fn diff_public_items_with_manifest_path() {
         &test_repo.path.path().to_string_lossy()
     ));
     cmd.arg("--color=never");
-    cmd.arg("--diff-git-checkouts");
+    cmd.arg("diff");
+    cmd.arg("--git-checkouts");
     cmd.arg("v0.2.0");
     cmd.arg("v0.3.0");
     cmd.assert()
@@ -395,7 +409,8 @@ fn diff_public_items_without_git_root() {
     cmd.arg("--manifest-path");
     cmd.arg("/does/not/exist/Cargo.toml");
     cmd.arg("--color=never");
-    cmd.arg("--diff-git-checkouts");
+    cmd.arg("diff");
+    cmd.arg("--git-checkouts");
     cmd.arg("v0.2.0");
     cmd.arg("v0.3.0");
     cmd.assert()
@@ -409,7 +424,8 @@ fn diff_public_items_without_git_root() {
 fn diff_public_items_with_color() {
     let mut cmd = TestCmd::new();
     cmd.arg("--color=always");
-    cmd.arg("--diff-git-checkouts");
+    cmd.arg("diff");
+    cmd.arg("--git-checkouts");
     cmd.arg("v0.1.0");
     cmd.arg("v0.2.0");
     cmd.assert()
@@ -430,14 +446,14 @@ fn list_public_items_with_color() {
 
 #[test]
 fn diff_public_items_from_files() {
-    diff_public_items_from_files_impl("--diff-rustdoc-json");
+    diff_public_items_from_files_impl(Some("--rustdoc-json"));
 }
 #[test]
 fn diff_public_items_from_files_smart_diff() {
-    diff_public_items_from_files_impl("--diff");
+    diff_public_items_from_files_impl(None);
 }
 
-fn diff_public_items_from_files_impl(diff_arg: &str) {
+fn diff_public_items_from_files_impl(diff_arg: Option<&str>) {
     // Create independent build dirs so all tests can run in parallel
     let build_dir = tempdir().unwrap();
     let build_dir2 = tempdir().unwrap();
@@ -445,7 +461,10 @@ fn diff_public_items_from_files_impl(diff_arg: &str) {
     let old = rustdoc_json_path_for_crate("../test-apis/example_api-v0.1.0", &build_dir);
     let new = rustdoc_json_path_for_crate("../test-apis/example_api-v0.2.0", &build_dir2);
     let mut cmd = cargo_public_api_cmd_simplified();
-    cmd.arg(diff_arg);
+    cmd.arg("diff");
+    if let Some(diff_arg) = diff_arg {
+        cmd.arg(diff_arg);
+    }
     cmd.arg(old);
     cmd.arg(new);
     cmd.assert()
@@ -455,29 +474,32 @@ fn diff_public_items_from_files_impl(diff_arg: &str) {
 
 #[test]
 fn diff_published() {
-    diff_published_impl("--diff-published", "example_api@0.1.0");
+    diff_published_impl(Some("--published"), "example_api@0.1.0");
 }
 
 #[test]
 fn diff_published_smart_diff() {
-    diff_published_impl("--diff", "example_api@0.1.0");
+    diff_published_impl(None, "example_api@0.1.0");
 }
 
 #[test]
 fn diff_published_fallback() {
-    diff_published_impl("--diff-published", "@0.1.0");
+    diff_published_impl(Some("--published"), "@0.1.0");
 }
 
 #[test]
 fn diff_published_smart_diff_fallback() {
-    diff_published_impl("--diff", "@0.1.0");
+    diff_published_impl(None, "@0.1.0");
 }
 
 /// Diff against a published crate.
-fn diff_published_impl(diff_arg: &str, spec: &str) {
+fn diff_published_impl(diff_arg: Option<&str>, spec: &str) {
     let mut cmd = TestCmd::new();
     cmd.arg("--color=never");
-    cmd.arg(diff_arg);
+    cmd.arg("diff");
+    if let Some(diff_arg) = diff_arg {
+        cmd.arg(diff_arg);
+    }
     cmd.arg(spec);
     cmd.assert()
         .stdout_or_bless("./tests/expected-output/diff_published.txt")
@@ -490,7 +512,8 @@ fn diff_published_explicit_package() {
     cmd.arg("--color=never");
     cmd.arg("-p");
     cmd.arg("example_api");
-    cmd.arg("--diff-published");
+    cmd.arg("diff");
+    cmd.arg("--published");
     cmd.arg("@0.1.0");
     cmd.assert()
         .stdout_or_bless("./tests/expected-output/diff_published.txt")
@@ -514,10 +537,11 @@ fn list_public_items_from_json_file() {
 #[test]
 fn diff_public_items_missing_one_arg() {
     let mut cmd = TestCmd::new();
-    cmd.arg("--diff-git-checkouts");
+    cmd.arg("diff");
+    cmd.arg("--git-checkouts");
     cmd.arg("v0.2.0");
     cmd.assert()
-        .stderr(contains("requires 2 values, but 1 was provided"))
+        .stderr(contains("Missing second commit!"))
         .failure();
 }
 
@@ -569,7 +593,7 @@ fn assert_presence_of_args_in_help(mut cmd: Command) {
     cmd.assert()
         .stdout(contains("--simplified"))
         .stdout(contains("--manifest-path"))
-        .stdout(contains("--diff-git-checkouts"))
+        // FIXME: Requires `cargo public-api diff --help`: .stdout(contains("--git-checkouts"))
         .success();
 }
 

--- a/docs/CI-EXAMPLES.md
+++ b/docs/CI-EXAMPLES.md
@@ -6,7 +6,7 @@ This document describes different ways to make use of `cargo public-api` in CI. 
 
 ### With a Public API Set in Stone
 
-If the API is set in stone, you can use the `--deny=all` flag together with `--diff-git-checkouts` to deny all kinds of changes (additions, changes, removals) to your public API. A GitHub Actions job to do this for PRs would look something like this:
+If the API is set in stone, you can use the `--deny=all` flag together with `diff ...` to deny all kinds of changes (additions, changes, removals) to your public API. A GitHub Actions job to do this for PRs would look something like this:
 
 ```yaml
 jobs:
@@ -26,7 +26,7 @@ jobs:
 
       # Install and run cargo public-api and deny any API diff
       - run: cargo install cargo-public-api
-      - run: cargo public-api --diff-git-checkouts ${GITHUB_BASE_REF} ${GITHUB_HEAD_REF} --deny=all
+      - run: cargo public-api diff --git-checkouts ${GITHUB_BASE_REF} ${GITHUB_HEAD_REF} --deny=all
 ```
 
 See `cargo public-api --help` for more variants of `--deny`.

--- a/scripts/multi-diff.sh
+++ b/scripts/multi-diff.sh
@@ -11,6 +11,6 @@ shift
 
 for new_version in $@; do
     echo "$base_version -> $new_version"
-    cargo public-api --diff-git-checkouts $base_version $new_version 2>/dev/null || echo "(Failed)"
+    cargo public-api diff --git-checkouts $base_version $new_version 2>/dev/null || echo "(Failed)"
     base_version=$new_version
 done


### PR DESCRIPTION
This passes CI and is a rather complete solution, but I still would like to call it a prototype.

This changes from

    cargo public-api --diff...

to

    cargo public-api diff...

Examples: Old vs new:
---

Diffing checkouts:

    cargo public-api --diff-git-checkouts v0.1.0 v0.2.0
    cargo public-api diff --git-checkouts v0.1.0 v0.2.0

Diffing against crates.io, short form:

    cargo public-api --diff @0.1.0
    cargo public-api diff @0.1.0

Pros of subcommand:
---

* Slightly easier to write

* clap enforces that `--deny` can only be used when diffing

Cons:
---

* Generic args can't be used after `diff`. This works: `cargo public-api --diff @0.1.0 --simplified`, but this does not work: `cargo public-api diff @0.1.0 --simplified`

* `cargo public-api --help` does not show `diff --help`. Instead `cargo public-api diff --help` must be invoked.

TODO:
---
* Would be good to keep old commands working, but printing a deprecation warning and referring to new syntax
* Tweak `--help` and `diff --help` output
* Decide if we want this. I think I am in favor of doing this.