### PR TITLE
Deprecate legacy `--diff` CLI and point to new `diff` subcommand instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ which will print the public API of `regex` with one line per public item in the 
 
 ## Diff the Public API
 
-To diff the API between say **0.2.2** and **0.2.3** of `regex`, use `--diff-git-checkouts 0.2.2 0.2.3` while standing in the git repo. Like this:
+To diff the API between say **0.2.2** and **0.2.3** of `regex`, use `diff 0.2.2..0.2.3` while standing in the git repo. Like this:
 
 ```bash
-cargo public-api --diff-git-checkouts 0.2.2 0.2.3
+cargo public-api diff 0.2.2..0.2.3
 ```
 
 and the API diff will be printed:
@@ -50,7 +50,7 @@ and the API diff will be printed:
 When you make changes to your library you often want to make sure that you do not accidentally change the public API of your library, or that the API change you are making looks like you expect. For this use case, first git commit your work in progress, and then run
 
 ```bash
-cargo public-api --diff-git-checkouts origin/main your-current-branch
+cargo public-api diff origin/main..your-current-branch
 ```
 
 which will print the diff of your public API changes compared to `origin/main`.
@@ -61,10 +61,10 @@ This tool can be put to good use in CI pipelines to e.g. help you make sure your
 
 ### … Against Published Version
 
-Before you `cargo publish` a new version of your crate, you can diff the public API of your local code against the public API of the version you last published. Use the `--diff-published` arg for that. Like this:
+Before you `cargo publish` a new version of your crate, you can diff the public API of your local code against the public API of the version you last published. Use the `diff <VERSION>` syntax for that. Like this:
 
 ```bash
-cargo public-api --diff-published regex@0.2.2
+cargo public-api diff 0.2.2
 ```
 
 ## Expected Output

--- a/cargo-public-api/src/published_crate.rs
+++ b/cargo-public-api/src/published_crate.rs
@@ -36,8 +36,8 @@ pub fn build_rustdoc_json(package_spec_str: &str, args: &Args) -> Result<PathBuf
 
 /// When diffing against a published crate, we want to allow the user to not
 /// specify the package name. Instead, we want to support to figure that out for
