### PR TITLE
Introduce `trait ApiSource` for a more powerful architecture

### DIFF
--- a/cargo-public-api/src/api_source.rs
+++ b/cargo-public-api/src/api_source.rs
@@ -1,0 +1,200 @@
+//! Contains various ways of obtaining the public API for crates.
+
+use anyhow::{anyhow, Context, Result};
+use rustdoc_json::BuildError;
+use std::path::{Path, PathBuf};
+
+use public_api::{Options, PublicApi, MINIMUM_RUSTDOC_JSON_VERSION};
+
+use crate::{git_utils, Args};
+
+/// Represents some place from which a public API can be obtained.
+/// Examples: a published crate, a git commit, an existing file.
+pub trait ApiSource {
+    /// Do the work necessary to obtain the public API.
+    fn obtain_api(&self, args: &Args) -> Result<PublicApi>;
+
+    /// If this source modifies the local git repo. If that is the case, whoever
+    /// uses this API source must make sure to restore the git repo to the
+    /// original state afterwards. The API source itself does not do any
+    /// restoration.
+    fn changes_commit(&self) -> bool {
+        false
+    }
+}
+
+/// The API is obtained by building the crate in the current directory.
+pub struct CurrentDir;
+
+impl ApiSource for CurrentDir {
+    fn obtain_api(&self, args: &Args) -> Result<PublicApi> {
+        public_api_for_current_dir(args)
+    }
+}
+/// The API is obtained from a crate published to crates.io.
+pub struct PublishedCrate {
+    package_spec_str: String,
+}
+
+impl PublishedCrate {
+    pub fn new(package_spec: &str) -> Self {
+        Self {
+            package_spec_str: package_spec.to_owned(),
+        }
+    }
+}
+
+impl ApiSource for PublishedCrate {
+    fn obtain_api(&self, args: &Args) -> Result<public_api::PublicApi> {
+        let rustdoc_json =
+            crate::published_crate::build_rustdoc_json(&self.package_spec_str, args)?;
+        public_api_from_rustdoc_json_path(&rustdoc_json, args)
+    }
+}
+
+/// The API is obtained from a git commit.
+pub struct Commit {
+    commit: String,
+}
+
+impl Commit {
+    pub fn new(args: &Args, commit_ref: &str) -> Result<Self> {
+        Ok(Self {
+            // Resolve the ref during creation to detect problems early
+            commit: git_utils::resolve_ref(&args.git_root()?, commit_ref)?,
+        })
+    }
+}
+
+impl ApiSource for Commit {
+    fn obtain_api(&self, args: &Args) -> Result<PublicApi> {
+        crate::git_checkout(args, &self.commit)?;
+        public_api_for_current_dir(args)
+    }
+
+    fn changes_commit(&self) -> bool {
+        true
+    }
+}
+
+/// The API is obtained from an existing rustdoc JSON file.
+pub struct RustdocJson {
+    path: PathBuf,
+}
+
+impl RustdocJson {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl ApiSource for RustdocJson {
+    fn obtain_api(&self, args: &Args) -> Result<PublicApi> {
+        public_api_from_rustdoc_json_path(&self.path, args)
+    }
+}
+
+/// Builds the public API for the library in the current working directory. Note
+/// that we sometimes checkout a different commit before invoking this function,
+/// which means it will return the public API of that commit.
+fn public_api_for_current_dir(args: &Args) -> Result<PublicApi> {
+    let json_path = rustdoc_json_for_current_dir(args)?;
+    public_api_from_rustdoc_json_path(json_path, args)
+}
+
+/// Builds the rustdoc JSON for the library in the current working directory.
+/// Also see [`public_api_for_current_dir()`].
+fn rustdoc_json_for_current_dir(args: &Args) -> Result<PathBuf> {
+    let builder = builder_from_args(args);
+    build_rustdoc_json(builder)
+}
+
+/// Helper to build rustdoc JSON with a builder while also handling any virtual
+/// manifest errors.
+pub fn build_rustdoc_json(builder: rustdoc_json::Builder) -> Result<PathBuf> {
+    match builder.build() {
+        Err(BuildError::VirtualManifest(manifest_path)) => virtual_manifest_error(&manifest_path),
+        res => Ok(res?),
+    }
+}
+
+/// Figure out what [`Options`] to pass to
+/// [`public_api::PublicApi::from_rustdoc_json_str`] based on our
+/// [`Args`]
+fn get_options(args: &Args) -> Options {
+    let mut options = Options::default();
+    options.debug_sorting = args.debug_sorting;
+    options.simplified = args.simplified;
+    options
+}
+
+/// Creates a rustdoc JSON builder based on the args to this program.
+pub fn builder_from_args(args: &Args) -> rustdoc_json::Builder {
+    let mut builder = rustdoc_json::Builder::default()
+        .toolchain(args.toolchain.clone())
+        .manifest_path(&args.manifest_path)
+        .all_features(args.all_features)
+        .no_default_features(args.no_default_features)
+        .features(&args.features);
+    if let Some(target_dir) = &args.target_dir {
+        builder = builder.target_dir(target_dir.clone());
+    }
+    if let Some(target) = &args.target {
+        builder = builder.target(target.clone());
+    }
+    if let Some(package) = &args.package {
+        builder = builder.package(package);
+    }
+    if let Some(cap_lints) = &args.cap_lints {
+        builder = builder.cap_lints(Some(cap_lints));
+    }
+    builder
+}
+
+fn public_api_from_rustdoc_json_path(
+    json_path: impl AsRef<Path>,
+    args: &Args,
+) -> Result<PublicApi> {
+    let options = get_options(args);
+
+    let rustdoc_json = &std::fs::read_to_string(&json_path)
+        .with_context(|| format!("Failed to read rustdoc JSON at {:?}", json_path.as_ref()))?;
+
+    if args.verbose {
+        println!("Processing {:?}", json_path.as_ref());
+    }
+
+    let public_api = PublicApi::from_rustdoc_json_str(rustdoc_json, options).with_context(|| {
+        format!(
+            "Failed to parse rustdoc JSON at {:?}.\n\
+            This version of `cargo public-api` requires at least:\n\n    {}\n\n\
+            If you have that, it might be `cargo public-api` that is out of date. Try\n\
+            to install the latest version with `cargo install cargo-public-api`. If the\n\
+            issue remains, please report at\n\n    https://github.com/Enselic/cargo-public-api/issues",
+            json_path.as_ref(),
+            MINIMUM_RUSTDOC_JSON_VERSION,
+        )
+    })?;
+
+    if args.verbose {
+        public_api.missing_item_ids().for_each(|i| {
+            println!("NOTE: rustdoc JSON missing referenced item with ID \"{i}\"");
+        });
+    }
+
+    Ok(public_api)
+}
+
+fn virtual_manifest_error(manifest_path: &Path) -> Result<PathBuf> {
+    Err(anyhow!(
+        "`{:?}` is a virtual manifest.
+
+Listing or diffing the public API of an entire workspace is not supported.
+
+Try
+
+    cargo public-api -p specific-crate
+",
+        manifest_path
+    ))
+}

--- a/cargo-public-api/src/published_crate.rs
+++ b/cargo-public-api/src/published_crate.rs
@@ -27,11 +27,11 @@ pub fn build_rustdoc_json(package_spec_str: &str, args: &Args) -> Result<PathBuf
     // `args.target_dir` is set, both the dummy crate and the real crate will
     // write to the same JSON path since they have the same project name! That
     // won't work. So always clear the target dir before we use the builder.
-    let builder = crate::builder_from_args(args)
+    let builder = crate::api_source::builder_from_args(args)
         .clear_target_dir()
         .manifest_path(&manifest)
         .package(&spec.name);
-    crate::build_rustdoc_json(builder)
+    crate::api_source::build_rustdoc_json(builder)
 }
 
 /// When diffing against a published crate, we want to allow the user to not


### PR DESCRIPTION
This allows us to make follow-up commits to later enable things like:

* Diff between two different published versions
* Diff between e.g. a commit and a rustdoc JSON file
* List the API for a specific commit/branch

However, my current plan is to not do the above until after I have polished and landed the `diff` subcommand (prototype in #210), because I think we can get a much nicer CLI with the `diff` subcommand.