### PR TITLE
Put auto derived `impl`s (`Clone`, `Debug`, etc) right after normal `impl`s

### DIFF
--- a/cargo-public-api/tests/expected-output/public_api_list.txt
+++ b/cargo-public-api/tests/expected-output/public_api_list.txt
@@ -68,8 +68,6 @@ impl core::marker::StructuralPartialEq for public_api::tokens::Token
 #[non_exhaustive] pub enum public_api::Error
 pub public_api::Error::IoError(std::io::error::Error)
 pub public_api::Error::SerdeJsonError(serde_json::error::Error)
-impl core::fmt::Debug for public_api::Error
-pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::Error
 pub fn public_api::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::error::Error for public_api::Error
@@ -78,18 +76,20 @@ impl core::convert::From<serde_json::error::Error> for public_api::Error
 impl core::convert::From<std::io::error::Error> for public_api::Error
 pub fn public_api::Error::from(source: serde_json::error::Error) -> Self
 pub fn public_api::Error::from(source: std::io::error::Error) -> Self
+impl core::fmt::Debug for public_api::Error
+pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 #[non_exhaustive] pub struct public_api::Options
 pub public_api::Options::debug_sorting: bool
 pub public_api::Options::simplified: bool
 pub public_api::Options::sorted: bool
 pub public_api::Options::with_blanket_implementations: bool
+impl core::default::Default for public_api::Options
+pub fn public_api::Options::default() -> Self
 impl core::clone::Clone for public_api::Options
 pub fn public_api::Options::clone(&self) -> public_api::Options
 impl core::marker::Copy for public_api::Options
 impl core::fmt::Debug for public_api::Options
 pub fn public_api::Options::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::default::Default for public_api::Options
-pub fn public_api::Options::default() -> Self
 #[non_exhaustive] pub struct public_api::PublicApi
 impl public_api::PublicApi
 pub fn public_api::PublicApi::from_rustdoc_json(path: impl core::convert::AsRef<std::path::Path>, options: public_api::Options) -> public_api::Result<public_api::PublicApi>