-/// the user. So instead of doing `--diff-published crate-name@1.2.3` they can
-/// just do `--diff-published @1.2.3`. This helper function figures out what
+/// the user. So instead of doing `diff --published crate-name@1.2.3` they can
+/// just do `diff --published @1.2.3`. This helper function figures out what
 /// package name to use in this case.
 fn package_name_from_args(args: &Args) -> Option<String> {
     if let Some(package) = &args.package {

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -445,6 +445,7 @@ fn diff_public_items_with_dirty_tree_succeedes_with_force_option() {
         .stdout_or_bless(
             "../../cargo-public-api/tests/expected-output/example_api_diff_v0.2.0_to_v0.3.0.txt",
         )
+        .stderr(contains("DEPRECATION WARNING"))
         .success();
 }
 
@@ -517,7 +518,11 @@ fn deny_without_diff() {
     cmd.arg("v0.1.0");
     cmd.arg("v0.1.1");
     cmd.arg("--deny=all");
-    cmd.assert().success();
+    cmd.assert()
+        .stderr(contains(
+            "DEPRECATION WARNING: `... --diff --deny` is deprecated, use `... diff --deny` instead",
+        ))
+        .success();
 }
 
 #[test]
@@ -622,7 +627,8 @@ fn diff_public_items_without_git_root() {
     cmd.arg("v0.3.0");
     cmd.assert()
         .stderr(predicates::str::starts_with(
-            "Error: No `.git` dir when starting from `",
+            "DEPRECATION WARNING: `... --diff-git-checkouts v0.2.0 v0.3.0` is deprecated, use `... diff v0.2.0..v0.3.0` instead.
+Error: No `.git` dir when starting from `",
         ))
         .failure();
 }
@@ -736,6 +742,7 @@ fn diff_published_explicit_package() {
     cmd.arg("@0.1.0");
     cmd.assert()
         .stdout_or_bless("../../cargo-public-api/tests/expected-output/diff_published.txt")
+        .stderr(contains("DEPRECATION WARNING"))
         .success();
 }
 

--- a/docs/CI-EXAMPLES.md
+++ b/docs/CI-EXAMPLES.md
@@ -6,7 +6,7 @@ This document describes different ways to make use of `cargo public-api` in CI. 
 
 ### With a Public API Set in Stone
 
-If the API is set in stone, you can use the `--deny=all` flag together with `--diff-git-checkouts` to deny all kinds of changes (additions, changes, removals) to your public API. A GitHub Actions job to do this for PRs would look something like this:
+If the API is set in stone, you can use the `--deny=all` flag together with `diff ...` to deny all kinds of changes (additions, changes, removals) to your public API. A GitHub Actions job to do this for PRs would look something like this:
 
 ```yaml
 jobs:
@@ -26,7 +26,7 @@ jobs:
 
       # Install and run cargo public-api and deny any API diff
       - run: cargo install cargo-public-api
-      - run: cargo public-api --diff-git-checkouts ${GITHUB_BASE_REF} ${GITHUB_HEAD_REF} --deny=all
+      - run: cargo public-api diff ${GITHUB_BASE_REF}..${GITHUB_HEAD_REF} --deny=all
 ```
 
 See `cargo public-api --help` for more variants of `--deny`.

--- a/docs/long-diff-help.txt
+++ b/docs/long-diff-help.txt
@@ -1,27 +1,62 @@
-Diffing of public APIs
+Diff the public API against a published version of the crate, or between commits.
+
+If the diffing
+
+* arg looks like a specific version string (`x.y.z`) then the diff will be between that published
+  version of the crate and the working directory.
+
+* arg has `..` like in `tag1..tag2` then the public API of each individual git commit will be
+  diffed. See below for how that works.
+
+* args end with `.json` like in `file1.json file2.json` then rustdoc JSON file diffing will be
+  performed.
+
+
+EXAMPLES:
+=========
+
+Diffing working tree against a published version of the crate:
+
+    cargo public-api diff 1.2.3
+
+Diffing working tree against a published version of a specific crate in the workspace:
+
+    cargo public-api -p specific-crate diff 1.2.3
+
+Diffing between commits:
+
+    cargo public-api diff v0.2.0..v0.3.0
+
+Diffing between rustdoc JSON files:
+
+    cargo public-api diff first.json second.json
+
+
+HOW COMMIT DIFFING WORKS:
+=========================
+
+When diffing commits, the following steps are performed:
+
+1. Remember the current branch/commit
+2. Do a literal in-tree, in-place `git checkout` of the first commit
+3. Collect public API
+4. Do a literal in-tree, in-place `git checkout` of the second commit
+5. Collect public API
+6. Print the diff between public API in step 2 and step 4
+7. Restore the original branch/commit
+
+If you have local changes, git will refuse to do `git checkout`, so your work will not be discarded.
+To force `git checkout`, use `--force`.
+
+Using the current git repo has the benefit of making it likely for the build to succeed. If we e.g.
+were to git clone a temporary copy of a commit ourselves, the risk is high that additional steps are
+needed before a build can succeed. Such as the need to set up git submodules.
 
 Usage: cargo-public-api diff [OPTIONS] [ARGS]...
 
 Arguments:
   [ARGS]...
-          Diff against published crate versions, between commits, or between rustdoc JSON files. If
-          the diffing arg looks like a specific version string (`x.y.z`) then the diffing will be
-          performed against a published version of the crate. The presence of `..` means git commits
-          will be diffed. The presence of `.json` means rustdoc JSON file diffing will be used.
-          
-          Examples:
-          
-          Diffing working tree against a published version of the crate:
-          
-          cargo public-api diff 1.2.3
-          
-          Diffing between commits:
-          
-          cargo public-api diff v0.2.0..v0.3.0
-          
-          Diffing between rustdoc JSON files:
-          
-          cargo public-api diff first.json second.json
+          What to diff. See `cargo public-api diff --help` for examples and more info
 
 Options:
       --deny <DENY>

--- a/docs/long-help.txt
+++ b/docs/long-help.txt
@@ -5,7 +5,7 @@ Usage: cargo-public-api [OPTIONS] [COMMAND]
 
 Commands:
   diff
-          Diffing of public APIs
+          Diff the public API against a published version of the crate, or between commits.
   help
           Print this message or the help of the given subcommand(s)
 
@@ -14,86 +14,6 @@ Options:
           Path to `Cargo.toml`
           
           [default: Cargo.toml]
-
-      --diff-git-checkouts <COMMIT_1> <COMMIT_2>
-          Diff the public API across two different commits.
-          
-          The following steps are performed:
-          
-          1. Remember the current branch/commit
-          
-          2. Do a literal in-tree, in-place `git checkout` of the first commit
-          
-          3. Collect public API
-          
-          4. Do a literal in-tree, in-place `git checkout` of the second commit
-          
-          5. Collect public API
-          
-          6. Print the diff between public API in step 2 and step 4
-          
-          7. Restore the original branch/commit
-          
-          If you have local changes, git will refuse to do `git checkout`, so your work will not be
-          discarded.
-          
-          Using the current git repo has the benefit of making it likely for the build to succeed.
-          If we e.g. were to git clone a temporary copy of a commit ourselves, the risk is high that
-          additional steps are needed before a build can succeed. Such as the need to set up git
-          submodules.
-
-      --force-git-checkouts
-          Discard working tree changes during git checkouts when `--diff-git-checkouts` is used
-
-      --diff-rustdoc-json <RUSTDOC_JSON_PATH_1> <RUSTDOC_JSON_PATH_2>
-          Diff the public API across two different rustdoc JSON files
-
-      --diff-published <CRATE_NAME@VERSION>
-          Diff the current API against the API in a published version.
-          
-          Example:
-          
-          cargo public-api --diff-published your-crate@1.2.3
-
-      --diff <TARGET>...
-          Automatically resolves to either `--diff-git-checkouts`, `--diff-rustdoc-json`, or
-          `--diff-published` depending on if args ends in `.json` or not, or if they contain `@`.
-          
-          Examples:
-          
-          cargo public-api --diff v0.2.0 v0.3.0
-          
-          resolves to
-          
-          cargo public-api --diff-git-checkouts v0.2.0 v0.3.0
-          
-          but
-          
-          cargo public-api --diff v0.2.0.json v0.3.0.json
-          
-          resolves to
-          
-          cargo public-api --diff-rustdoc-json v0.2.0.json v0.3.0.json
-          
-          and
-          
-          cargo public-api --diff some-crate@1.2.3
-          
-          resolves to
-          
-          cargo public-api --diff-published some-crate@1.2.3
-
-      --deny <DENY>
-          Exit with failure if the specified API diff is detected.
-          
-          Can be combined. For example, to only allow additions to the API, use `--deny=added
-          --deny=changed`.
-
-          Possible values:
-          - all:     All forms of API diffs are denied: additions, changes, deletions
-          - added:   Deny added things in API diffs
-          - changed: Deny changed things in API diffs
-          - removed: Deny removed things in API diffs
 
       --color [<COLOR>]
           How to color the output. By default, `--color=auto` is active. Using just `--color`

--- a/docs/short-diff-help.txt
+++ b/docs/short-diff-help.txt
@@ -1,13 +1,9 @@
-Diffing of public APIs
+Diff the public API against a published version of the crate, or between commits.
 
 Usage: cargo-public-api diff [OPTIONS] [ARGS]...
 
 Arguments:
-  [ARGS]...  Diff against published crate versions, between commits, or between rustdoc JSON files.
-             If the diffing arg looks like a specific version string (`x.y.z`) then the diffing will
-             be performed against a published version of the crate. The presence of `..` means git
-             commits will be diffed. The presence of `.json` means rustdoc JSON file diffing will be
-             used
+  [ARGS]...  What to diff. See `cargo public-api diff --help` for examples and more info
 
 Options:
       --deny <DENY>  Exit with failure if the specified API diff is detected [possible values: all,

--- a/docs/short-help.txt
+++ b/docs/short-help.txt
@@ -4,44 +4,21 @@ API changes and semver violations.
 Usage: cargo-public-api [OPTIONS] [COMMAND]
 
 Commands:
-  diff  Diffing of public APIs
+  diff  Diff the public API against a published version of the crate, or between commits.
   help  Print this message or the help of the given subcommand(s)
 
 Options:
-      --manifest-path <PATH>
-          Path to `Cargo.toml` [default: Cargo.toml]
-      --diff-git-checkouts <COMMIT_1> <COMMIT_2>
-          Diff the public API across two different commits
-      --force-git-checkouts
-          Discard working tree changes during git checkouts when `--diff-git-checkouts` is used
-      --diff-rustdoc-json <RUSTDOC_JSON_PATH_1> <RUSTDOC_JSON_PATH_2>
-          Diff the public API across two different rustdoc JSON files
-      --diff-published <CRATE_NAME@VERSION>
-          Diff the current API against the API in a published version
-      --diff <TARGET>...
-          Automatically resolves to either `--diff-git-checkouts`, `--diff-rustdoc-json`, or
-          `--diff-published` depending on if args ends in `.json` or not, or if they contain `@`
-      --deny <DENY>
-          Exit with failure if the specified API diff is detected [possible values: all, added,
-          changed, removed]
-      --color [<COLOR>]
-          How to color the output. By default, `--color=auto` is active. Using just `--color`
-          without an arg is equivalent to `--color=always` [possible values: auto, never, always]
-  -s, --simplified
-          Omit items that belong to Blanket Implementations and Auto Trait Implementations
-      --toolchain <TOOLCHAIN>
-          Build rustdoc JSON with a toolchain other than `nightly`
-      --target <TARGET>
-          Build for the target triple
-  -F, --features <FEATURES>...
-          Space or comma separated list of features to activate
-      --all-features
-          Activate all available features
-      --no-default-features
-          Do not activate the `default` feature
-  -p, --package <PACKAGE>
-          Name of package in workspace to list or diff the public API for
-  -h, --help
-          Print help information (use `--help` for more detail)
-  -V, --version
-          Print version information
+      --manifest-path <PATH>    Path to `Cargo.toml` [default: Cargo.toml]
+      --color [<COLOR>]         How to color the output. By default, `--color=auto` is active. Using
+                                just `--color` without an arg is equivalent to `--color=always` [possible
+                                values: auto, never, always]
+  -s, --simplified              Omit items that belong to Blanket Implementations and Auto Trait
+                                Implementations
+      --toolchain <TOOLCHAIN>   Build rustdoc JSON with a toolchain other than `nightly`
+      --target <TARGET>         Build for the target triple
+  -F, --features <FEATURES>...  Space or comma separated list of features to activate
+      --all-features            Activate all available features
+      --no-default-features     Do not activate the `default` feature
+  -p, --package <PACKAGE>       Name of package in workspace to list or diff the public API for
+  -h, --help                    Print help information (use `--help` for more detail)
+  -V, --version                 Print version information

--- a/scripts/multi-diff.sh
+++ b/scripts/multi-diff.sh
@@ -11,6 +11,6 @@ shift
 
 for new_version in $@; do
     echo "$base_version -> $new_version"
-    cargo public-api --diff-git-checkouts $base_version $new_version 2>/dev/null || echo "(Failed)"
+    cargo public-api diff $base_version..$new_version 2>/dev/null || echo "(Failed)"
     base_version=$new_version
 done


### PR DESCRIPTION
After some time (how long exactly is to be decided) we will remove the legacy `--diff` CLI. We don't want to spend contributor and maintainer effort on maintaining two different CLIs for diffing. Nor do we want to burden users with making a choice between the two CLIs.

Also do quite a big cleanup of the help texts.