### PR TITLE
Properly group multiple inherent `impl`s

### DIFF
--- a/cargo-public-api/tests/expected-output/public_api_list.txt
+++ b/cargo-public-api/tests/expected-output/public_api_list.txt
@@ -3,15 +3,13 @@ pub mod public_api::diff
 pub struct public_api::diff::ChangedPublicItem
 pub public_api::diff::ChangedPublicItem::new: public_api::PublicItem
 pub public_api::diff::ChangedPublicItem::old: public_api::PublicItem
+impl public_api::diff::ChangedPublicItem
+pub fn public_api::diff::ChangedPublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
 impl core::clone::Clone for public_api::diff::ChangedPublicItem
 pub fn public_api::diff::ChangedPublicItem::clone(&self) -> public_api::diff::ChangedPublicItem
 impl core::cmp::Eq for public_api::diff::ChangedPublicItem
-impl core::cmp::Ord for public_api::diff::ChangedPublicItem
-pub fn public_api::diff::ChangedPublicItem::cmp(&self, other: &public_api::diff::ChangedPublicItem) -> core::cmp::Ordering
 impl core::cmp::PartialEq<public_api::diff::ChangedPublicItem> for public_api::diff::ChangedPublicItem
 pub fn public_api::diff::ChangedPublicItem::eq(&self, other: &public_api::diff::ChangedPublicItem) -> bool
-impl core::cmp::PartialOrd<public_api::diff::ChangedPublicItem> for public_api::diff::ChangedPublicItem
-pub fn public_api::diff::ChangedPublicItem::partial_cmp(&self, other: &public_api::diff::ChangedPublicItem) -> core::option::Option<core::cmp::Ordering>
 impl core::fmt::Debug for public_api::diff::ChangedPublicItem
 pub fn public_api::diff::ChangedPublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralEq for public_api::diff::ChangedPublicItem
@@ -104,23 +102,18 @@ impl core::fmt::Debug for public_api::PublicApi
 pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct public_api::PublicItem
 impl public_api::PublicItem
+pub fn public_api::PublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
 pub fn public_api::PublicItem::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::tokens::Token>
-impl core::cmp::Ord for public_api::PublicItem
-pub fn public_api::PublicItem::cmp(&self, other: &Self) -> core::cmp::Ordering
-impl core::cmp::PartialOrd<public_api::PublicItem> for public_api::PublicItem
-pub fn public_api::PublicItem::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
+impl core::cmp::Eq for public_api::PublicItem
+impl core::cmp::PartialEq<public_api::PublicItem> for public_api::PublicItem
+pub fn public_api::PublicItem::eq(&self, other: &Self) -> bool
 impl core::fmt::Debug for public_api::PublicItem
 pub fn public_api::PublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::PublicItem
 pub fn public_api::PublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for public_api::PublicItem
+pub fn public_api::PublicItem::hash<H: core::hash::Hasher>(&self, state: &mut H)
 impl core::clone::Clone for public_api::PublicItem
 pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
-impl core::cmp::Eq for public_api::PublicItem
-impl core::cmp::PartialEq<public_api::PublicItem> for public_api::PublicItem
-pub fn public_api::PublicItem::eq(&self, other: &public_api::PublicItem) -> bool
-impl core::hash::Hash for public_api::PublicItem
-pub fn public_api::PublicItem::hash<__H: core::hash::Hasher>(&self, state: &mut __H) -> ()
-impl core::marker::StructuralEq for public_api::PublicItem
-impl core::marker::StructuralPartialEq for public_api::PublicItem
 pub const public_api::MINIMUM_RUSTDOC_JSON_VERSION: &str
 pub type public_api::Result<T> = core::result::Result<T, public_api::Error>

--- a/public-api/CHANGELOG.md
+++ b/public-api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 If a version is not listed below, it means it had no API changes.
 
+## Unreleased v0.27.0
+* Make `Eq` and `Hash` for `PublicItem` only take tokens into account, to make diffing insensitive to internal data that has no bearing on public API surface of a crate
+* Remove `Ord` and `PartialOrd` impls of `PublicItem` and `ChangedPublicItem`. Use `PublicItem::grouping_cmp` and `ChangedPublicItem::grouping_cmp` instead.
+
 ## v0.26.0
 * Put auto-derived impls (`Clone`, `Debug`, etc) in a separate group, right after normal `impl`s
 * Remove deprecated `Options::with_blanket_implementations`

--- a/public-api/public-api.txt
+++ b/public-api/public-api.txt
@@ -3,15 +3,13 @@ pub mod public_api::diff
 pub struct public_api::diff::ChangedPublicItem
 pub public_api::diff::ChangedPublicItem::new: public_api::PublicItem
 pub public_api::diff::ChangedPublicItem::old: public_api::PublicItem
+impl public_api::diff::ChangedPublicItem
+pub fn public_api::diff::ChangedPublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
 impl core::clone::Clone for public_api::diff::ChangedPublicItem
 pub fn public_api::diff::ChangedPublicItem::clone(&self) -> public_api::diff::ChangedPublicItem
 impl core::cmp::Eq for public_api::diff::ChangedPublicItem