@@ -97,28 +97,28 @@ pub fn public_api::PublicApi::from_rustdoc_json_str(rustdoc_json_str: impl core:
 pub fn public_api::PublicApi::into_items(self) -> impl core::iter::traits::iterator::Iterator<Item = public_api::PublicItem>
 pub fn public_api::PublicApi::items(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::PublicItem>
 pub fn public_api::PublicApi::missing_item_ids(&self) -> impl core::iter::traits::iterator::Iterator<Item = &alloc::string::String>
-impl core::fmt::Debug for public_api::PublicApi
-pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::PublicApi
+pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Debug for public_api::PublicApi
 pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct public_api::PublicItem
 impl public_api::PublicItem
 pub fn public_api::PublicItem::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::tokens::Token>
-impl core::clone::Clone for public_api::PublicItem
-pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
 impl core::fmt::Debug for public_api::PublicItem
 pub fn public_api::PublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::PublicItem
 pub fn public_api::PublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::cmp::Ord for public_api::PublicItem
+pub fn public_api::PublicItem::cmp(&self, other: &Self) -> core::cmp::Ordering
+impl core::cmp::PartialOrd<public_api::PublicItem> for public_api::PublicItem
+pub fn public_api::PublicItem::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
+impl core::clone::Clone for public_api::PublicItem
+pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
 impl core::cmp::Eq for public_api::PublicItem
 impl core::hash::Hash for public_api::PublicItem
 pub fn public_api::PublicItem::hash<__H: core::hash::Hasher>(&self, state: &mut __H) -> ()
-impl core::cmp::Ord for public_api::PublicItem
-pub fn public_api::PublicItem::cmp(&self, other: &Self) -> core::cmp::Ordering
 impl core::cmp::PartialEq<public_api::PublicItem> for public_api::PublicItem
 pub fn public_api::PublicItem::eq(&self, other: &public_api::PublicItem) -> bool
-impl core::cmp::PartialOrd<public_api::PublicItem> for public_api::PublicItem
-pub fn public_api::PublicItem::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
 impl core::marker::StructuralEq for public_api::PublicItem
 impl core::marker::StructuralPartialEq for public_api::PublicItem
 pub const public_api::MINIMUM_RUSTDOC_JSON_VERSION: &str

--- a/public-api/public-api.txt
+++ b/public-api/public-api.txt
@@ -143,8 +143,6 @@ pub fn public_api::tokens::Token::try_into(self) -> core::result::Result<U, <U a
 #[non_exhaustive] pub enum public_api::Error
 pub public_api::Error::IoError(std::io::error::Error)
 pub public_api::Error::SerdeJsonError(serde_json::error::Error)
-impl core::fmt::Debug for public_api::Error
-pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::Error
 pub fn public_api::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::error::Error for public_api::Error
@@ -153,6 +151,8 @@ impl core::convert::From<serde_json::error::Error> for public_api::Error
 impl core::convert::From<std::io::error::Error> for public_api::Error
 pub fn public_api::Error::from(source: serde_json::error::Error) -> Self
 pub fn public_api::Error::from(source: std::io::error::Error) -> Self
+impl core::fmt::Debug for public_api::Error
+pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl !core::panic::unwind_safe::RefUnwindSafe for public_api::Error
 impl core::marker::Send for public_api::Error
 impl core::marker::Sync for public_api::Error
@@ -183,13 +183,13 @@ pub public_api::Options::debug_sorting: bool
 pub public_api::Options::simplified: bool
 pub public_api::Options::sorted: bool
 pub public_api::Options::with_blanket_implementations: bool
+impl core::default::Default for public_api::Options
+pub fn public_api::Options::default() -> Self
 impl core::clone::Clone for public_api::Options
 pub fn public_api::Options::clone(&self) -> public_api::Options
 impl core::marker::Copy for public_api::Options
 impl core::fmt::Debug for public_api::Options
 pub fn public_api::Options::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::default::Default for public_api::Options
-pub fn public_api::Options::default() -> Self
 impl core::panic::unwind_safe::RefUnwindSafe for public_api::Options
 impl core::marker::Send for public_api::Options
 impl core::marker::Sync for public_api::Options
@@ -222,9 +222,9 @@ pub fn public_api::PublicApi::from_rustdoc_json_str(rustdoc_json_str: impl core:
 pub fn public_api::PublicApi::into_items(self) -> impl core::iter::traits::iterator::Iterator<Item = public_api::PublicItem>
 pub fn public_api::PublicApi::items(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::PublicItem>
 pub fn public_api::PublicApi::missing_item_ids(&self) -> impl core::iter::traits::iterator::Iterator<Item = &alloc::string::String>
-impl core::fmt::Debug for public_api::PublicApi
-pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::PublicApi
+pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Debug for public_api::PublicApi
 pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::panic::unwind_safe::RefUnwindSafe for public_api::PublicApi
 impl core::marker::Send for public_api::PublicApi
@@ -252,21 +252,21 @@ pub fn public_api::PublicApi::try_into(self) -> core::result::Result<U, <U as co
 pub struct public_api::PublicItem
 impl public_api::PublicItem
 pub fn public_api::PublicItem::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::tokens::Token>
-impl core::clone::Clone for public_api::PublicItem
-pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
 impl core::fmt::Debug for public_api::PublicItem
 pub fn public_api::PublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::PublicItem
 pub fn public_api::PublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::cmp::Ord for public_api::PublicItem
+pub fn public_api::PublicItem::cmp(&self, other: &Self) -> core::cmp::Ordering
+impl core::cmp::PartialOrd<public_api::PublicItem> for public_api::PublicItem
+pub fn public_api::PublicItem::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
+impl core::clone::Clone for public_api::PublicItem
+pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
 impl core::cmp::Eq for public_api::PublicItem
 impl core::hash::Hash for public_api::PublicItem
 pub fn public_api::PublicItem::hash<__H: core::hash::Hasher>(&self, state: &mut __H) -> ()
-impl core::cmp::Ord for public_api::PublicItem
-pub fn public_api::PublicItem::cmp(&self, other: &Self) -> core::cmp::Ordering
 impl core::cmp::PartialEq<public_api::PublicItem> for public_api::PublicItem
 pub fn public_api::PublicItem::eq(&self, other: &public_api::PublicItem) -> bool
-impl core::cmp::PartialOrd<public_api::PublicItem> for public_api::PublicItem
-pub fn public_api::PublicItem::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
 impl core::marker::StructuralEq for public_api::PublicItem
 impl core::marker::StructuralPartialEq for public_api::PublicItem
 impl core::panic::unwind_safe::RefUnwindSafe for public_api::PublicItem

--- a/public-api/src/item_processor.rs
+++ b/public-api/src/item_processor.rs
@@ -170,7 +170,7 @@ impl<'c> ItemProcessor<'c> {
         item: &'c Item,
         impl_: &'c Impl,
     ) {
-        if !ImplKind::from(impl_).is_active(self.options) {
+        if !ImplKind::from(item, impl_).is_active(self.options) {
             return;
         }
 
@@ -289,35 +289,42 @@ pub(crate) fn sorting_prefix(item: &Item) -> u8 {
 
         ItemEnum::Typedef(_) => 19,
 
-        ItemEnum::Impl(impl_) => match ImplKind::from(impl_) {
+        ItemEnum::Impl(impl_) => match ImplKind::from(item, impl_) {
             ImplKind::Normal => 20,
-            ImplKind::AutoTrait => 21,
-            ImplKind::Blanket => 22,
+            ImplKind::AutoDerived => 21,
+            ImplKind::AutoTrait => 22,
+            ImplKind::Blanket => 23,
         },
 
-        ItemEnum::ForeignType => 23,
+        ItemEnum::ForeignType => 24,
 
-        ItemEnum::OpaqueTy(_) => 24,
+        ItemEnum::OpaqueTy(_) => 25,
 
-        ItemEnum::TraitAlias(_) => 25,
+        ItemEnum::TraitAlias(_) => 26,
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ImplKind {
     Normal,
+    AutoDerived,
     AutoTrait,
     Blanket,
 }
 
-impl From<&Impl> for ImplKind {
-    fn from(impl_: &Impl) -> Self {
+impl ImplKind {
+    fn from(impl_item: &Item, impl_: &Impl) -> Self {
         let has_blanket_impl = matches!(impl_.blanket_impl, Some(_));
+        let is_automatically_derived = impl_item
+            .attrs
+            .iter()
+            .any(|a| a == "#[automatically_derived]");
 
         // See https://github.com/rust-lang/rust/blob/54f20bbb8a7aeab93da17c0019c1aaa10329245a/src/librustdoc/json/conversions.rs#L589-L590
         match (impl_.synthetic, has_blanket_impl) {
             (true, false) => ImplKind::AutoTrait,
             (false, true) => ImplKind::Blanket,
+            _ if is_automatically_derived => ImplKind::AutoDerived,
             _ => ImplKind::Normal,
         }
     }
@@ -327,7 +334,7 @@ impl ImplKind {
     fn is_active(&self, options: Options) -> bool {
         match self {
             ImplKind::Blanket | ImplKind::AutoTrait => !options.simplified,
-            ImplKind::Normal => true,
+            ImplKind::Normal | ImplKind::AutoDerived => true,
         }
     }
 }

--- a/rustdoc-json/public-api.txt
+++ b/rustdoc-json/public-api.txt
@@ -5,8 +5,6 @@ pub rustdoc_json::BuildError::CargoMetadataError(cargo_metadata::errors::Error)
 pub rustdoc_json::BuildError::General(alloc::string::String)
 pub rustdoc_json::BuildError::IoError(std::io::error::Error)
 pub rustdoc_json::BuildError::VirtualManifest(std::path::PathBuf)
-impl core::fmt::Debug for rustdoc_json::BuildError
-pub fn rustdoc_json::BuildError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for rustdoc_json::BuildError
 pub fn rustdoc_json::BuildError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::error::Error for rustdoc_json::BuildError
@@ -17,6 +15,8 @@ impl core::convert::From<std::io::error::Error> for rustdoc_json::BuildError
 pub fn rustdoc_json::BuildError::from(source: cargo_manifest::error::Error) -> Self
 pub fn rustdoc_json::BuildError::from(source: cargo_metadata::errors::Error) -> Self
 pub fn rustdoc_json::BuildError::from(source: std::io::error::Error) -> Self
+impl core::fmt::Debug for rustdoc_json::BuildError
+pub fn rustdoc_json::BuildError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl !core::panic::unwind_safe::RefUnwindSafe for rustdoc_json::BuildError
 impl core::marker::Send for rustdoc_json::BuildError
 impl core::marker::Sync for rustdoc_json::BuildError
@@ -96,12 +96,12 @@ pub const fn rustdoc_json::Builder::silent(self, silent: bool) -> Self
 pub fn rustdoc_json::Builder::target(self, target: alloc::string::String) -> Self
 pub fn rustdoc_json::Builder::target_dir(self, target_dir: impl core::convert::AsRef<std::path::Path>) -> Self
 pub fn rustdoc_json::Builder::toolchain(self, toolchain: impl core::convert::Into<core::option::Option<alloc::string::String>>) -> Self
+impl core::default::Default for rustdoc_json::Builder
+pub fn rustdoc_json::Builder::default() -> Self
 impl core::clone::Clone for rustdoc_json::Builder
 pub fn rustdoc_json::Builder::clone(&self) -> rustdoc_json::Builder
 impl core::fmt::Debug for rustdoc_json::Builder
 pub fn rustdoc_json::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::default::Default for rustdoc_json::Builder
-pub fn rustdoc_json::Builder::default() -> Self
 impl core::panic::unwind_safe::RefUnwindSafe for rustdoc_json::Builder
 impl core::marker::Send for rustdoc_json::Builder
 impl core::marker::Sync for rustdoc_json::Builder

--- a/rustup-toolchain/public-api.txt
+++ b/rustup-toolchain/public-api.txt
@@ -3,14 +3,14 @@ pub mod rustup_toolchain
 pub rustup_toolchain::Error::IoError(std::io::error::Error)
 pub rustup_toolchain::Error::RustupToolchainInstallError
 pub rustup_toolchain::Error::StdSyncPoisonError
-impl core::fmt::Debug for rustup_toolchain::Error
-pub fn rustup_toolchain::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for rustup_toolchain::Error
 pub fn rustup_toolchain::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::error::Error for rustup_toolchain::Error
 pub fn rustup_toolchain::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::convert::From<std::io::error::Error> for rustup_toolchain::Error
 pub fn rustup_toolchain::Error::from(source: std::io::error::Error) -> Self
+impl core::fmt::Debug for rustup_toolchain::Error
+pub fn rustup_toolchain::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl !core::panic::unwind_safe::RefUnwindSafe for rustup_toolchain::Error
 impl core::marker::Send for rustup_toolchain::Error
 impl core::marker::Sync for rustup_toolchain::Error


### PR DESCRIPTION
In preparation of fixing #256