### PR TITLE
Get rid of `enum variant` and `struct field` prefixes

### DIFF
--- a/cargo-public-api/tests/expected-output/diff_published.txt
+++ b/cargo-public-api/tests/expected-output/diff_published.txt
@@ -9,7 +9,7 @@ Changed items in the public API
 
 Added items to the public API
 =============================
-+pub struct field example_api::Struct::v2_field: usize
++pub example_api::Struct::v2_field: usize
 +pub struct example_api::StructV2
-+pub struct field example_api::StructV2::field: usize
++pub example_api::StructV2::field: usize
 

--- a/cargo-public-api/tests/expected-output/example_api-v0.3.0.txt
+++ b/cargo-public-api/tests/expected-output/example_api-v0.3.0.txt
@@ -1,8 +1,8 @@
 pub mod example_api
 #[non_exhaustive] pub struct example_api::Struct
-pub struct field example_api::Struct::v1_field: usize
-pub struct field example_api::Struct::v2_field: usize
+pub example_api::Struct::v1_field: usize
+pub example_api::Struct::v2_field: usize
 impl core::fmt::Debug for example_api::Struct
 pub fn example_api::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct example_api::StructV2
-pub struct field example_api::StructV2::field: usize
+pub example_api::StructV2::field: usize

--- a/cargo-public-api/tests/expected-output/example_api-v0.3.0_document-private-items.txt
+++ b/cargo-public-api/tests/expected-output/example_api-v0.3.0_document-private-items.txt
@@ -1,9 +1,9 @@
 pub mod example_api
 #[non_exhaustive] pub struct example_api::Struct
-pub struct field example_api::Struct::v1_field: usize
-pub struct field example_api::Struct::v2_field: usize
+pub example_api::Struct::v1_field: usize
+pub example_api::Struct::v2_field: usize
 impl core::fmt::Debug for example_api::Struct
 pub fn example_api::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct example_api::StructV2
-pub struct field example_api::StructV2::field: usize
-pub struct field example_api::StructV2::private_field: usize
+pub example_api::StructV2::field: usize
+pub example_api::StructV2::private_field: usize

--- a/cargo-public-api/tests/expected-output/example_api_diff_v0.1.0_to_v0.2.0.txt
+++ b/cargo-public-api/tests/expected-output/example_api_diff_v0.1.0_to_v0.2.0.txt
@@ -11,7 +11,7 @@ Changed items in the public API
 
 Added items to the public API
 =============================
-+pub struct field example_api::Struct::v2_field: usize
++pub example_api::Struct::v2_field: usize
 +pub struct example_api::StructV2
-+pub struct field example_api::StructV2::field: usize
++pub example_api::StructV2::field: usize
 

--- a/cargo-public-api/tests/expected-output/example_api_diff_v0.1.0_to_v0.2.0_colored.txt
+++ b/cargo-public-api/tests/expected-output/example_api_diff_v0.1.0_to_v0.2.0_colored.txt
@@ -11,7 +11,7 @@ Changed items in the public API
 
 Added items to the public API
 =============================