-impl core::cmp::Ord for public_api::diff::ChangedPublicItem
-pub fn public_api::diff::ChangedPublicItem::cmp(&self, other: &public_api::diff::ChangedPublicItem) -> core::cmp::Ordering
 impl core::cmp::PartialEq<public_api::diff::ChangedPublicItem> for public_api::diff::ChangedPublicItem
 pub fn public_api::diff::ChangedPublicItem::eq(&self, other: &public_api::diff::ChangedPublicItem) -> bool
-impl core::cmp::PartialOrd<public_api::diff::ChangedPublicItem> for public_api::diff::ChangedPublicItem
-pub fn public_api::diff::ChangedPublicItem::partial_cmp(&self, other: &public_api::diff::ChangedPublicItem) -> core::option::Option<core::cmp::Ordering>
 impl core::fmt::Debug for public_api::diff::ChangedPublicItem
 pub fn public_api::diff::ChangedPublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralEq for public_api::diff::ChangedPublicItem
@@ -252,24 +250,19 @@ impl<T> core::convert::From<T> for public_api::PublicApi
 pub fn public_api::PublicApi::from(t: T) -> T
 pub struct public_api::PublicItem
 impl public_api::PublicItem
+pub fn public_api::PublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
 pub fn public_api::PublicItem::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::tokens::Token>
-impl core::cmp::Ord for public_api::PublicItem
-pub fn public_api::PublicItem::cmp(&self, other: &Self) -> core::cmp::Ordering
-impl core::cmp::PartialOrd<public_api::PublicItem> for public_api::PublicItem
-pub fn public_api::PublicItem::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
+impl core::cmp::Eq for public_api::PublicItem
+impl core::cmp::PartialEq<public_api::PublicItem> for public_api::PublicItem
+pub fn public_api::PublicItem::eq(&self, other: &Self) -> bool
 impl core::fmt::Debug for public_api::PublicItem
 pub fn public_api::PublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::PublicItem
 pub fn public_api::PublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for public_api::PublicItem
+pub fn public_api::PublicItem::hash<H: core::hash::Hasher>(&self, state: &mut H)
 impl core::clone::Clone for public_api::PublicItem
 pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
