### PR TITLE
Move some tests from `test-invocation-variants.sh` to `cargo test`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,6 +45,7 @@ jobs:
 
   cargo-test:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - macos-latest

--- a/cargo-public-api/tests/expected-output/test_repo_api_latest_not_simplified.txt
+++ b/cargo-public-api/tests/expected-output/test_repo_api_latest_not_simplified.txt
@@ -1,0 +1,50 @@
+pub mod example_api
+#[non_exhaustive] pub struct example_api::Struct
+pub struct field example_api::Struct::v1_field: usize
+pub struct field example_api::Struct::v2_field: usize
+impl core::fmt::Debug for example_api::Struct
+pub fn example_api::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::panic::unwind_safe::RefUnwindSafe for example_api::Struct
+impl core::marker::Send for example_api::Struct
+impl core::marker::Sync for example_api::Struct
+impl core::marker::Unpin for example_api::Struct
+impl core::panic::unwind_safe::UnwindSafe for example_api::Struct
+impl<T> core::any::Any for example_api::Struct where T: 'static + core::marker::Sized
+pub fn example_api::Struct::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for example_api::Struct where T: core::marker::Sized
+pub fn example_api::Struct::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for example_api::Struct where T: core::marker::Sized
+pub fn example_api::Struct::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for example_api::Struct
+pub fn example_api::Struct::from(t: T) -> T
+impl<T, U> core::convert::Into<U> for example_api::Struct where U: core::convert::From<T>
+pub fn example_api::Struct::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for example_api::Struct where U: core::convert::Into<T>
+pub type example_api::Struct::Error = core::convert::Infallible
+pub fn example_api::Struct::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for example_api::Struct where U: core::convert::TryFrom<T>
+pub type example_api::Struct::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn example_api::Struct::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+pub struct example_api::StructV2
+pub struct field example_api::StructV2::field: usize
+impl core::panic::unwind_safe::RefUnwindSafe for example_api::StructV2
+impl core::marker::Send for example_api::StructV2
+impl core::marker::Sync for example_api::StructV2
+impl core::marker::Unpin for example_api::StructV2
+impl core::panic::unwind_safe::UnwindSafe for example_api::StructV2
+impl<T> core::any::Any for example_api::StructV2 where T: 'static + core::marker::Sized
+pub fn example_api::StructV2::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for example_api::StructV2 where T: core::marker::Sized
+pub fn example_api::StructV2::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for example_api::StructV2 where T: core::marker::Sized
+pub fn example_api::StructV2::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for example_api::StructV2
+pub fn example_api::StructV2::from(t: T) -> T
+impl<T, U> core::convert::Into<U> for example_api::StructV2 where U: core::convert::From<T>
+pub fn example_api::StructV2::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for example_api::StructV2 where U: core::convert::Into<T>
+pub type example_api::StructV2::Error = core::convert::Infallible
+pub fn example_api::StructV2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for example_api::StructV2 where U: core::convert::TryFrom<T>
+pub type example_api::StructV2::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn example_api::StructV2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>

--- a/scripts/test-invocation-variants.sh
+++ b/scripts/test-invocation-variants.sh
@@ -75,40 +75,8 @@ assert_progress_and_output() {
 
 # Now we are ready to run the actual tests
 
-# Make sure we can conveniently run the tool from the source dir. We want the
-# tool to print progress when it builds rustdoc JSON. The presence of
-# "Documenting comprehensive_api" on stderr is what we use to test if that is
-# the case. We assume that if we can pass args, it will also work to not have
-# any args at all. This assumptions allows us to run tests fast. We do arg-less
-# tests further down.
-assert_progress_and_output \
-    "cargo run -- --manifest-path test-apis/comprehensive_api/Cargo.toml --simplified" \
-    public-api/tests/expected-output/comprehensive_api.txt \
-    "Documenting comprehensive_api"
-
 # Install the tool
 cargo install --debug --path cargo-public-api
-
-# Make sure we can run the tool on the current directory as a cargo sub-command
-(
-    cd test-apis/comprehensive_api
-    assert_progress_and_output \
-        "cargo public-api --simplified" \
-        ../../public-api/tests/expected-output/comprehensive_api.txt \
-        "Documenting comprehensive_api"
-)
-
-# Make sure we can run the tool on an external directory as a cargo sub-command
-assert_progress_and_output \
-    "cargo public-api --manifest-path test-apis/comprehensive_api/Cargo.toml --simplified" \
-    public-api/tests/expected-output/comprehensive_api.txt \
-    "Documenting comprehensive_api"
-
-# Make sure cargo subcommand args filtering of 'public-api' is not too aggressive
-assert_progress_and_output \
-    "cargo public-api -p public-api --simplified " \
-    cargo-public-api/tests/expected-output/public_api_list.txt \
-    "Documenting public-api"
 
 # Make sure we can run the tool with MINIMUM_RUSTDOC_JSON_VERSION. Test against
 # comprehensive_api, because we want any rustdoc JSON format incompatibilities

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -36,3 +36,21 @@ fn rustdoc_json_path_for_crate_impl(test_crate: &str, target_dir: Option<&Path>)
 
     builder.build().unwrap()
 }
+
+/// Adds `./target/debug` to `PATH` so that the subcommand `cargo public-api`
+/// starts working (since `./target/debug` contains the `cargo-public-api`
+/// binary).
+pub fn add_target_debug_to_path() {
+    let mut bin_dir = std::env::current_exe().unwrap(); // ".../target/debug/deps/cargo_public_api_bin_tests-d0f2f926b349fbb9"
+    bin_dir.pop(); // Pop "cargo_public_api_bin_tests-d0f2f926b349fbb9"
+    bin_dir.pop(); // Pop "deps"
+    add_to_path(bin_dir); // ".../target/debug"
+}
+
+fn add_to_path(dir: PathBuf) {
+    let mut path = std::env::var_os("PATH").unwrap();
+    let mut dirs: Vec<_> = std::env::split_paths(&path).collect();
+    dirs.insert(0, dir);
+    path = std::env::join_paths(dirs).unwrap();
+    std::env::set_var("PATH", path);
+}


### PR DESCRIPTION
Remove the `cargo run` test, because it is equivalent to running `cargo-public-api`, which we already have plenty of tests for.

The other ones we port to `cargo test` after adding `./target/debug` to `PATH` in the tests.

For me this makes `./scripts/run-ci-locally.sh` finish in ~12s instead of ~16s.

(This is a smaller version of https://github.com/Enselic/cargo-public-api/pull/215 which I got some problems with. I still want to merge this fix though.)