### PR TITLE
Split `public_api::Options::simplified` into `::omit_auto_trait_impls` and `::omit_blanket_impls`

### DIFF
--- a/cargo-public-api/src/api_source.rs
+++ b/cargo-public-api/src/api_source.rs
@@ -132,7 +132,8 @@ pub fn build_rustdoc_json(builder: rustdoc_json::Builder) -> Result<PathBuf> {
 fn get_options(args: &Args) -> Options {
     let mut options = Options::default();
     options.debug_sorting = args.debug_sorting;
-    options.simplified = args.simplified();
+    options.omit_blanket_impls = args.simplified();
+    options.omit_auto_trait_impls = args.simplified();
     options.omit_auto_derived_impls = args.omit_auto_derived_impls();
     options
 }

--- a/cargo-public-api/tests/expected-output/public_api_list.txt
+++ b/cargo-public-api/tests/expected-output/public_api_list.txt
@@ -81,7 +81,8 @@ pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::
 #[non_exhaustive] pub struct public_api::Options
 pub public_api::Options::debug_sorting: bool
 pub public_api::Options::omit_auto_derived_impls: bool
-pub public_api::Options::simplified: bool
+pub public_api::Options::omit_auto_trait_impls: bool
+pub public_api::Options::omit_blanket_impls: bool
 pub public_api::Options::sorted: bool
 impl core::default::Default for public_api::Options
 pub fn public_api::Options::default() -> Self

--- a/public-api/CHANGELOG.md
+++ b/public-api/CHANGELOG.md
@@ -4,6 +4,7 @@ If a version is not listed below, it means it had no API changes.
 
 ## Unreleased v0.26.0
 * Remove deprecated `Options::with_blanket_implementations`
+* Split `Options::simplified` into `Options::omit_auto_trait_impls` and `Options::omit_blanket_impls`
 
 ## v0.25.0
 * Get rid of `enum variant` and `struct field` prefixes in rendered items

--- a/public-api/public-api.txt
+++ b/public-api/public-api.txt
@@ -181,7 +181,8 @@ pub fn public_api::Error::try_into(self) -> core::result::Result<U, <U as core::
 #[non_exhaustive] pub struct public_api::Options
 pub public_api::Options::debug_sorting: bool
 pub public_api::Options::omit_auto_derived_impls: bool
-pub public_api::Options::simplified: bool
+pub public_api::Options::omit_auto_trait_impls: bool
+pub public_api::Options::omit_blanket_impls: bool
 pub public_api::Options::sorted: bool
 impl core::default::Default for public_api::Options
 pub fn public_api::Options::default() -> Self

--- a/public-api/src/item_processor.rs
+++ b/public-api/src/item_processor.rs
@@ -333,7 +333,8 @@ impl ImplKind {
 impl ImplKind {
     fn is_active(&self, options: Options) -> bool {
         match self {
-            ImplKind::Blanket | ImplKind::AutoTrait => !options.simplified,
+            ImplKind::Blanket => !options.omit_blanket_impls,
+            ImplKind::AutoTrait => !options.omit_auto_trait_impls,
             ImplKind::AutoDerived => !options.omit_auto_derived_impls,
             ImplKind::Normal => true,
         }

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -90,20 +90,27 @@ pub struct Options {
     /// The default value is `false`
     pub debug_sorting: bool,
 
-    /// If `true`, items that belongs to Blanket Implementations and Auto Trait
-    /// Implementations are omitted from the output. This makes the output
-    /// significantly less noisy and repetitive, at the cost of not fully
-    /// describing the public API.
+    /// If `true`, items that belongs to Blanket Implementations are omitted
+    /// from the output. This makes the output less noisy, at the cost of not
+    /// fully describing the public API.
     ///
     /// Examples of Blanket Implementations: `impl<T> Any for T`, `impl<T>
     /// Borrow<T> for T`, and `impl<T, U> Into<U> for T where U: From<T>`
+    ///
+    /// The default value is `false` so that the listed public API is complete
+    /// by default.
+    pub omit_blanket_impls: bool,
+
+    /// If `true`, items that belongs to Auto Trait Implementations are omitted
+    /// from the output. This makes the output less noisy, at the cost of not
+    /// fully describing the public API.
     ///
     /// Examples of Auto Trait Implementations: `impl Send for Foo`, `impl Sync
     /// for Foo`, and `impl Unpin for Foo`
     ///
     /// The default value is `false` so that the listed public API is complete
     /// by default.
-    pub simplified: bool,
+    pub omit_auto_trait_impls: bool,
 
     /// If `true`, items that belongs to automatically derived implementations
     /// (`Clone`, `Debug`, `Eq`, etc) are omitted from the output. This makes
@@ -129,7 +136,8 @@ impl Default for Options {
         Self {
             sorted: true,
             debug_sorting: false,
-            simplified: false,
+            omit_blanket_impls: false,
+            omit_auto_trait_impls: false,
             omit_auto_derived_impls: false,
         }
     }

--- a/public-api/src/main.rs
+++ b/public-api/src/main.rs
@@ -20,6 +20,7 @@ enum Error {
 
 type Result<T> = std::result::Result<T, Error>;
 
+/// Use `cargo-public-api` for a much richer set of command line options.
 #[derive(Default)]
 struct Args {
     help: bool,
@@ -36,7 +37,10 @@ fn main_() -> Result<()> {
     }
 
     let mut options = Options::default();
-    options.simplified = args.simplified;
+    if args.simplified {
+        options.omit_blanket_impls = true;
+        options.omit_auto_trait_impls = true;
+    }
     options.sorted = true;
 
     let files = args.files;

--- a/public-api/tests/expected-output/example_api-v0.2.0-omit_auto_trait_impls.txt
+++ b/public-api/tests/expected-output/example_api-v0.2.0-omit_auto_trait_impls.txt
@@ -1,0 +1,41 @@
+pub mod example_api
+#[non_exhaustive] pub struct example_api::Struct
+pub example_api::Struct::v1_field: usize
+pub example_api::Struct::v2_field: usize
+impl core::fmt::Debug for example_api::Struct
+pub fn example_api::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> core::any::Any for example_api::Struct where T: 'static + core::marker::Sized
+pub fn example_api::Struct::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for example_api::Struct where T: core::marker::Sized
+pub fn example_api::Struct::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for example_api::Struct where T: core::marker::Sized
+pub fn example_api::Struct::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for example_api::Struct
+pub fn example_api::Struct::from(t: T) -> T
+impl<T, U> core::convert::Into<U> for example_api::Struct where U: core::convert::From<T>
+pub fn example_api::Struct::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for example_api::Struct where U: core::convert::Into<T>
+pub type example_api::Struct::Error = core::convert::Infallible
+pub fn example_api::Struct::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for example_api::Struct where U: core::convert::TryFrom<T>
+pub type example_api::Struct::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn example_api::Struct::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+pub struct example_api::StructV2
+pub example_api::StructV2::field: usize
+impl<T> core::any::Any for example_api::StructV2 where T: 'static + core::marker::Sized
+pub fn example_api::StructV2::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for example_api::StructV2 where T: core::marker::Sized
+pub fn example_api::StructV2::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for example_api::StructV2 where T: core::marker::Sized
+pub fn example_api::StructV2::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for example_api::StructV2
+pub fn example_api::StructV2::from(t: T) -> T
+impl<T, U> core::convert::Into<U> for example_api::StructV2 where U: core::convert::From<T>
+pub fn example_api::StructV2::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for example_api::StructV2 where U: core::convert::Into<T>
+pub type example_api::StructV2::Error = core::convert::Infallible
+pub fn example_api::StructV2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for example_api::StructV2 where U: core::convert::TryFrom<T>
+pub type example_api::StructV2::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn example_api::StructV2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize)

--- a/public-api/tests/expected-output/example_api-v0.2.0-omit_blanket_impls.txt
+++ b/public-api/tests/expected-output/example_api-v0.2.0-omit_blanket_impls.txt
@@ -1,0 +1,19 @@
+pub mod example_api
+#[non_exhaustive] pub struct example_api::Struct
+pub example_api::Struct::v1_field: usize
+pub example_api::Struct::v2_field: usize
+impl core::fmt::Debug for example_api::Struct
+pub fn example_api::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::panic::unwind_safe::RefUnwindSafe for example_api::Struct
+impl core::marker::Send for example_api::Struct
+impl core::marker::Sync for example_api::Struct
+impl core::marker::Unpin for example_api::Struct
+impl core::panic::unwind_safe::UnwindSafe for example_api::Struct
+pub struct example_api::StructV2
+pub example_api::StructV2::field: usize
+impl core::panic::unwind_safe::RefUnwindSafe for example_api::StructV2
+impl core::marker::Send for example_api::StructV2
+impl core::marker::Sync for example_api::StructV2
+impl core::marker::Unpin for example_api::StructV2
+impl core::panic::unwind_safe::UnwindSafe for example_api::StructV2
+pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize)

--- a/public-api/tests/expected-output/example_api-v0.2.0-simplified_without_auto_derived_impls.txt
+++ b/public-api/tests/expected-output/example_api-v0.2.0-simplified_without_auto_derived_impls.txt
@@ -1,0 +1,7 @@
+pub mod example_api
+#[non_exhaustive] pub struct example_api::Struct
+pub example_api::Struct::v1_field: usize
+pub example_api::Struct::v2_field: usize
+pub struct example_api::StructV2
+pub example_api::StructV2::field: usize
+pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize)

--- a/public-api/tests/public-api-lib-tests.rs
+++ b/public-api/tests/public-api-lib-tests.rs
@@ -37,6 +37,21 @@ fn not_simplified() {
 }
 
 #[test]
+fn simplified_without_auto_derived_impls() {
+    // Create independent build dir so all tests can run in parallel
+    let build_dir = tempdir().unwrap();
+
+    let mut options = simplified();
+    options.omit_auto_derived_impls = true;
+
+    assert_public_api(
+        rustdoc_json_path_for_crate("../test-apis/example_api-v0.2.0", &build_dir),
+        "./expected-output/example_api-v0.2.0-simplified_without_auto_derived_impls.txt",
+        options,
+    );
+}
+
+#[test]
 fn diff_with_added_items() {
     // Create independent build dirs so all tests can run in parallel
     let build_dir = tempdir().unwrap();
@@ -130,9 +145,7 @@ fn assert_public_api_diff(
 /// matches the expected output. For brevity, Auto Trait or Blanket impls are
 /// not included.
 fn assert_simplified_public_api(json: impl AsRef<Path>, expected: impl AsRef<Path>) {
-    let mut options = Options::default();
-    options.simplified = true;
-    assert_public_api(json, expected, options);
+    assert_public_api(json, expected, simplified());
 }
 
 /// Asserts that the public API of the crate in the given rustdoc JSON file
@@ -147,4 +160,13 @@ fn assert_public_api(
         .to_string();
 
     expect_file![expected_output.as_ref()].assert_eq(&api);
+}
+
+/// Returns options for a so called "simplified" API, which is an API without
+/// Auto Trait or Blanket impls, to reduce public item noise.
+fn simplified() -> Options {
+    let mut options = Options::default();
+    options.omit_blanket_impls = true;
+    options.omit_auto_trait_impls = true;
+    options
 }

--- a/public-api/tests/public-api-lib-tests.rs
+++ b/public-api/tests/public-api-lib-tests.rs
@@ -52,6 +52,36 @@ fn simplified_without_auto_derived_impls() {
 }
 
 #[test]
+fn omit_blanket_impls() {
+    // Create independent build dir so all tests can run in parallel
+    let build_dir = tempdir().unwrap();
+
+    let mut options = Options::default();
+    options.omit_blanket_impls = true;
+
+    assert_public_api(
+        rustdoc_json_path_for_crate("../test-apis/example_api-v0.2.0", &build_dir),
+        "./expected-output/example_api-v0.2.0-omit_blanket_impls.txt",
+        options,
+    );
+}
+
+#[test]
+fn omit_auto_trait_impls() {
+    // Create independent build dir so all tests can run in parallel
+    let build_dir = tempdir().unwrap();
+
+    let mut options = Options::default();
+    options.omit_auto_trait_impls = true;
+
+    assert_public_api(
+        rustdoc_json_path_for_crate("../test-apis/example_api-v0.2.0", &build_dir),
+        "./expected-output/example_api-v0.2.0-omit_auto_trait_impls.txt",
+        options,
+    );
+}
+
+#[test]
 fn diff_with_added_items() {
     // Create independent build dirs so all tests can run in parallel
     let build_dir = tempdir().unwrap();


### PR DESCRIPTION
So that the public-api public API gets higher resolution and more powerful.

For CLIs we keep `--simplified` for now, because I think it would be unnecessarily complicated to have a CLI that controls these independently.