### PR TITLE
Support `cargo public-api diff latest` to diff against the latest published version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,3 +53,4 @@ jobs:
           profile: minimal
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --locked
+      - run: cargo build --locked --no-default-features # Build without "diff-latest" feature

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,7 @@ dependencies = [
  "cargo-manifest",
  "cargo_metadata",
  "clap",
+ "crates-index",
  "diff",
  "dirs",
  "expect-test",
@@ -118,6 +119,9 @@ name = "cc"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -161,6 +165,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "crates-index"
+version = "0.18.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "599f67b56f40863598cb30450427049935d05de2e36c61d33c050f04d7ec8cf2"
+dependencies = [
+ "git2",
+ "hex",
+ "home",
+ "memchr",
+ "num_cpus",
+ "rustc-hash",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "smartstring",
+ "toml",
 ]
 
 [[package]]
@@ -264,6 +288,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +305,19 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "git2"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
 ]
 
 [[package]]
@@ -299,6 +345,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "home"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -358,16 +432,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
+name = "jobserver"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.14.0+1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47a00859c70c8a4f7218e6d1cc32875c4b55f6799445b842b0d8ed5e4c3d959b"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "memchr"
@@ -383,6 +499,16 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -411,6 +537,18 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "percent-encoding"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "predicates"
@@ -554,6 +692,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustdoc-json"
 version = "0.7.4"
 dependencies = [
@@ -649,6 +793,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "serde",
+ "static_assertions",
+ "version_check",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +887,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "toml"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,10 +912,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -25,6 +25,10 @@ thiserror = "1.0.38"
 version = "4.0.32"
 features = ["derive", "wrap_help"]
 
+[dependencies.crates-index]
+version = "0.18.11"
+default-features = false
+
 [dependencies.rustdoc-json]
 path = "../rustdoc-json"
 version = "0.7.4"

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -11,6 +11,12 @@ categories = ["command-line-utilities", "development-tools::cargo-plugins"]
 license = "MIT"
 repository = "https://github.com/Enselic/cargo-public-api"
 
+[features]
+default = ["diff-latest"]
+# Enable `cargo public-api diff latest`. Requires 33 more deps (most notably the
+# `git2` crate) so that the crates.io index can be updated and read.
+diff-latest = ["crates-index"]
+
 [dependencies]
 nu-ansi-term = "0.46.0"
 anyhow = "1.0.68"
@@ -28,6 +34,7 @@ features = ["derive", "wrap_help"]
 [dependencies.crates-index]
 version = "0.18.11"
 default-features = false
+optional = true
 
 [dependencies.rustdoc-json]
 path = "../rustdoc-json"

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/Enselic/cargo-public-api"
 default = ["diff-latest"]
 # Enable `cargo public-api diff latest`. Requires 33 more deps (most notably the
 # `git2` crate) so that the crates.io index can be updated and read.
-diff-latest = ["crates-index"]
+diff-latest = ["dep:crates-index"]
 
 [dependencies]
 nu-ansi-term = "0.46.0"

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -161,9 +161,13 @@ enum Subcommand {
     /// EXAMPLES:
     /// =========
     ///
-    /// Diffing working tree against a published version of the crate:
+    /// Diffing a published version of a crate against the current working tree:
     ///
     ///     cargo public-api diff 1.2.3
+    ///
+    /// Diffing the latest published version of a crate against the current working tree:
+    ///
+    ///     cargo public-api diff latest
     ///
     /// Diffing working tree against a published version of a specific crate in the workspace:
     ///

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -227,6 +227,10 @@ pub enum Action {
     RestoreBranch { name: String },
 }
 
+/// The string used by users to request a diff of the latest published version
+/// of a given crate.
+const LATEST: &str = "latest";
+
 fn main_() -> Result<()> {
     let args = get_args();
 
@@ -344,7 +348,7 @@ for more.
                 Commit::new(args, commits[1])?.boxed(),
             )
         }
-        (Some(first), None) if semver::Version::parse(first).is_ok() => {
+        (Some(first), None) if semver::Version::parse(first).is_ok() || first == LATEST => {
             MainTask::print_diff(PublishedCrate::new(first).boxed(), CurrentDir.boxed())
         }
         (Some(first), None) => {

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -229,7 +229,7 @@ pub enum Action {
 
 /// The string used by users to request a diff of the latest published version
 /// of a given crate.
-const LATEST: &str = "latest";
+const LATEST_VERSION_ARG: &str = "latest";
 
 fn main_() -> Result<()> {
     let args = get_args();
@@ -348,7 +348,9 @@ for more.
                 Commit::new(args, commits[1])?.boxed(),
             )
         }
-        (Some(first), None) if semver::Version::parse(first).is_ok() || first == LATEST => {
+        (Some(first), None)
+            if semver::Version::parse(first).is_ok() || first == LATEST_VERSION_ARG =>
+        {
             MainTask::print_diff(PublishedCrate::new(first).boxed(), CurrentDir.boxed())
         }
         (Some(first), None) => {

--- a/cargo-public-api/src/published_crate.rs
+++ b/cargo-public-api/src/published_crate.rs
@@ -2,7 +2,7 @@
 //! rustdoc JSON for. We then build rustdoc JSON for the crate using this dummy
 //! project.
 
-use crate::Args;
+use crate::{Args, LATEST_VERSION_ARG};
 use anyhow::{anyhow, Result};
 use std::path::PathBuf;
 
@@ -10,11 +10,9 @@ pub fn build_rustdoc_json(version: impl Into<String>, args: &Args) -> Result<Pat
     let package_name = package_name_from_args(args).ok_or_else(|| anyhow!("You must specify a package with either `-p package-name` or `--manifest-path path/to/Cargo.toml`"))?;
 
     let mut version = version.into();
-    if version == crate::LATEST {
+    if version == LATEST_VERSION_ARG {
         version = most_recent_version_for_package(&package_name)?;
-        if args.verbose {
-            println!("Latest published version for `{package_name}` is `{version}`");
-        }
+        eprintln!("Resolved `diff {LATEST_VERSION_ARG}` to `diff {version}`");
     }
 
     let spec = PackageSpec {

--- a/cargo-public-api/src/published_crate.rs
+++ b/cargo-public-api/src/published_crate.rs
@@ -59,7 +59,7 @@ fn most_recent_version_for_package(package_name: &str) -> Result<String> {
     #[cfg(not(feature = "diff-latest"))]
     {
         Err(anyhow!(
-            "Can't find latest version of `{package_name}`; the `diff-latest` feature is disabled"
+            "Can not find latest version of `{package_name}`; the `diff-latest` feature needs to be enabled for `cargo-public-api`"
         ))
     }
 }

--- a/cargo-public-api/src/published_crate.rs
+++ b/cargo-public-api/src/published_crate.rs
@@ -47,12 +47,21 @@ pub fn build_rustdoc_json(version: impl Into<String>, args: &Args) -> Result<Pat
 /// Gets the most recent version for the given package, by querying the
 /// crates.io index that users have locally.
 fn most_recent_version_for_package(package_name: &str) -> Result<String> {
-    let index = crates_index::Index::new_cargo_default()?;
-    let crate_ = index
-        .crate_(package_name)
-        .ok_or_else(|| anyhow!("Could not find crate `{package_name}` in the crates.io index"))?;
-    let version = crate_.most_recent_version();
-    return Ok(version.version().to_string());
+    #[cfg(feature = "diff-latest")]
+    {
+        let index = crates_index::Index::new_cargo_default()?;
+        let crate_ = index.crate_(package_name).ok_or_else(|| {
+            anyhow!("Could not find crate `{package_name}` in the crates.io index")
+        })?;
+        let version = crate_.most_recent_version();
+        Ok(version.version().to_string())
+    }
+    #[cfg(not(feature = "diff-latest"))]
+    {
+        Err(anyhow!(
+            "Can't find latest version of `{package_name}`; the `diff-latest` feature is disabled"
+        ))
+    }
 }
 
 /// When diffing against a published crate, we want to allow the user to not

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -663,6 +663,7 @@ fn diff_against_latest_published_version() {
     cmd.arg("latest");
     cmd.assert()
         .stdout_or_update("./expected-output/diff-latest.txt")
+        .stderr(contains("Resolved `diff latest` to `diff 0.3.0`"))
         .success();
 }
 

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -650,6 +650,23 @@ fn diff_against_published_version() {
 }
 
 #[test]
+fn diff_against_latest_published_version() {
+    // Create a test repo. It already is at the latest version
+    let test_repo = TestRepo::new();
+
+    // Add a new item to the public API
+    append_to_lib_rs_in_test_repo(&test_repo, "pub struct AddedSinceLatest;");
+
+    let mut cmd = TestCmd::new().with_separate_target_dir();
+    cmd.current_dir(test_repo.path());
+    cmd.arg("diff");
+    cmd.arg("latest");
+    cmd.assert()
+        .stdout_or_update("./expected-output/diff-latest.txt")
+        .success();
+}
+
+#[test]
 fn diff_published_explicit_package() {
     let mut cmd = TestCmd::new().with_test_repo();
     cmd.arg("-p");

--- a/cargo-public-api/tests/expected-output/diff-latest.txt
+++ b/cargo-public-api/tests/expected-output/diff-latest.txt
@@ -1,0 +1,12 @@
+Removed items from the public API
+=================================
+(none)
+
+Changed items in the public API
+===============================
+(none)
+
+Added items to the public API
+=============================
++pub struct example_api::AddedSinceLatest
+

--- a/docs/long-diff-help.txt
+++ b/docs/long-diff-help.txt
@@ -15,9 +15,13 @@ If the diffing
 EXAMPLES:
 =========
 
-Diffing working tree against a published version of the crate:
+Diffing a published version of a crate against the current working tree:
 
     cargo public-api diff 1.2.3
+
+Diffing the latest published version of a crate against the current working tree:
+
+    cargo public-api diff latest
 
 Diffing working tree against a published version of a specific crate in the workspace:
 

--- a/scripts/run-ci-locally.sh
+++ b/scripts/run-ci-locally.sh
@@ -13,3 +13,4 @@ scripts/cargo-clippy.sh
 
 cargo test --locked
 
+cargo build --locked --no-default-features # Build without "diff-latest" feature


### PR DESCRIPTION
Which will diff against the latest published version of a crate.

Downsides:
* Using `crates-index` adds 22 deps, crossing the 100 deps line (we end up at 115). Maybe we can find a more light-weight solution.
