### PR TITLE
Hide `--toolchain` from `-h`/`--help`

### DIFF
--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -171,7 +171,7 @@ pub struct Args {
     ///
     /// Useful if you have built a toolchain from source for example, or if you
     /// want to use a fixed toolchain in CI.
-    #[arg(long, value_parser = parse_toolchain)]
+    #[arg(long, value_parser = parse_toolchain, hide = true)]
     toolchain: Option<String>,
 
     /// Build for the target triple

--- a/docs/long-help.txt
+++ b/docs/long-help.txt
@@ -135,14 +135,6 @@ Options:
           Examples of Auto Trait Implementations: `impl Send for Foo`, `impl Sync for Foo`, and
           `impl Unpin for Foo`
 
-      --toolchain <TOOLCHAIN>
-          Build rustdoc JSON with a toolchain other than `nightly`.
-          
-          Consider using `cargo +toolchain public-api` instead.
-          
-          Useful if you have built a toolchain from source for example, or if you want to use a
-          fixed toolchain in CI.
-
       --target <TARGET>
           Build for the target triple
 

--- a/docs/short-help.txt
+++ b/docs/short-help.txt
@@ -30,8 +30,6 @@ Options:
           Whether or not to use colors [default: auto] [possible values: auto, never, always]
   -s, --simplified
           Omit items that belong to Blanket Implementations and Auto Trait Implementations
-      --toolchain <TOOLCHAIN>
-          Build rustdoc JSON with a toolchain other than `nightly`
       --target <TARGET>
           Build for the target triple
   -F, --features <FEATURES>...


### PR DESCRIPTION
We want users to use `cargo +toolchain public-api` instead of `cargo public-api --toolchain toolchain`.

And we want the help output to be as free of noise as possible, to make it easier to digest for our users.