### PR TITLE
Bump minimum nightly version to `nightly-2022-11-22`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "rustdoc-types"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7745b68b43d89a088d2d270be09f54f948e587fc540cb15e3d3b75cb327a01c3"
+checksum = "fd62550e9cd1e785b22928008446bdecc4e5b093abecc74186cbf45dee5adf12"
 dependencies = [
  "serde",
 ]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ List and diff the public API of Rust library crates between releases and commits
 # Install cargo-public-api with a recent regular stable Rust toolchain
 cargo install cargo-public-api
 
-# Ensure nightly-2022-09-28 or later is installed so cargo-public-api can build rustdoc JSON for you
+# Ensure nightly-2022-11-22 or later is installed so cargo-public-api can build rustdoc JSON for you
 rustup install nightly
 ```
 
@@ -109,7 +109,8 @@ cargo public-api --simplified
 
 | cargo-public-api | Understands the rustdoc JSON output of  |
 | ---------------- | --------------------------------------- |
-| 0.20.x — 0.25.x  | nightly-2022-09-28 —                    |
+| 0.26.x           | nightly-2022-11-22 —                    |
+| 0.20.x — 0.25.x  | nightly-2022-09-28 — nightly-2022-11-21 |
 | 0.19.x           | nightly-2022-09-08 — nightly-2022-09-27 |
 | 0.18.x           | nightly-2022-09-07                      |
 | 0.17.x           | nightly-2022-09-06                      |

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -23,7 +23,7 @@ features = ["unbounded_depth"]
 
 [dependencies.rustdoc-types]
 # path = "/Users/martin/src/rustdoc-types"
-version = "0.18.0"
+version = "0.19.0"
 
 [dev-dependencies]
 anyhow = "1.0.68"

--- a/public-api/README.md
+++ b/public-api/README.md
@@ -16,7 +16,7 @@ The library comes with a thin bin wrapper that can be used to explore the capabi
 # Build and install the thin bin wrapper with a recent stable Rust toolchain
 cargo install public-api
 
-# Install nightly-2022-09-28 or later so you can build up-to-date rustdoc JSON files
+# Install nightly-2022-11-22 or later so you can build up-to-date rustdoc JSON files
 rustup install nightly
 ```
 

--- a/public-api/src/item_processor.rs
+++ b/public-api/src/item_processor.rs
@@ -285,7 +285,6 @@ pub(crate) fn sorting_prefix(item: &Item) -> u8 {
         ItemEnum::AssocConst { .. } => 16,
 
         ItemEnum::Function(_) => 17,
-        ItemEnum::Method(_) => 18,
 
         ItemEnum::Typedef(_) => 19,
 

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -68,7 +68,7 @@ pub use public_item::PublicItem;
 /// The rustdoc JSON format is still changing, so every now and then we update
 /// this library to support the latest format. If you use this version of
 /// nightly or later, you should be fine.
-pub const MINIMUM_RUSTDOC_JSON_VERSION: &str = "nightly-2022-09-28";
+pub const MINIMUM_RUSTDOC_JSON_VERSION: &str = "nightly-2022-11-22";
 
 /// Contains various options that you can pass to [`PublicApi::from_rustdoc_json_str`].
 #[derive(Copy, Clone, Debug)]

--- a/public-api/src/render.rs
+++ b/public-api/src/render.rs
@@ -100,12 +100,6 @@ impl<'c> RenderingContext<'c> {
                 &inner.generics,
                 &inner.header,
             ),
-            ItemEnum::Method(inner) => self.render_function(
-                self.render_path(item_path),
-                &inner.decl,
-                &inner.generics,
-                &inner.header,
-            ),
             ItemEnum::Trait(trait_) => self.render_trait(trait_, item_path),
             ItemEnum::TraitAlias(_) => self.render_simple(&["trait", "alias"], item_path),
             ItemEnum::Impl(impl_) => self.render_impl(impl_, item_path),
@@ -235,8 +229,7 @@ impl<'c> RenderingContext<'c> {
     fn render_path(&self, path: &[NameableItem]) -> Vec<Token> {
         let mut output = vec![];
         for item in path {
-            let token_fn = if matches!(item.item.inner, ItemEnum::Function(_) | ItemEnum::Method(_))
-            {
+            let token_fn = if matches!(item.item.inner, ItemEnum::Function(_)) {
                 Token::function
             } else if matches!(
                 item.item.inner,


### PR DESCRIPTION
Adapt to  https://github.com/rust-lang/rust/pull/104499 being merged

This PR should fail with todays nightly but pass with tomorrows nightly