### PR TITLE
Build more tests with independent target dirs

### DIFF
--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -162,6 +162,12 @@ pub struct Args {
     #[arg(long, hide = true)]
     debug_sorting: bool,
 
+    /// Put rustdoc JSON build artifacts in the specified dir instead of in
+    /// `./target`. Option hidden by default because it will typically not be
+    /// needed by users. Mainly useful to allow tests to run in parallel.
+    #[arg(long, value_name = "PATH", hide = true)]
+    target_dir: Option<PathBuf>,
+
     /// Build rustdoc JSON with a toolchain other than `nightly`.
     ///
     /// Consider using `cargo +toolchain public-api` instead.
@@ -481,6 +487,9 @@ fn builder_from_args(args: &Args) -> rustdoc_json::Builder {
         .all_features(args.all_features)
         .no_default_features(args.no_default_features)
         .features(&args.features);
+    if let Some(target_dir) = &args.target_dir {
+        builder = builder.target_dir(target_dir.clone());
+    }
     if let Some(target) = &args.target {
         builder = builder.target(target.clone());
     }

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -91,6 +91,13 @@ cargo llvm-cov --html && open ../target/llvm-cov/html/index.html
 
 Which requires you to have done `cargo install cargo-llvm-cov` first.
 
+## Finding flaky tests
+
+Run this (WARNING: destructive) command for a while and then scroll back and look at the output. It will find flakiness both in the case of requiring a clean build, and in case of requiring an incremental build. You can also remove the `git clean` of course.
+```bash
+while true ; do git clean -xdf ; cargo --quiet test ; cargo --quiet test ; sleep 1 ; done | grep -v -e '0 failed' -e 'running [0-9]\+ test'
+```
+
 # Maintainer guidelines
 
 Please see [MAINTAINER.md](./MAINTAINER.md).

--- a/rustdoc-json/CHANGELOG.md
+++ b/rustdoc-json/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.7.1
+* Add `Builder::clear_target_dir()`
+
 ## v0.7.0
 * Remove deprecated `BuildOptions` and `fn build(...)`. Use `Builder` and `Builder::build()` instead.
 * Use `cargo-manifest` to parse Cargo manifests

--- a/rustdoc-json/public-api.txt
+++ b/rustdoc-json/public-api.txt
@@ -47,6 +47,7 @@ impl rustdoc_json::Builder
 pub const fn rustdoc_json::Builder::all_features(self, all_features: bool) -> Self
 pub fn rustdoc_json::Builder::build(self) -> core::result::Result<std::path::PathBuf, rustdoc_json::BuildError>
 pub fn rustdoc_json::Builder::cap_lints(self, cap_lints: core::option::Option<impl core::convert::AsRef<str>>) -> Self
+pub fn rustdoc_json::Builder::clear_target_dir(self) -> Self
 pub fn rustdoc_json::Builder::features<I: core::iter::traits::collect::IntoIterator<Item = S>, S: core::convert::AsRef<str>>(self, features: I) -> Self
 pub fn rustdoc_json::Builder::manifest_path(self, manifest_path: impl core::convert::AsRef<std::path::Path>) -> Self
 pub const fn rustdoc_json::Builder::no_default_features(self, no_default_features: bool) -> Self

--- a/rustdoc-json/src/build.rs
+++ b/rustdoc-json/src/build.rs
@@ -196,6 +196,13 @@ impl Builder {
         self
     }
 
+    /// Clear a target dir previously set with [`Self::target_dir`].
+    #[must_use]
+    pub fn clear_target_dir(mut self) -> Self {
+        self.target_dir = None;
+        self
+    }
+
     /// Whether or not to pass `--quiet` to `cargo rustdoc`. Default: `false`
     #[must_use]
     pub const fn quiet(mut self, quiet: bool) -> Self {


### PR DESCRIPTION
Before this commit many tests share target dirs, which is bad for parallelism because of `./target/debug/.cargo-lock`.

On my 16-core machine this commit makes

    time cargo test -p cargo-public-api

take 2.7s instead of 3.3s, and fixes all (knock on wood) test flakiness.