### PR TITLE
If `--simplifed` is passed twice, omit auto derived `impl`s (`Clone`, `Debug`, etc)

### DIFF
--- a/cargo-public-api/src/api_source.rs
+++ b/cargo-public-api/src/api_source.rs
@@ -132,7 +132,8 @@ pub fn build_rustdoc_json(builder: rustdoc_json::Builder) -> Result<PathBuf> {
 fn get_options(args: &Args) -> Options {
     let mut options = Options::default();
     options.debug_sorting = args.debug_sorting;
-    options.simplified = args.simplified;
+    options.simplified = args.simplified();
+    options.omit_auto_derived_impls = args.omit_auto_derived_impls();
     options
 }
 

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -34,7 +34,8 @@ pub struct Args {
     package: Option<String>,
 
     /// Omit items that belong to Blanket Implementations and Auto Trait
-    /// Implementations.
+    /// Implementations (first use), and Auto Derived Implementations (second
+    /// use).
     ///
     /// This makes the output significantly less noisy and repetitive, at the
     /// cost of not fully describing the public API.
@@ -44,8 +45,10 @@ pub struct Args {
     ///
     /// Examples of Auto Trait Implementations: `impl Send for Foo`, `impl Sync
     /// for Foo`, and `impl Unpin for Foo`
-    #[arg(short, long)]
-    simplified: bool,
+    ///
+    /// Examples of Auto Derived Implementations: `Clone`, `Debug`, `Eq`
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    simplified: u8,
 
     /// Space or comma separated list of features to activate
     #[arg(long, short = 'F', num_args = 1..)]
@@ -447,6 +450,14 @@ impl Action {
 }
 
 impl Args {
+    fn simplified(&self) -> bool {
+        self.simplified > 0
+    }
+
+    fn omit_auto_derived_impls(&self) -> bool {
+        self.simplified > 1
+    }
+
     fn git_root(&self) -> Result<PathBuf> {
         git_utils::git_root_from_manifest_path(self.manifest_path.as_path())
     }

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -43,6 +43,15 @@ fn list_public_items() {
 }
 
 #[test]
+fn list_public_items_omit_auto_derived_impls() {
+    let mut cmd = TestCmd::as_subcommand_without_args().with_test_repo();
+    cmd.arg("-ss"); // Note the double -s
+    cmd.assert()
+        .stdout_or_update("./expected-output/omit-auto-derived-impls.txt")
+        .success();
+}
+
+#[test]
 fn list_public_items_with_lint_error() {
     let mut cmd = TestCmd::new().with_separate_target_dir();
     cmd.args(["--manifest-path", "../test-apis/lint_error/Cargo.toml"]);

--- a/cargo-public-api/tests/expected-output/omit-auto-derived-impls.txt
+++ b/cargo-public-api/tests/expected-output/omit-auto-derived-impls.txt
@@ -1,0 +1,6 @@
+pub mod example_api
+#[non_exhaustive] pub struct example_api::Struct
+pub example_api::Struct::v1_field: usize
+pub example_api::Struct::v2_field: usize
+pub struct example_api::StructV2
+pub example_api::StructV2::field: usize

--- a/cargo-public-api/tests/expected-output/public_api_list.txt
+++ b/cargo-public-api/tests/expected-output/public_api_list.txt
@@ -80,6 +80,7 @@ impl core::fmt::Debug for public_api::Error
 pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 #[non_exhaustive] pub struct public_api::Options
 pub public_api::Options::debug_sorting: bool
+pub public_api::Options::omit_auto_derived_impls: bool
 pub public_api::Options::simplified: bool
 pub public_api::Options::sorted: bool
 pub public_api::Options::with_blanket_implementations: bool

--- a/docs/long-help.txt
+++ b/docs/long-help.txt
@@ -18,8 +18,9 @@ Options:
   -p, --package <PACKAGE>
           Name of package in workspace to list or diff the public API for
 
-  -s, --simplified
-          Omit items that belong to Blanket Implementations and Auto Trait Implementations.
+  -s, --simplified...
+          Omit items that belong to Blanket Implementations and Auto Trait Implementations (first
+          use), and Auto Derived Implementations (second use).
           
           This makes the output significantly less noisy and repetitive, at the cost of not fully
           describing the public API.
@@ -29,6 +30,8 @@ Options:
           
           Examples of Auto Trait Implementations: `impl Send for Foo`, `impl Sync for Foo`, and
           `impl Unpin for Foo`
+          
+          Examples of Auto Derived Implementations: `Clone`, `Debug`, `Eq`
 
   -F, --features <FEATURES>...
           Space or comma separated list of features to activate

--- a/docs/short-help.txt
+++ b/docs/short-help.txt
@@ -10,8 +10,9 @@ Commands:
 Options:
       --manifest-path <PATH>    Path to `Cargo.toml` [default: Cargo.toml]
   -p, --package <PACKAGE>       Name of package in workspace to list or diff the public API for
-  -s, --simplified              Omit items that belong to Blanket Implementations and Auto Trait
-                                Implementations
+  -s, --simplified...           Omit items that belong to Blanket Implementations and Auto Trait
+                                Implementations (first use), and Auto Derived Implementations
+                                (second use)
   -F, --features <FEATURES>...  Space or comma separated list of features to activate
       --all-features            Activate all available features
       --no-default-features     Do not activate the `default` feature

--- a/public-api/public-api.txt
+++ b/public-api/public-api.txt
@@ -180,6 +180,7 @@ pub type public_api::Error::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn public_api::Error::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
 #[non_exhaustive] pub struct public_api::Options
 pub public_api::Options::debug_sorting: bool
+pub public_api::Options::omit_auto_derived_impls: bool
 pub public_api::Options::simplified: bool
 pub public_api::Options::sorted: bool
 pub public_api::Options::with_blanket_implementations: bool

--- a/public-api/src/item_processor.rs
+++ b/public-api/src/item_processor.rs
@@ -334,7 +334,8 @@ impl ImplKind {
     fn is_active(&self, options: Options) -> bool {
         match self {
             ImplKind::Blanket | ImplKind::AutoTrait => !options.simplified,
-            ImplKind::Normal | ImplKind::AutoDerived => true,
+            ImplKind::AutoDerived => !options.omit_auto_derived_impls,
+            ImplKind::Normal => true,
         }
     }
 }

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -112,6 +112,15 @@ pub struct Options {
     /// The default value is `false` so that the listed public API is complete
     /// by default.
     pub simplified: bool,
+
+    /// If `true`, items that belongs to automatically derived implementations
+    /// (`Clone`, `Debug`, `Eq`, etc) are omitted from the output. This makes
+    /// the output less noisy, at the cost of not fully describing the public
+    /// API.
+    ///
+    /// The default value is `false` so that the listed public API is complete
+    /// by default.
+    pub omit_auto_derived_impls: bool,
 }
 
 /// Enables options to be set up like this (note that `Options` is marked
@@ -131,6 +140,7 @@ impl Default for Options {
             sorted: true,
             debug_sorting: false,
             simplified: false,
+            omit_auto_derived_impls: false,
         }
     }
 }


### PR DESCRIPTION
Closes #256 