### PR TITLE
Remove deprecated `public_api::Options::with_blanket_implementations`

### DIFF
--- a/cargo-public-api/tests/expected-output/public_api_list.txt
+++ b/cargo-public-api/tests/expected-output/public_api_list.txt
@@ -83,7 +83,6 @@ pub public_api::Options::debug_sorting: bool
 pub public_api::Options::omit_auto_derived_impls: bool
 pub public_api::Options::simplified: bool
 pub public_api::Options::sorted: bool
-pub public_api::Options::with_blanket_implementations: bool
 impl core::default::Default for public_api::Options
 pub fn public_api::Options::default() -> Self
 impl core::clone::Clone for public_api::Options

--- a/public-api/CHANGELOG.md
+++ b/public-api/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 If a version is not listed below, it means it had no API changes.
 
+## Unreleased v0.26.0
+* Remove deprecated `Options::with_blanket_implementations`
+
 ## v0.25.0
 * Get rid of `enum variant` and `struct field` prefixes in rendered items
 * Group impl blocks together with their respective functions

--- a/public-api/public-api.txt
+++ b/public-api/public-api.txt
@@ -183,7 +183,6 @@ pub public_api::Options::debug_sorting: bool
 pub public_api::Options::omit_auto_derived_impls: bool
 pub public_api::Options::simplified: bool
 pub public_api::Options::sorted: bool
-pub public_api::Options::with_blanket_implementations: bool
 impl core::default::Default for public_api::Options
 pub fn public_api::Options::default() -> Self
 impl core::clone::Clone for public_api::Options

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -75,14 +75,6 @@ pub const MINIMUM_RUSTDOC_JSON_VERSION: &str = "nightly-2022-09-28";
 #[non_exhaustive] // More options are likely to be added in the future
 #[allow(clippy::struct_excessive_bools)]
 pub struct Options {
-    /// Deprecated. Blanket Implementations are included by default. Set
-    /// `simplified = true` to omit both Blanket Implementations and Auto Trait
-    /// Implementations.
-    #[deprecated(
-        note = "Blanket Implementations are included by default. Set `simplified = true` to omit both Blanket Implementations and Auto Trait Implementations"
-    )]
-    pub with_blanket_implementations: bool,
-
     /// If `true`, items will be sorted before being returned. If you will pass
     /// on the return value to [`diff::PublicApiDiff::between`], it is
     /// currently unnecessary to sort first, because the sorting will be
@@ -134,9 +126,7 @@ pub struct Options {
 /// ```
 impl Default for Options {
     fn default() -> Self {
-        #[allow(deprecated)]
         Self {
-            with_blanket_implementations: false,
             sorted: true,
             debug_sorting: false,
             simplified: false,


### PR DESCRIPTION
I will split up `Options::simplified` into `Options::omit_auto_trait_impls` and `Options::omit_blanket_impls`, so we might as well remove this deprecation option too now.