### PR TITLE
Interpret `--color` as `--color=always`

### DIFF
--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -127,9 +127,11 @@ pub struct Args {
     #[arg(long, value_enum)]
     deny: Option<Vec<DenyMethod>>,
 
-    /// Whether or not to use colors.
-    #[arg(long, value_enum, default_value_t = Color::Auto)]
-    color: Color,
+    /// How to color the output. By default, `--color=auto` is active. Using
+    /// just `--color` without an arg is equivalent to `--color=always`.
+    #[allow(clippy::option_option)]
+    #[arg(long, value_enum)]
+    color: Option<Option<Color>>,
 
     /// Omit items that belong to Blanket Implementations and Auto Trait
     /// Implementations.

--- a/cargo-public-api/src/plain.rs
+++ b/cargo-public-api/src/plain.rs
@@ -21,7 +21,7 @@ impl Plain {
     }
 
     pub fn print_diff(w: &mut dyn Write, args: &Args, diff: &PublicApiDiff) -> Result<()> {
-        let use_color = args.color.active();
+        let use_color = color_active(args.color);
 
         print_items_with_header(
             w,
@@ -78,11 +78,26 @@ impl Plain {
 }
 
 fn print_item(args: &Args, w: &mut dyn Write, item: &PublicItem) -> Result<()> {
-    if args.color.active() {
+    if color_active(args.color) {
         writeln!(w, "{}", color_item(item))
     } else {
         writeln!(w, "{}", item)
     }
+}
+
+#[allow(clippy::option_option)]
+fn color_active(color: Option<Option<crate::arg_types::Color>>) -> bool {
+    match color {
+        // An explicit color was specified: `--color=...`
+        Some(Some(color)) => color,
+
+        // Just `--color`
+        Some(None) => crate::arg_types::Color::Always,
+
+        // No `--color` at all
+        None => crate::arg_types::Color::Auto,
+    }
+    .active()
 }
 
 fn color_item(item: &public_api::PublicItem) -> String {

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -629,8 +629,17 @@ fn diff_public_items_without_git_root() {
 
 #[test]
 fn diff_public_items_with_color() {
+    diff_public_items_with_color_impl("--color=always");
+}
+
+#[test]
+fn diff_public_items_with_color_implicitly() {
+    diff_public_items_with_color_impl("--color"); // Same as `--color=always`
+}
+
+fn diff_public_items_with_color_impl(color_arg: &str) {
     let mut cmd = TestCmd::new().with_test_repo();
-    cmd.arg("--color=always");
+    cmd.arg(color_arg);
     cmd.arg("--diff-git-checkouts");
     cmd.arg("v0.1.0");
     cmd.arg("v0.2.0");

--- a/docs/long-help.txt
+++ b/docs/long-help.txt
@@ -109,10 +109,9 @@ Options:
           - changed: Deny changed things in API diffs
           - removed: Deny removed things in API diffs
 
-      --color <COLOR>
-          Whether or not to use colors
-          
-          [default: auto]
+      --color [<COLOR>]
+          How to color the output. By default, `--color=auto` is active. Using just `--color`
+          without an arg is equivalent to `--color=always`
 
           Possible values:
           - auto:

--- a/docs/short-help.txt
+++ b/docs/short-help.txt
@@ -26,8 +26,9 @@ Options:
       --deny <DENY>
           Exit with failure if the specified API diff is detected [possible values: all, added,
           changed, removed]
-      --color <COLOR>
-          Whether or not to use colors [default: auto] [possible values: auto, never, always]
+      --color [<COLOR>]
+          How to color the output. By default, `--color=auto` is active. Using just `--color`
+          without an arg is equivalent to `--color=always` [possible values: auto, never, always]
   -s, --simplified
           Omit items that belong to Blanket Implementations and Auto Trait Implementations
       --toolchain <TOOLCHAIN>


### PR DESCRIPTION
This is the same semantics as `git diff --color[=...]` has.