### PR TITLE
Remove `diff crate-name@0.1.0` support, use `-p crate-name diff 0.1.0` instead

### DIFF
--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -312,6 +312,17 @@ fn diff_with_invalid_published_crate_version() {
 }
 
 #[test]
+fn diff_with_invalid_manifest_path() {
+    let mut cmd = TestCmd::new().with_test_repo();
+    cmd.arg("--manifest-path=/does/not/exists/Cargo.toml");
+    cmd.arg("diff");
+    cmd.arg("0.1.0");
+    cmd.assert()
+        .stderr(contains("You must specify a package"))
+        .failure();
+}
+
+#[test]
 fn diff_with_invalid_git_refs() {
     let mut cmd = TestCmd::new().with_test_repo();
     cmd.arg("diff");


### PR DESCRIPTION
There is no need for the `diff crate-name@0.1.0` syntax, so there is no point in having the overhead of supporting it.