### PR TITLE
Add `rustdoc_json::Builder::silent()` to suppress stdout and stderr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,9 +601,11 @@ dependencies = [
 name = "rustdoc-json"
 version = "0.7.3"
 dependencies = [
+ "assert_cmd",
  "cargo-manifest",
  "cargo_metadata",
  "expect-test",
+ "predicates",
  "public-api",
  "serde",
  "tempfile",

--- a/rustdoc-json/CHANGELOG.md
+++ b/rustdoc-json/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
-* Add `Builder::package_target` and `PackageTarget`
+* Add `Builder::package_target()` and `PackageTarget`
 * Correctly determine json path for `Builder::default().package("crate@1.0.0")`
+* Add `Builder::silent()` to suppress stdout and stderr
 
 ## v0.7.3
 * Derive `Clone` for `rustdoc_json::Builder`

--- a/rustdoc-json/Cargo.toml
+++ b/rustdoc-json/Cargo.toml
@@ -17,7 +17,9 @@ thiserror = "1.0.29"
 toml = "0.5.6"
 
 [dev-dependencies]
+assert_cmd = "2.0.4"
 expect-test = "1.4.0"
+predicates = "2.1.1"
 tempfile = "3.3.0"
 
 [dev-dependencies.public-api]

--- a/rustdoc-json/public-api.txt
+++ b/rustdoc-json/public-api.txt
@@ -92,6 +92,7 @@ pub const fn rustdoc_json::Builder::no_default_features(self, no_default_feature
 pub fn rustdoc_json::Builder::package(self, package: impl core::convert::AsRef<str>) -> Self
 pub fn rustdoc_json::Builder::package_target(self, package_target: rustdoc_json::PackageTarget) -> Self
 pub const fn rustdoc_json::Builder::quiet(self, quiet: bool) -> Self
+pub const fn rustdoc_json::Builder::silent(self, silent: bool) -> Self
 pub fn rustdoc_json::Builder::target(self, target: alloc::string::String) -> Self
 pub fn rustdoc_json::Builder::target_dir(self, target_dir: impl core::convert::AsRef<std::path::Path>) -> Self
 pub fn rustdoc_json::Builder::toolchain(self, toolchain: impl core::convert::Into<core::option::Option<alloc::string::String>>) -> Self

--- a/rustdoc-json/src/bin/test-silent-build.rs
+++ b/rustdoc-json/src/bin/test-silent-build.rs
@@ -1,0 +1,11 @@
+//! The cargo test framework can't capture stderr from child processes. This
+//! little program enables us to test if stderr can be suppressed with
+//! `silent(true)`.
+
+fn main() {
+    rustdoc_json::Builder::default()
+        .manifest_path("invalid/because/we/want/it/to/fail/Cargo.toml")
+        .silent(std::env::args().nth(1) == Some("--silent".to_owned()))
+        .build()
+        .unwrap();
+}

--- a/rustdoc-json/src/builder.rs
+++ b/rustdoc-json/src/builder.rs
@@ -44,6 +44,7 @@ fn cargo_rustdoc_command(options: &Builder) -> Command {
         target_dir,
         target,
         quiet,
+        silent,
         no_default_features,
         all_features,
         features,
@@ -78,6 +79,10 @@ fn cargo_rustdoc_command(options: &Builder) -> Command {
     }
     if *quiet {
         command.arg("--quiet");
+    }
+    if *silent {
+        command.stdout(std::process::Stdio::null());
+        command.stderr(std::process::Stdio::null());
     }
     command.arg("--manifest-path");
     command.arg(manifest_path);
@@ -185,6 +190,7 @@ pub struct Builder {
     target_dir: Option<PathBuf>,
     target: Option<String>,
     quiet: bool,
+    silent: bool,
     no_default_features: bool,
     all_features: bool,
     features: Vec<String>,
@@ -202,6 +208,7 @@ impl Default for Builder {
             target_dir: None,
             target: None,
             quiet: false,
+            silent: false,
             no_default_features: false,
             all_features: false,
             features: vec![],
@@ -259,6 +266,13 @@ impl Builder {
     #[must_use]
     pub const fn quiet(mut self, quiet: bool) -> Self {
         self.quiet = quiet;
+        self
+    }
+
+    /// Whether or not to redirect stdout and stderr to /dev/null. Default: `false`
+    #[must_use]
+    pub const fn silent(mut self, silent: bool) -> Self {
+        self.silent = silent;
         self
     }
 

--- a/rustdoc-json/tests/rustdoc-json-lib-tests.rs
+++ b/rustdoc-json/tests/rustdoc-json-lib-tests.rs
@@ -102,3 +102,27 @@ fn test_specified_dependency_version() {
     // We check for this here, to keep track of future changes.
     assert_eq!(path_1, path_2);
 }
+
+/// The cargo test framework can't capture stderr from child processes. So use a
+/// simple program and capture its stderr to test if `silent(true)` works.
+#[test]
+fn silent_build() {
+    use assert_cmd::Command;
+    use predicates::str::contains;
+
+    let stderr_substring_if_not_silent = "invalid/because/we/want/it/to/fail/Cargo.toml";
+    Command::cargo_bin("test-silent-build")
+        .unwrap()
+        .assert()
+        .stderr(contains(stderr_substring_if_not_silent))
+        .failure();
+
+    Command::cargo_bin("test-silent-build")
+        .unwrap()
+        .arg("--silent")
+        .assert()
+        .try_stderr(contains(stderr_substring_if_not_silent))
+        .expect_err(&format!(
+            "Found `{stderr_substring_if_not_silent}` in stderr, but stderr should be silent!"
+        ));
+}

--- a/rustdoc-json/tests/rustdoc-json-lib-tests.rs
+++ b/rustdoc-json/tests/rustdoc-json-lib-tests.rs
@@ -87,7 +87,7 @@ fn test_specified_dependency_version() {
 
     // test_dep is present multiple times in the dependency graph.
     // Check that just passing "test_dep" errors
-    match builder.clone().package("test_dep").build() {
+    match builder.clone().package("test_dep").silent(true).build() {
         Err(rustdoc_json::BuildError::General(_)) => {}
         _ => panic!("Expected ambiguous specification error"),
     }


### PR DESCRIPTION
And use it to suppress stderr from `test_specified_dependency_version()` (see https://github.com/Enselic/cargo-public-api/pull/247#pullrequestreview-1223510330)

CC @dimpolo (and Emilgardis but I think you see this anyway)