-impl core::cmp::Eq for public_api::PublicItem
-impl core::cmp::PartialEq<public_api::PublicItem> for public_api::PublicItem
-pub fn public_api::PublicItem::eq(&self, other: &public_api::PublicItem) -> bool
-impl core::hash::Hash for public_api::PublicItem
-pub fn public_api::PublicItem::hash<__H: core::hash::Hasher>(&self, state: &mut __H) -> ()
-impl core::marker::StructuralEq for public_api::PublicItem
-impl core::marker::StructuralPartialEq for public_api::PublicItem
 impl core::marker::Send for public_api::PublicItem
 impl core::marker::Sync for public_api::PublicItem
 impl core::marker::Unpin for public_api::PublicItem

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -229,7 +229,7 @@ impl PublicApi {
         let mut public_api = item_processor::public_api_in_crate(&crate_, options);
 
         if options.sorted {
-            public_api.items.sort();
+            public_api.items.sort_by(PublicItem::grouping_cmp);
         }
 
         Ok(public_api)

--- a/public-api/tests/common/mod.rs
+++ b/public-api/tests/common/mod.rs
@@ -1,3 +1,5 @@
+#![allow(unused)] // Used from many crates, but not all crates use all functions.
+
 use std::path::{Path, PathBuf};
 
 /// Builds rustdoc JSON for the given test crate.
@@ -5,12 +7,25 @@ use std::path::{Path, PathBuf};
 /// Output of child processes are not captured by the Rust test framework (see
 /// <https://users.rust-lang.org/t/cargo-doesnt-capture-stderr-in-tests/67045/4>),
 /// so build quietly to avoid noisy test output.
-pub fn rustdoc_json_path_for_crate(test_crate: &str, target_dir: impl AsRef<Path>) -> PathBuf {
+pub fn rustdoc_json_path_for_crate(
+    test_crate: impl AsRef<Path>,
+    target_dir: impl AsRef<Path>,
+) -> PathBuf {
+    let mut manifest_path = test_crate.as_ref().to_path_buf();
+    manifest_path.push("Cargo.toml");
+
     rustdoc_json::Builder::default()
-        .manifest_path(&format!("{}/Cargo.toml", test_crate))
+        .manifest_path(&manifest_path)
         .toolchain("nightly".to_owned())
         .target_dir(target_dir)
         .quiet(true)
         .build()
         .unwrap()
+}
+
+/// Builds rustdoc JSON for the given temporary test crate. A temporary test
+/// crate is a crate set up in a temporary directory, so that the target dir and
+/// root dir can be the same while still allowing tests to run concurrently.
+pub fn rustdoc_json_path_for_temp_crate(temp_crate: impl AsRef<Path>) -> PathBuf {
+    rustdoc_json_path_for_crate(temp_crate.as_ref(), temp_crate.as_ref())
 }

--- a/public-api/tests/expected-output/comprehensive_api.txt
+++ b/public-api/tests/expected-output/comprehensive_api.txt
@@ -149,8 +149,8 @@ pub fn comprehensive_api::structs::Plain::s1(self)
 pub fn comprehensive_api::structs::Plain::s2(&self)
 pub fn comprehensive_api::structs::Plain::s3(&mut self)
 impl<'a> comprehensive_api::structs::Plain
-impl<'a> comprehensive_api::structs::Plain
 pub fn comprehensive_api::structs::Plain::s4(&'a self)
+impl<'a> comprehensive_api::structs::Plain
 pub fn comprehensive_api::structs::Plain::s5(&'a self)
 pub struct comprehensive_api::structs::PrivateField
 pub struct comprehensive_api::structs::TupleStructDouble(pub usize, pub bool)
@@ -169,8 +169,8 @@ pub struct comprehensive_api::structs::WithLifetimeAndGenericParam<'a, T>
 pub comprehensive_api::structs::WithLifetimeAndGenericParam::t: T
 pub comprehensive_api::structs::WithLifetimeAndGenericParam::unit_ref: &'a comprehensive_api::structs::Unit
 impl<'b, T> comprehensive_api::structs::WithLifetimeAndGenericParam<'b, T>
-impl<'b, T> comprehensive_api::structs::WithLifetimeAndGenericParam<'b, T>
 pub fn comprehensive_api::structs::WithLifetimeAndGenericParam::new_any(unit_ref: &'b comprehensive_api::structs::Unit, t: T) -> Self
+impl<'b, T> comprehensive_api::structs::WithLifetimeAndGenericParam<'b, T>
 pub fn comprehensive_api::structs::WithLifetimeAndGenericParam::new_any_duplicate(unit_ref: &'b comprehensive_api::structs::Unit, t: T) -> Self
 impl<'b> comprehensive_api::structs::WithLifetimeAndGenericParam<'b, alloc::string::String>
 pub fn comprehensive_api::structs::WithLifetimeAndGenericParam::new(unit_ref: &'b comprehensive_api::structs::Unit, t: alloc::string::String) -> Self
@@ -233,8 +233,8 @@ pub fn comprehensive_api::Plain::s1(self)
 pub fn comprehensive_api::Plain::s2(&self)
 pub fn comprehensive_api::Plain::s3(&mut self)
 impl<'a> comprehensive_api::structs::Plain
-impl<'a> comprehensive_api::structs::Plain
 pub fn comprehensive_api::Plain::s4(&'a self)
+impl<'a> comprehensive_api::structs::Plain
 pub fn comprehensive_api::Plain::s5(&'a self)
 pub struct comprehensive_api::RenamedPlain
 pub comprehensive_api::RenamedPlain::x: usize
@@ -245,7 +245,7 @@ pub fn comprehensive_api::RenamedPlain::s1(self)
 pub fn comprehensive_api::RenamedPlain::s2(&self)
 pub fn comprehensive_api::RenamedPlain::s3(&mut self)
 impl<'a> comprehensive_api::structs::Plain
-impl<'a> comprehensive_api::structs::Plain
 pub fn comprehensive_api::RenamedPlain::s4(&'a self)
+impl<'a> comprehensive_api::structs::Plain
 pub fn comprehensive_api::RenamedPlain::s5(&'a self)
 pub struct comprehensive_api::StructInPrivateMod

--- a/public-api/tests/expected-output/diff_move_item_between_inherent_impls.txt
+++ b/public-api/tests/expected-output/diff_move_item_between_inherent_impls.txt
@@ -1,0 +1,5 @@
+PublicApiDiff {
+    removed: [],
+    changed: [],
+    added: [],
+}

--- a/public-api/tests/public-api-lib-tests.rs
+++ b/public-api/tests/public-api-lib-tests.rs
@@ -181,6 +181,22 @@ fn comprehensive_api_proc_macro() {
     );
 }
 
+/// Test that `debug_sorting` does not result in stack overflow because of
+/// recursion. This can quite easily happen unless we test for it continuously.
+/// We don't care what the exact output is, just that we don't crash.
+#[test]
+fn comprehensive_api_debug_sorting_no_stack_overflow() {
+    // Create independent build dir so all tests can run in parallel
+    let build_dir = tempdir().unwrap();
+
+    let mut options = Options::default();
+    options.debug_sorting = true;
+    let rustdoc_json = rustdoc_json_path_for_crate("../test-apis/comprehensive_api", &build_dir);
+    let _api = PublicApi::from_rustdoc_json(rustdoc_json, options)
+        .unwrap()
+        .to_string();
+}
+
 #[test]
 fn invalid_json() {
     let result = PublicApi::from_rustdoc_json_str("}}}}}}}}}", Options::default());


### PR DESCRIPTION
"properly" meaning "group items like rustdoc HTML does it", which means each inherent `impl` is presented separately (i.e. no de-duplication)

Closes #251

Depends on #269
