### PR TITLE
Auto-create PR with blessed output from latest nightly

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,18 +1,12 @@
 name: CI
 
 on:
-  workflow_call: # From .github/workflows/Release.yml
+  workflow_call: # From .github/workflows/Release.yml, .github/workflows/Nightly.yml
   workflow_dispatch:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-  # The purpose of running every night is to detect when a change to
-  # https://github.com/rust-lang/rust/tree/master/src/rustdoc-json-types
-  # requires that we release a new version of public-api to be compatible with
-  # the latest nightly toolchain
-  schedule:
-    - cron: '33 3 * * *'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -3,7 +3,7 @@ name: Nightly
 on:
   workflow_dispatch:
   schedule:
-    - cron: '44 4 * * *'
+    - cron: '33 3 * * *'
 
 env:
   CARGO_TERM_COLOR: always
@@ -16,3 +16,25 @@ jobs:
     steps:
     - run: cargo install public-api
     - run: cargo install cargo-public-api
+
+  # The purpose of running every night is to detect when a change to
+  # https://github.com/rust-lang/rust/tree/master/src/rustdoc-json-types
+  # requires that we release a new version of public-api to be compatible with
+  # the latest nightly toolchain
+  ci:
+    uses: ./.github/workflows/CI.yml
+
+  # If Rust nightly changes output, auto-create a PR with the new blessed
+  # output, which maintainers can conveniently merge after manual review
+  auto-bless:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        profile: minimal
+    - uses: Swatinem/rust-cache@v2
+    - run: ./scripts/auto-bless.sh
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/auto-bless.sh
+++ b/scripts/auto-bless.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -o nounset -o pipefail -o errexit
+
+# Bless
+./scripts/bless.sh
+
+# If nothing changed there is nothing more to do
+if [ -z "$(git status --porcelain)" ]; then
+    echo "Nothing to bless so nothing to do, exiting"
+    exit 0
+fi
+
+# Figure out name of current nightly
+current_nightly=$(echo nightly-$(date +%Y-%m-%d))
+
+# Prepare a branch to create a PR from
+# With `date +%s` so that repeated runs don't get the same branch name
+branch_name="auto-bless-${current_nightly}-$(date +%s)"
+git checkout -b "${branch_name}"
+
+# Commit the blessed changes and push the branch
+title="Bless output with ${current_nightly}"
+git config user.email "junta-pixlar0l@icloud.com"
+git config user.name "EnselicCICD"
+git commit -a -m "${title}"
+git push origin "${branch_name}"
+
+# Create a PR from the newly pushed branch
+gh pr create \
+    --head "${branch_name}" \
+    --title "${title}" \
+    --body "" \
+    --label "category-exclude" \


### PR DESCRIPTION
Closes #217

Also change CI.yml to trigger its nightly build via Nightly.yml rather than by itself, to make things more neatly organized.