### PR TITLE
Add new CLI for diffing: a `diff` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,7 @@ dependencies = [
  "public-api",
  "rustdoc-json",
  "rustup-toolchain",
+ "semver",
  "tempfile",
  "thiserror",
 ]

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -19,6 +19,7 @@ cargo-manifest = "0.4.0"
 clap = { version = "4.0.23", features = ["derive", "wrap_help"] }
 diff = "0.1.12"
 dirs = "4.0.0"
+semver = "1.0.6"
 thiserror = "1.0.29"
 
 [dependencies.rustdoc-json]

--- a/cargo-public-api/src/api_source.rs
+++ b/cargo-public-api/src/api_source.rs
@@ -21,6 +21,13 @@ pub trait ApiSource {
     fn changes_commit(&self) -> bool {
         false
     }
+
+    fn boxed(self) -> Box<dyn ApiSource>
+    where
+        Self: Sized + 'static,
+    {
+        Box::new(self)
+    }
 }
 
 /// The API is obtained by building the crate in the current directory.

--- a/cargo-public-api/src/git_utils.rs
+++ b/cargo-public-api/src/git_utils.rs
@@ -79,7 +79,7 @@ fn trimmed_stdout(mut cmd: Command) -> Result<String> {
     if output.status.success() {
         Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
     } else {
-        Err(anyhow!("Failure: {:?}", output))
+        Err(anyhow!(String::from_utf8_lossy(&output.stderr).to_string()))
     }
 }
 

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -379,14 +379,42 @@ fn main_task_from_diff_args(args: &Args) -> Result<Option<MainTask>> {
 
     let first_arg = diff_args.args.get(0);
     let second_arg = diff_args.args.get(1);
-    if diff_args.args.is_empty() || diff_args.args.len() > 2 {
+    if diff_args.args.is_empty() {
+        bail!(
+            "Must specify what to diff.
+
+Examples:
+
+Diff against a specific version of the crate published to crates.io:
+
+    cargo public-api diff 1.2.3
+
+Diff between two git commits:
+
+    cargo public-api diff v0.2.0..v0.3.0
+
+To select a package in a workspace, use the --package flag:
+
+    cargo public-api --package my-package diff ...
+
+See
+
+    cargo public-api diff --help
+
+for more.
+"
+        );
+    } else if diff_args.args.len() > 2 {
         bail!(
             "Expected 1 or 2 arguments, but got {}",
             diff_args.args.len()
-        );
+        )
     }
 
     let main_task = match (first_arg, second_arg) {
+        (Some(first), None) if first.contains("...") => {
+            bail!("Invalid git diff syntax: {first}. Use: rev1..rev2");
+        }
         (Some(first), None) if first.contains("..") => {
             let commits: Vec<_> = first.split("..").collect();
             if commits.len() != 2 {

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -298,6 +298,18 @@ fn diff_public_items_impl(diff_arg: &str) {
     assert_eq!(branch_before, branch_after);
 }
 
+#[test]
+fn diff_public_items_with_subcommand() {
+    let mut cmd = TestCmd::new().with_test_repo();
+    cmd.arg("diff");
+    cmd.arg("v0.2.0..v0.3.0");
+    cmd.assert()
+        .stdout_or_bless(
+            "../../cargo-public-api/tests/expected-output/example_api_diff_v0.2.0_to_v0.3.0.txt",
+        )
+        .success();
+}
+
 /// Test that the mechanism to restore the original git branch works even if
 /// there is no current branch
 #[test]
@@ -449,6 +461,17 @@ fn deny_with_diff() {
 }
 
 #[test]
+fn deny_with_diff_with_subcommand() {
+    let mut cmd = TestCmd::new().with_test_repo();
+    cmd.arg("diff");
+    cmd.arg("v0.1.0..v0.2.0");
+    cmd.arg("--deny=all");
+    cmd.assert()
+        .stderr(contains("The API diff is not allowed as per --deny"))
+        .failure();
+}
+
+#[test]
 fn deny_added_with_diff() {
     let mut cmd = TestCmd::new().with_test_repo();
     cmd.arg("--diff-git-checkouts");
@@ -556,9 +579,15 @@ fn list_public_items_with_color() {
 }
 
 #[test]
+fn diff_public_items_from_files_with_subcommand() {
+    diff_public_items_from_files_impl("diff");
+}
+
+#[test]
 fn diff_public_items_from_files() {
     diff_public_items_from_files_impl("--diff-rustdoc-json");
 }
+
 #[test]
 fn diff_public_items_from_files_smart_diff() {
     diff_public_items_from_files_impl("--diff");
@@ -595,6 +624,11 @@ fn diff_published_smart_diff() {
 #[test]
 fn diff_published_fallback() {
     diff_published_impl("--diff-published", "@0.1.0");
+}
+
+#[test]
+fn diff_published_fallback_with_subcommand() {
+    diff_published_impl("diff", "0.1.0");
 }
 
 #[test]

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -310,6 +310,78 @@ fn diff_public_items_with_subcommand() {
         .success();
 }
 
+#[test]
+fn diff_without_args() {
+    let mut cmd = TestCmd::new().with_test_repo();
+    cmd.arg("diff");
+    cmd.assert()
+        .stderr(contains("Error: Must specify what to diff"))
+        .failure();
+}
+
+#[test]
+fn diff_with_invalid_published_crate_version() {
+    let mut cmd = TestCmd::new().with_test_repo();
+    cmd.arg("diff");
+    cmd.arg("foo");
+    cmd.assert()
+        .stderr("Error: Invalid published crate version syntax: foo\n")
+        .failure();
+}
+
+#[test]
+fn diff_with_invalid_git_refs() {
+    let mut cmd = TestCmd::new().with_test_repo();
+    cmd.arg("diff");
+    cmd.arg("foo..bar");
+    cmd.assert()
+        .stderr(contains("Error: fatal: ambiguous argument 'foo': unknown revision or path not in the working tree."))
+        .failure();
+}
+
+#[test]
+fn diff_with_invalid_git_refs_three_dots() {
+    let mut cmd = TestCmd::new().with_test_repo();
+    cmd.arg("diff");
+    cmd.arg("foo...bar");
+    cmd.assert()
+        .stderr("Error: Invalid git diff syntax: foo...bar. Use: rev1..rev2\n")
+        .failure();
+}
+
+#[test]
+fn diff_with_invalid_git_refs_four_dots() {
+    let mut cmd = TestCmd::new().with_test_repo();
+    cmd.arg("diff");
+    cmd.arg("foo....bar");
+    cmd.assert()
+        .stderr("Error: Invalid git diff syntax: foo....bar. Use: rev1..rev2\n")
+        .failure();
+}
+
+#[test]
+fn diff_with_three_args() {
+    let mut cmd = TestCmd::new().with_test_repo();
+    cmd.arg("diff");
+    cmd.arg("v0.1.0");
+    cmd.arg("v0.2.0");
+    cmd.arg("v0.3.0");
+    cmd.assert()
+        .stderr("Error: Expected 1 or 2 arguments, but got 3\n")
+        .failure();
+}
+
+#[test]
+fn diff_with_dots_two_times() {
+    let mut cmd = TestCmd::new().with_test_repo();
+    cmd.arg("diff");
+    cmd.arg("v0.1.0..v0.2.0");
+    cmd.arg("v0.2.0..v0.3.0");
+    cmd.assert()
+        .stderr("Error: Use `ref1..ref2` syntax to diff git commits\n")
+        .failure();
+}
+
 /// Test that the mechanism to restore the original git branch works even if
 /// there is no current branch
 #[test]


### PR DESCRIPTION
Its syntax is much simpler than the legacy diffing CLI, which we will keep around for a while for backwards compatibility.

The new CLI for diffing looks like this:

### Diffing between two commits

We start  using the same syntax as `git diff`.

    cargo public-api diff v0.4.0..v0.5.0

### Diffing current working directory against a published crate version on crates.io:

    cargo public-api diff 0.4.0

### Same, but for a package in a workspace:

    cargo public-api -p the-package diff 0.4.0

### Diffing two rustdoc JSON files:

    cargo public-api diff first-file.json second-file.json

You'll notice that the equivalents of `--diff-git-checkouts`, `--diff-published`, etc, will not remain, long-term.

## Plan going forward

1. Release `diff` subcommand to users, but don't make it very prominent
1. Migrate docs to use new `diff` subcommand
1. Later, deprecate legacy diffing CLI
1. Later, remove legacy diffing CLI