-+[34mpub[0m [34mstruct[0m [34mfield[0m [36mexample_api[0m::[32mStruct[0m::[36mv2_field[0m: [32musize[0m
++[34mpub[0m [36mexample_api[0m::[32mStruct[0m::[36mv2_field[0m: [32musize[0m
 +[34mpub[0m [34mstruct[0m [36mexample_api[0m::[32mStructV2[0m
-+[34mpub[0m [34mstruct[0m [34mfield[0m [36mexample_api[0m::[32mStructV2[0m::[36mfield[0m: [32musize[0m
++[34mpub[0m [36mexample_api[0m::[32mStructV2[0m::[36mfield[0m: [32musize[0m
 

--- a/cargo-public-api/tests/expected-output/example_api_v0.3.0_colored.txt
+++ b/cargo-public-api/tests/expected-output/example_api_v0.3.0_colored.txt
@@ -1,8 +1,8 @@
 [34mpub[0m [34mmod[0m [36mexample_api[0m
 #[non_exhaustive] [34mpub[0m [34mstruct[0m [36mexample_api[0m::[32mStruct[0m
-[34mpub[0m [34mstruct[0m [34mfield[0m [36mexample_api[0m::[32mStruct[0m::[36mv1_field[0m: [32musize[0m
-[34mpub[0m [34mstruct[0m [34mfield[0m [36mexample_api[0m::[32mStruct[0m::[36mv2_field[0m: [32musize[0m
+[34mpub[0m [36mexample_api[0m::[32mStruct[0m::[36mv1_field[0m: [32musize[0m
+[34mpub[0m [36mexample_api[0m::[32mStruct[0m::[36mv2_field[0m: [32musize[0m
 [34mimpl[0m [36mcore[0m::[36mfmt[0m::[32mDebug[0m [34mfor[0m [36mexample_api[0m::[32mStruct[0m
 [34mpub[0m [34mfn[0m [36mexample_api[0m::[32mStruct[0m::[33mfmt[0m(&[34mself[0m, [36mf[0m: &[34mmut[0m [36mcore[0m::[36mfmt[0m::[32mFormatter[0m<[34m'_[0m>) -> [36mcore[0m::[36mfmt[0m::[32mResult[0m
 [34mpub[0m [34mstruct[0m [36mexample_api[0m::[32mStructV2[0m
-[34mpub[0m [34mstruct[0m [34mfield[0m [36mexample_api[0m::[32mStructV2[0m::[36mfield[0m: [32musize[0m
+[34mpub[0m [36mexample_api[0m::[32mStructV2[0m::[36mfield[0m: [32musize[0m

--- a/cargo-public-api/tests/expected-output/features-featall.txt
+++ b/cargo-public-api/tests/expected-output/features-featall.txt
@@ -1,5 +1,5 @@
 pub mod features
 #[non_exhaustive] pub struct features::AStruct
-pub struct field features::AStruct::feature_a: ()
-pub struct field features::AStruct::feature_b: ()
-pub struct field features::AStruct::feature_c: ()
+pub features::AStruct::feature_a: ()
+pub features::AStruct::feature_b: ()
+pub features::AStruct::feature_c: ()

--- a/cargo-public-api/tests/expected-output/features-featnonefeature_afeature_bfeature_c.txt
+++ b/cargo-public-api/tests/expected-output/features-featnonefeature_afeature_bfeature_c.txt
@@ -1,5 +1,5 @@
 pub mod features
 #[non_exhaustive] pub struct features::AStruct
-pub struct field features::AStruct::feature_a: ()
-pub struct field features::AStruct::feature_b: ()
-pub struct field features::AStruct::feature_c: ()
+pub features::AStruct::feature_a: ()
+pub features::AStruct::feature_b: ()
+pub features::AStruct::feature_c: ()

--- a/cargo-public-api/tests/expected-output/features-featnonefeature_b.txt
+++ b/cargo-public-api/tests/expected-output/features-featnonefeature_b.txt
@@ -1,3 +1,3 @@
 pub mod features
 #[non_exhaustive] pub struct features::AStruct
-pub struct field features::AStruct::feature_b: ()
+pub features::AStruct::feature_b: ()

--- a/cargo-public-api/tests/expected-output/features-featnonefeature_c.txt
+++ b/cargo-public-api/tests/expected-output/features-featnonefeature_c.txt
@@ -1,3 +1,3 @@
 pub mod features
 #[non_exhaustive] pub struct features::AStruct
-pub struct field features::AStruct::feature_c: ()
+pub features::AStruct::feature_c: ()

--- a/cargo-public-api/tests/expected-output/public_api_list.txt
+++ b/cargo-public-api/tests/expected-output/public_api_list.txt
@@ -1,8 +1,8 @@
 pub mod public_api
 pub mod public_api::diff
 pub struct public_api::diff::ChangedPublicItem
-pub struct field public_api::diff::ChangedPublicItem::new: public_api::PublicItem
-pub struct field public_api::diff::ChangedPublicItem::old: public_api::PublicItem
+pub public_api::diff::ChangedPublicItem::new: public_api::PublicItem
+pub public_api::diff::ChangedPublicItem::old: public_api::PublicItem
 impl core::clone::Clone for public_api::diff::ChangedPublicItem
 pub fn public_api::diff::ChangedPublicItem::clone(&self) -> public_api::diff::ChangedPublicItem
 impl core::fmt::Debug for public_api::diff::ChangedPublicItem
@@ -17,9 +17,9 @@ pub fn public_api::diff::ChangedPublicItem::partial_cmp(&self, other: &public_ap
 impl core::marker::StructuralEq for public_api::diff::ChangedPublicItem
 impl core::marker::StructuralPartialEq for public_api::diff::ChangedPublicItem
 pub struct public_api::diff::PublicApiDiff
-pub struct field public_api::diff::PublicApiDiff::added: alloc::vec::Vec<public_api::PublicItem>
-pub struct field public_api::diff::PublicApiDiff::changed: alloc::vec::Vec<public_api::diff::ChangedPublicItem>
-pub struct field public_api::diff::PublicApiDiff::removed: alloc::vec::Vec<public_api::PublicItem>
+pub public_api::diff::PublicApiDiff::added: alloc::vec::Vec<public_api::PublicItem>
+pub public_api::diff::PublicApiDiff::changed: alloc::vec::Vec<public_api::diff::ChangedPublicItem>
+pub public_api::diff::PublicApiDiff::removed: alloc::vec::Vec<public_api::PublicItem>
 impl public_api::diff::PublicApiDiff
 pub fn public_api::diff::PublicApiDiff::between(old: public_api::PublicApi, new: public_api::PublicApi) -> Self
 pub fn public_api::diff::PublicApiDiff::is_empty(&self) -> bool
@@ -34,19 +34,19 @@ impl core::marker::StructuralEq for public_api::diff::PublicApiDiff
 impl core::marker::StructuralPartialEq for public_api::diff::PublicApiDiff
 pub mod public_api::tokens
 pub enum public_api::tokens::Token
-pub enum variant public_api::tokens::Token::Annotation(alloc::string::String)
-pub enum variant public_api::tokens::Token::Function(alloc::string::String)
-pub enum variant public_api::tokens::Token::Generic(alloc::string::String)
-pub enum variant public_api::tokens::Token::Identifier(alloc::string::String)
-pub enum variant public_api::tokens::Token::Keyword(alloc::string::String)
-pub enum variant public_api::tokens::Token::Kind(alloc::string::String)
-pub enum variant public_api::tokens::Token::Lifetime(alloc::string::String)
-pub enum variant public_api::tokens::Token::Primitive(alloc::string::String)
-pub enum variant public_api::tokens::Token::Qualifier(alloc::string::String)
-pub enum variant public_api::tokens::Token::Self_(alloc::string::String)
-pub enum variant public_api::tokens::Token::Symbol(alloc::string::String)
-pub enum variant public_api::tokens::Token::Type(alloc::string::String)
-pub enum variant public_api::tokens::Token::Whitespace
+pub public_api::tokens::Token::Annotation(alloc::string::String)
+pub public_api::tokens::Token::Function(alloc::string::String)
+pub public_api::tokens::Token::Generic(alloc::string::String)
+pub public_api::tokens::Token::Identifier(alloc::string::String)
+pub public_api::tokens::Token::Keyword(alloc::string::String)
+pub public_api::tokens::Token::Kind(alloc::string::String)
+pub public_api::tokens::Token::Lifetime(alloc::string::String)
+pub public_api::tokens::Token::Primitive(alloc::string::String)
+pub public_api::tokens::Token::Qualifier(alloc::string::String)
+pub public_api::tokens::Token::Self_(alloc::string::String)
+pub public_api::tokens::Token::Symbol(alloc::string::String)
+pub public_api::tokens::Token::Type(alloc::string::String)
+pub public_api::tokens::Token::Whitespace
 impl public_api::tokens::Token
 pub fn public_api::tokens::Token::len(&self) -> usize
 pub fn public_api::tokens::Token::text(&self) -> &str
@@ -66,8 +66,8 @@ pub fn public_api::tokens::Token::partial_cmp(&self, other: &public_api::tokens:
 impl core::marker::StructuralEq for public_api::tokens::Token
 impl core::marker::StructuralPartialEq for public_api::tokens::Token
 #[non_exhaustive] pub enum public_api::Error
-pub enum variant public_api::Error::IoError(std::io::error::Error)
-pub enum variant public_api::Error::SerdeJsonError(serde_json::error::Error)
+pub public_api::Error::IoError(std::io::error::Error)
+pub public_api::Error::SerdeJsonError(serde_json::error::Error)
 impl core::fmt::Debug for public_api::Error
 pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::Error
@@ -79,10 +79,10 @@ impl core::convert::From<std::io::error::Error> for public_api::Error
 pub fn public_api::Error::from(source: serde_json::error::Error) -> Self
 pub fn public_api::Error::from(source: std::io::error::Error) -> Self
 #[non_exhaustive] pub struct public_api::Options
-pub struct field public_api::Options::debug_sorting: bool
-pub struct field public_api::Options::simplified: bool
-pub struct field public_api::Options::sorted: bool
-pub struct field public_api::Options::with_blanket_implementations: bool
+pub public_api::Options::debug_sorting: bool
+pub public_api::Options::simplified: bool
+pub public_api::Options::sorted: bool
+pub public_api::Options::with_blanket_implementations: bool
 impl core::clone::Clone for public_api::Options
 pub fn public_api::Options::clone(&self) -> public_api::Options
 impl core::marker::Copy for public_api::Options

--- a/cargo-public-api/tests/expected-output/test_repo_api_latest.txt
+++ b/cargo-public-api/tests/expected-output/test_repo_api_latest.txt
@@ -1,8 +1,8 @@
 pub mod example_api
 #[non_exhaustive] pub struct example_api::Struct
-pub struct field example_api::Struct::v1_field: usize
-pub struct field example_api::Struct::v2_field: usize
+pub example_api::Struct::v1_field: usize
+pub example_api::Struct::v2_field: usize
 impl core::fmt::Debug for example_api::Struct
 pub fn example_api::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct example_api::StructV2
-pub struct field example_api::StructV2::field: usize
+pub example_api::StructV2::field: usize

--- a/cargo-public-api/tests/expected-output/test_repo_api_latest_not_simplified.txt
+++ b/cargo-public-api/tests/expected-output/test_repo_api_latest_not_simplified.txt
@@ -1,7 +1,7 @@
 pub mod example_api
 #[non_exhaustive] pub struct example_api::Struct
-pub struct field example_api::Struct::v1_field: usize
-pub struct field example_api::Struct::v2_field: usize
+pub example_api::Struct::v1_field: usize
+pub example_api::Struct::v2_field: usize
 impl core::fmt::Debug for example_api::Struct
 pub fn example_api::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::panic::unwind_safe::RefUnwindSafe for example_api::Struct
@@ -26,7 +26,7 @@ impl<T, U> core::convert::TryInto<U> for example_api::Struct where U: core::conv
 pub type example_api::Struct::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn example_api::Struct::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
 pub struct example_api::StructV2
-pub struct field example_api::StructV2::field: usize
+pub example_api::StructV2::field: usize
 impl core::panic::unwind_safe::RefUnwindSafe for example_api::StructV2
 impl core::marker::Send for example_api::StructV2
 impl core::marker::Sync for example_api::StructV2

--- a/public-api/public-api.txt
+++ b/public-api/public-api.txt
@@ -1,8 +1,8 @@
 pub mod public_api
 pub mod public_api::diff
 pub struct public_api::diff::ChangedPublicItem
-pub struct field public_api::diff::ChangedPublicItem::new: public_api::PublicItem
-pub struct field public_api::diff::ChangedPublicItem::old: public_api::PublicItem
+pub public_api::diff::ChangedPublicItem::new: public_api::PublicItem
+pub public_api::diff::ChangedPublicItem::old: public_api::PublicItem
 impl core::clone::Clone for public_api::diff::ChangedPublicItem
 pub fn public_api::diff::ChangedPublicItem::clone(&self) -> public_api::diff::ChangedPublicItem
 impl core::fmt::Debug for public_api::diff::ChangedPublicItem
@@ -42,9 +42,9 @@ impl<T, U> core::convert::TryInto<U> for public_api::diff::ChangedPublicItem whe
 pub type public_api::diff::ChangedPublicItem::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn public_api::diff::ChangedPublicItem::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
 pub struct public_api::diff::PublicApiDiff
-pub struct field public_api::diff::PublicApiDiff::added: alloc::vec::Vec<public_api::PublicItem>
-pub struct field public_api::diff::PublicApiDiff::changed: alloc::vec::Vec<public_api::diff::ChangedPublicItem>
-pub struct field public_api::diff::PublicApiDiff::removed: alloc::vec::Vec<public_api::PublicItem>
+pub public_api::diff::PublicApiDiff::added: alloc::vec::Vec<public_api::PublicItem>
+pub public_api::diff::PublicApiDiff::changed: alloc::vec::Vec<public_api::diff::ChangedPublicItem>
+pub public_api::diff::PublicApiDiff::removed: alloc::vec::Vec<public_api::PublicItem>
 impl public_api::diff::PublicApiDiff
 pub fn public_api::diff::PublicApiDiff::between(old: public_api::PublicApi, new: public_api::PublicApi) -> Self
 pub fn public_api::diff::PublicApiDiff::is_empty(&self) -> bool
@@ -84,19 +84,19 @@ pub type public_api::diff::PublicApiDiff::Error = <U as core::convert::TryFrom<T
 pub fn public_api::diff::PublicApiDiff::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
 pub mod public_api::tokens
 pub enum public_api::tokens::Token
-pub enum variant public_api::tokens::Token::Annotation(alloc::string::String)
-pub enum variant public_api::tokens::Token::Function(alloc::string::String)
-pub enum variant public_api::tokens::Token::Generic(alloc::string::String)
-pub enum variant public_api::tokens::Token::Identifier(alloc::string::String)
-pub enum variant public_api::tokens::Token::Keyword(alloc::string::String)
-pub enum variant public_api::tokens::Token::Kind(alloc::string::String)
-pub enum variant public_api::tokens::Token::Lifetime(alloc::string::String)
-pub enum variant public_api::tokens::Token::Primitive(alloc::string::String)
-pub enum variant public_api::tokens::Token::Qualifier(alloc::string::String)
-pub enum variant public_api::tokens::Token::Self_(alloc::string::String)
-pub enum variant public_api::tokens::Token::Symbol(alloc::string::String)
-pub enum variant public_api::tokens::Token::Type(alloc::string::String)
-pub enum variant public_api::tokens::Token::Whitespace
+pub public_api::tokens::Token::Annotation(alloc::string::String)
+pub public_api::tokens::Token::Function(alloc::string::String)
+pub public_api::tokens::Token::Generic(alloc::string::String)
+pub public_api::tokens::Token::Identifier(alloc::string::String)
+pub public_api::tokens::Token::Keyword(alloc::string::String)
+pub public_api::tokens::Token::Kind(alloc::string::String)
+pub public_api::tokens::Token::Lifetime(alloc::string::String)
+pub public_api::tokens::Token::Primitive(alloc::string::String)
+pub public_api::tokens::Token::Qualifier(alloc::string::String)
+pub public_api::tokens::Token::Self_(alloc::string::String)
+pub public_api::tokens::Token::Symbol(alloc::string::String)
+pub public_api::tokens::Token::Type(alloc::string::String)
+pub public_api::tokens::Token::Whitespace
 impl public_api::tokens::Token
 pub fn public_api::tokens::Token::len(&self) -> usize
 pub fn public_api::tokens::Token::text(&self) -> &str
@@ -141,8 +141,8 @@ impl<T, U> core::convert::TryInto<U> for public_api::tokens::Token where U: core
 pub type public_api::tokens::Token::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn public_api::tokens::Token::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
 #[non_exhaustive] pub enum public_api::Error
-pub enum variant public_api::Error::IoError(std::io::error::Error)
-pub enum variant public_api::Error::SerdeJsonError(serde_json::error::Error)
+pub public_api::Error::IoError(std::io::error::Error)
+pub public_api::Error::SerdeJsonError(serde_json::error::Error)
 impl core::fmt::Debug for public_api::Error
 pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::Error
@@ -179,10 +179,10 @@ impl<T, U> core::convert::TryInto<U> for public_api::Error where U: core::conver
 pub type public_api::Error::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn public_api::Error::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
 #[non_exhaustive] pub struct public_api::Options
-pub struct field public_api::Options::debug_sorting: bool
-pub struct field public_api::Options::simplified: bool
-pub struct field public_api::Options::sorted: bool
-pub struct field public_api::Options::with_blanket_implementations: bool
+pub public_api::Options::debug_sorting: bool
+pub public_api::Options::simplified: bool
+pub public_api::Options::sorted: bool
+pub public_api::Options::with_blanket_implementations: bool
 impl core::clone::Clone for public_api::Options
 pub fn public_api::Options::clone(&self) -> public_api::Options
 impl core::marker::Copy for public_api::Options

--- a/public-api/src/render.rs
+++ b/public-api/src/render.rs
@@ -66,7 +66,7 @@ impl<'c> RenderingContext<'c> {
                 output
             }
             ItemEnum::StructField(inner) => {
-                let mut output = self.render_simple(&["struct", "field"], item_path);
+                let mut output = self.render_simple(&[], item_path);
                 output.extend(colon());
                 output.extend(self.render_type(inner));
                 output
@@ -77,7 +77,7 @@ impl<'c> RenderingContext<'c> {
                 output
             }
             ItemEnum::Variant(inner) => {
-                let mut output = self.render_simple(&["enum", "variant"], item_path);
+                let mut output = self.render_simple(&[], item_path);
                 match inner {
                     Variant::Struct { .. } => {} // Each struct field is printed individually
                     Variant::Plain(discriminant) => {

--- a/public-api/tests/expected-output/comprehensive_api.txt
+++ b/public-api/tests/expected-output/comprehensive_api.txt
@@ -6,9 +6,9 @@ pub use comprehensive_api::my_i32
 pub use comprehensive_api::u32
 pub mod comprehensive_api::attributes
 #[non_exhaustive] pub enum comprehensive_api::attributes::NonExhaustive
-pub enum variant comprehensive_api::attributes::NonExhaustive::MoreToCome
+pub comprehensive_api::attributes::NonExhaustive::MoreToCome
 #[repr(C)] pub struct comprehensive_api::attributes::C
-pub struct field comprehensive_api::attributes::C::b: bool
+pub comprehensive_api::attributes::C::b: bool
 #[no_mangle] #[link_section = ".custom"] pub static comprehensive_api::attributes::NO_MANGLE_WITH_CUSTOM_LINK_SECTION: usize
 #[export_name = "something_arbitrary"] pub fn comprehensive_api::attributes::export_name()
 pub fn comprehensive_api::attributes::must_use() -> usize
@@ -16,29 +16,29 @@ pub mod comprehensive_api::constants
 pub const comprehensive_api::constants::CONST: &str
 pub mod comprehensive_api::enums
 pub enum comprehensive_api::enums::DiverseVariants
-pub enum variant comprehensive_api::enums::DiverseVariants::Recursive
-pub struct field comprehensive_api::enums::DiverseVariants::Recursive::child: alloc::boxed::Box<comprehensive_api::enums::DiverseVariants>
-pub enum variant comprehensive_api::enums::DiverseVariants::Simple
-pub enum variant comprehensive_api::enums::DiverseVariants::Struct
-pub struct field comprehensive_api::enums::DiverseVariants::Struct::x: usize
-pub struct field comprehensive_api::enums::DiverseVariants::Struct::y: comprehensive_api::enums::SingleVariant
-pub enum variant comprehensive_api::enums::DiverseVariants::Tuple(usize, bool)
+pub comprehensive_api::enums::DiverseVariants::Recursive
+pub comprehensive_api::enums::DiverseVariants::Recursive::child: alloc::boxed::Box<comprehensive_api::enums::DiverseVariants>
+pub comprehensive_api::enums::DiverseVariants::Simple
+pub comprehensive_api::enums::DiverseVariants::Struct
+pub comprehensive_api::enums::DiverseVariants::Struct::x: usize
+pub comprehensive_api::enums::DiverseVariants::Struct::y: comprehensive_api::enums::SingleVariant
+pub comprehensive_api::enums::DiverseVariants::Tuple(usize, bool)
 pub enum comprehensive_api::enums::EnumWithExplicitDiscriminants
-pub enum variant comprehensive_api::enums::EnumWithExplicitDiscriminants::First = 1
-pub enum variant comprehensive_api::enums::EnumWithExplicitDiscriminants::Second = 2
-pub enum variant comprehensive_api::enums::EnumWithExplicitDiscriminants::TenPlusTen = 20
+pub comprehensive_api::enums::EnumWithExplicitDiscriminants::First = 1
+pub comprehensive_api::enums::EnumWithExplicitDiscriminants::Second = 2
+pub comprehensive_api::enums::EnumWithExplicitDiscriminants::TenPlusTen = 20
 pub enum comprehensive_api::enums::EnumWithGenerics<'a, T, D: core::fmt::Debug> where T: core::fmt::Display
-pub enum variant comprehensive_api::enums::EnumWithGenerics::Variant
-pub struct field comprehensive_api::enums::EnumWithGenerics::Variant::d: D
-pub struct field comprehensive_api::enums::EnumWithGenerics::Variant::t: &'a T
+pub comprehensive_api::enums::EnumWithGenerics::Variant
+pub comprehensive_api::enums::EnumWithGenerics::Variant::d: D
+pub comprehensive_api::enums::EnumWithGenerics::Variant::t: &'a T
 pub enum comprehensive_api::enums::EnumWithStrippedTupleVariants
-pub enum variant comprehensive_api::enums::EnumWithStrippedTupleVariants::Double(bool, bool)
-pub enum variant comprehensive_api::enums::EnumWithStrippedTupleVariants::DoubleFirstHidden(_, bool)
-pub enum variant comprehensive_api::enums::EnumWithStrippedTupleVariants::DoubleSecondHidden(bool, _)
-pub enum variant comprehensive_api::enums::EnumWithStrippedTupleVariants::Single(usize)
-pub enum variant comprehensive_api::enums::EnumWithStrippedTupleVariants::SingleHidden(_)
+pub comprehensive_api::enums::EnumWithStrippedTupleVariants::Double(bool, bool)
+pub comprehensive_api::enums::EnumWithStrippedTupleVariants::DoubleFirstHidden(_, bool)
+pub comprehensive_api::enums::EnumWithStrippedTupleVariants::DoubleSecondHidden(bool, _)
+pub comprehensive_api::enums::EnumWithStrippedTupleVariants::Single(usize)
+pub comprehensive_api::enums::EnumWithStrippedTupleVariants::SingleHidden(_)
 pub enum comprehensive_api::enums::SingleVariant
-pub enum variant comprehensive_api::enums::SingleVariant::Variant
+pub comprehensive_api::enums::SingleVariant::Variant
 pub mod comprehensive_api::exports
 pub mod comprehensive_api::exports::issue_145
 pub mod comprehensive_api::exports::issue_145::external
@@ -102,11 +102,11 @@ pub fn comprehensive_api::functions::synthetic_arg(t: impl comprehensive_api::tr
 pub unsafe fn comprehensive_api::functions::unsafe_fn()
 pub mod comprehensive_api::higher_ranked_trait_bounds
 pub struct comprehensive_api::higher_ranked_trait_bounds::Bar<'a>
-pub struct field comprehensive_api::higher_ranked_trait_bounds::Bar::bar: &'a (dyn for<'b> comprehensive_api::higher_ranked_trait_bounds::Trait<'b> + core::marker::Unpin)
-pub struct field comprehensive_api::higher_ranked_trait_bounds::Bar::baz: &'a (dyn core::marker::Unpin + for<'b> comprehensive_api::higher_ranked_trait_bounds::Trait<'b>)
+pub comprehensive_api::higher_ranked_trait_bounds::Bar::bar: &'a (dyn for<'b> comprehensive_api::higher_ranked_trait_bounds::Trait<'b> + core::marker::Unpin)
+pub comprehensive_api::higher_ranked_trait_bounds::Bar::baz: &'a (dyn core::marker::Unpin + for<'b> comprehensive_api::higher_ranked_trait_bounds::Trait<'b>)
 pub struct comprehensive_api::higher_ranked_trait_bounds::Foo<'a>
-pub struct field comprehensive_api::higher_ranked_trait_bounds::Foo::some_func: for<'c> fn(val: &'c i32) -> i32
-pub struct field comprehensive_api::higher_ranked_trait_bounds::Foo::some_trait: &'a dyn for<'b> comprehensive_api::higher_ranked_trait_bounds::Trait<'b>
+pub comprehensive_api::higher_ranked_trait_bounds::Foo::some_func: for<'c> fn(val: &'c i32) -> i32
+pub comprehensive_api::higher_ranked_trait_bounds::Foo::some_trait: &'a dyn for<'b> comprehensive_api::higher_ranked_trait_bounds::Trait<'b>
 impl<'a> comprehensive_api::higher_ranked_trait_bounds::Foo<'a>
 pub fn comprehensive_api::higher_ranked_trait_bounds::Foo::bar<T>() where T: comprehensive_api::higher_ranked_trait_bounds::Trait<'a>
 pub trait comprehensive_api::higher_ranked_trait_bounds::B<'x>
@@ -135,9 +135,9 @@ pub static comprehensive_api::statics::FUNCTION_POINTER: core::option::Option<fn
 pub mut static comprehensive_api::statics::MUT_ANSWER: i8
 pub mod comprehensive_api::structs
 pub struct comprehensive_api::structs::ConstArg<T, const N: usize>
-pub struct field comprehensive_api::structs::ConstArg::items: [T; N]
+pub comprehensive_api::structs::ConstArg::items: [T; N]
 pub struct comprehensive_api::structs::Plain
-pub struct field comprehensive_api::structs::Plain::x: usize
+pub comprehensive_api::structs::Plain::x: usize
 impl comprehensive_api::structs::Plain
 impl<'a> comprehensive_api::structs::Plain
 pub fn comprehensive_api::structs::Plain::f()
@@ -155,8 +155,8 @@ pub struct comprehensive_api::structs::Unit
 impl comprehensive_api::traits::Simple for comprehensive_api::structs::Unit
 pub fn comprehensive_api::structs::Unit::act()
 pub struct comprehensive_api::structs::WithLifetimeAndGenericParam<'a, T>
-pub struct field comprehensive_api::structs::WithLifetimeAndGenericParam::t: T
-pub struct field comprehensive_api::structs::WithLifetimeAndGenericParam::unit_ref: &'a comprehensive_api::structs::Unit
+pub comprehensive_api::structs::WithLifetimeAndGenericParam::t: T
+pub comprehensive_api::structs::WithLifetimeAndGenericParam::unit_ref: &'a comprehensive_api::structs::Unit
 impl<'b> comprehensive_api::structs::WithLifetimeAndGenericParam<'b, alloc::string::String>
 pub fn comprehensive_api::structs::WithLifetimeAndGenericParam::new(unit_ref: &'b comprehensive_api::structs::Unit, t: alloc::string::String) -> Self
 pub struct comprehensive_api::structs::WithTraitBounds<T: core::fmt::Display + core::fmt::Debug>
@@ -194,11 +194,11 @@ pub type comprehensive_api::typedefs::RedefinedResult<T, E> = core::result::Resu
 pub type comprehensive_api::typedefs::TypedefPlain = comprehensive_api::structs::Plain
 pub mod comprehensive_api::unions
 pub union comprehensive_api::unions::Basic
-pub struct field comprehensive_api::unions::Basic::x: usize
-pub struct field comprehensive_api::unions::Basic::y: usize
+pub comprehensive_api::unions::Basic::x: usize
+pub comprehensive_api::unions::Basic::y: usize
 pub macro comprehensive_api::simple_macro!
 pub struct comprehensive_api::Plain
-pub struct field comprehensive_api::Plain::x: usize
+pub comprehensive_api::Plain::x: usize
 impl comprehensive_api::structs::Plain
 impl<'a> comprehensive_api::structs::Plain
 pub fn comprehensive_api::Plain::f()
@@ -208,7 +208,7 @@ pub fn comprehensive_api::Plain::s2(&self)
 pub fn comprehensive_api::Plain::s3(&mut self)
 pub fn comprehensive_api::Plain::s4(&'a self)
 pub struct comprehensive_api::RenamedPlain
-pub struct field comprehensive_api::RenamedPlain::x: usize
+pub comprehensive_api::RenamedPlain::x: usize
 impl comprehensive_api::structs::Plain
 impl<'a> comprehensive_api::structs::Plain
 pub fn comprehensive_api::RenamedPlain::f()

--- a/public-api/tests/expected-output/diff_with_added_items.txt
+++ b/public-api/tests/expected-output/diff_with_added_items.txt
@@ -11,9 +11,9 @@ PublicApiDiff {
         },
     ],
     added: [
-        pub struct field example_api::Struct::v2_field: usize,
+        pub example_api::Struct::v2_field: usize,
         pub struct example_api::StructV2,
-        pub struct field example_api::StructV2::field: usize,
+        pub example_api::StructV2::field: usize,
         impl core::panic::unwind_safe::RefUnwindSafe for example_api::StructV2,
         impl core::marker::Send for example_api::StructV2,
         impl core::marker::Sync for example_api::StructV2,

--- a/public-api/tests/expected-output/diff_with_removed_items.txt
+++ b/public-api/tests/expected-output/diff_with_removed_items.txt
@@ -1,8 +1,8 @@
 PublicApiDiff {
     removed: [
-        pub struct field example_api::Struct::v2_field: usize,
+        pub example_api::Struct::v2_field: usize,
         pub struct example_api::StructV2,
-        pub struct field example_api::StructV2::field: usize,
+        pub example_api::StructV2::field: usize,
         impl core::panic::unwind_safe::RefUnwindSafe for example_api::StructV2,
         impl core::marker::Send for example_api::StructV2,
         impl core::marker::Sync for example_api::StructV2,

--- a/public-api/tests/expected-output/example_api-v0.2.0-not-simplified.txt
+++ b/public-api/tests/expected-output/example_api-v0.2.0-not-simplified.txt
@@ -1,7 +1,7 @@
 pub mod example_api
 #[non_exhaustive] pub struct example_api::Struct
-pub struct field example_api::Struct::v1_field: usize
-pub struct field example_api::Struct::v2_field: usize
+pub example_api::Struct::v1_field: usize
+pub example_api::Struct::v2_field: usize
 impl core::fmt::Debug for example_api::Struct
 pub fn example_api::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::panic::unwind_safe::RefUnwindSafe for example_api::Struct
@@ -26,7 +26,7 @@ impl<T, U> core::convert::TryInto<U> for example_api::Struct where U: core::conv
 pub type example_api::Struct::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn example_api::Struct::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
 pub struct example_api::StructV2
-pub struct field example_api::StructV2::field: usize
+pub example_api::StructV2::field: usize
 impl core::panic::unwind_safe::RefUnwindSafe for example_api::StructV2
 impl core::marker::Send for example_api::StructV2
 impl core::marker::Sync for example_api::StructV2

--- a/public-api/tests/expected-output/print_diff.txt
+++ b/public-api/tests/expected-output/print_diff.txt
@@ -8,7 +8,7 @@ Changed:
 +pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize)
 
 Added:
-+pub struct field example_api::Struct::v2_field: usize
++pub example_api::Struct::v2_field: usize
 +pub struct example_api::StructV2
-+pub struct field example_api::StructV2::field: usize
++pub example_api::StructV2::field: usize
 

--- a/public-api/tests/expected-output/print_diff_reversed.txt
+++ b/public-api/tests/expected-output/print_diff_reversed.txt
@@ -1,7 +1,7 @@
 Removed:
--pub struct field example_api::Struct::v2_field: usize
+-pub example_api::Struct::v2_field: usize
 -pub struct example_api::StructV2
--pub struct field example_api::StructV2::field: usize
+-pub example_api::StructV2::field: usize
 
 Changed:
 -#[non_exhaustive] pub struct example_api::Struct

--- a/rustdoc-json/public-api.txt
+++ b/rustdoc-json/public-api.txt
@@ -1,10 +1,10 @@
 pub mod rustdoc_json
 #[non_exhaustive] pub enum rustdoc_json::BuildError
-pub enum variant rustdoc_json::BuildError::CargoManifestError(cargo_manifest::error::Error)
-pub enum variant rustdoc_json::BuildError::CargoMetadataError(cargo_metadata::errors::Error)
-pub enum variant rustdoc_json::BuildError::General(alloc::string::String)
-pub enum variant rustdoc_json::BuildError::IoError(std::io::error::Error)
-pub enum variant rustdoc_json::BuildError::VirtualManifest(std::path::PathBuf)
+pub rustdoc_json::BuildError::CargoManifestError(cargo_manifest::error::Error)
+pub rustdoc_json::BuildError::CargoMetadataError(cargo_metadata::errors::Error)
+pub rustdoc_json::BuildError::General(alloc::string::String)
+pub rustdoc_json::BuildError::IoError(std::io::error::Error)
+pub rustdoc_json::BuildError::VirtualManifest(std::path::PathBuf)
 impl core::fmt::Debug for rustdoc_json::BuildError
 pub fn rustdoc_json::BuildError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for rustdoc_json::BuildError
@@ -43,11 +43,11 @@ impl<T, U> core::convert::TryInto<U> for rustdoc_json::BuildError where U: core:
 pub type rustdoc_json::BuildError::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn rustdoc_json::BuildError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
 #[non_exhaustive] pub enum rustdoc_json::PackageTarget
-pub enum variant rustdoc_json::PackageTarget::Bench(alloc::string::String)
-pub enum variant rustdoc_json::PackageTarget::Bin(alloc::string::String)
-pub enum variant rustdoc_json::PackageTarget::Example(alloc::string::String)
-pub enum variant rustdoc_json::PackageTarget::Lib
-pub enum variant rustdoc_json::PackageTarget::Test(alloc::string::String)
+pub rustdoc_json::PackageTarget::Bench(alloc::string::String)
+pub rustdoc_json::PackageTarget::Bin(alloc::string::String)
+pub rustdoc_json::PackageTarget::Example(alloc::string::String)
+pub rustdoc_json::PackageTarget::Lib
+pub rustdoc_json::PackageTarget::Test(alloc::string::String)
 impl core::clone::Clone for rustdoc_json::PackageTarget
 pub fn rustdoc_json::PackageTarget::clone(&self) -> rustdoc_json::PackageTarget
 impl core::fmt::Debug for rustdoc_json::PackageTarget

--- a/rustup-toolchain/public-api.txt
+++ b/rustup-toolchain/public-api.txt
@@ -1,8 +1,8 @@
 pub mod rustup_toolchain
 #[non_exhaustive] pub enum rustup_toolchain::Error
-pub enum variant rustup_toolchain::Error::IoError(std::io::error::Error)
-pub enum variant rustup_toolchain::Error::RustupToolchainInstallError
-pub enum variant rustup_toolchain::Error::StdSyncPoisonError
+pub rustup_toolchain::Error::IoError(std::io::error::Error)
+pub rustup_toolchain::Error::RustupToolchainInstallError
+pub rustup_toolchain::Error::StdSyncPoisonError
 impl core::fmt::Debug for rustup_toolchain::Error
 pub fn rustup_toolchain::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for rustup_toolchain::Error


### PR DESCRIPTION
They make the output look very non-Rusty, and by now I think the surrounding items (due to https://github.com/Enselic/cargo-public-api/pull/198 being merged some time ago) and the name of the item itself, makes it sufficiently clear what kind of item it is.

@douweschulte @Emilgardis : This is a quite significant change, so I would like to check with you if you think this sounds and looks good