### PR TITLE
CI: Start running `cargo deny check`, mostly to checks licences of deps

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,6 +42,13 @@ jobs:
       - uses: actions/checkout@v2
       - run: scripts/cargo-audit.sh
 
+  cargo-deny:
+    name: cargo deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: EmbarkStudios/cargo-deny-action@v1
+
   cargo-test:
     strategy:
       fail-fast: false

--- a/deny.toml
+++ b/deny.toml
@@ -23,3 +23,7 @@ exceptions = [
     #    https://github.com/frewsxcv/rust-crates-index/pull/90
     { name = "smartstring", allow = ["MPL-2.0"] },
 ]
+
+[bans]
+multiple-versions = "deny"
+wildcards = "deny"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,25 @@
+[licenses]
+allow = [
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "MIT",
+    "Unicode-DFS-2016",
+]
+
+unlicensed = "deny"
+copyleft = "deny"
+default = "deny"
+
+exceptions = [
+    # Allowed because:
+    #  * MPL-2.0 is a weak/non-viral copyleft license that doesn't cause much
+    #    trouble in practice
+    #  * Only affects the `cargo-public-api` binary and not any of our libraries
+    #    (`public-api`, `rustdoc-json`, `rustup-toolchain`). The dependency
+    #    chain is: `cargo-public-api` -> `crates-index` -> `smartstring`
+    #  * Can be opted out from by disabling the `diff-latest` feature
+    #  * Upstream is hesitant to remove the dependency because of better
+    #    performance than alternatives:
+    #    https://github.com/frewsxcv/rust-crates-index/pull/90
+    { name = "smartstring", allow = ["MPL-2.0"] },
+]

--- a/repo-tests/Cargo.toml
+++ b/repo-tests/Cargo.toml
@@ -3,6 +3,7 @@ edition = "2021"
 name = "repo-tests"
 version = "0.1.0"
 description = "Contains various repo-wide tests"
+license = "MIT"
 
 [dev-dependencies.public-api]
 path = "../public-api"

--- a/scripts/cargo-deny.sh
+++ b/scripts/cargo-deny.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -o nounset -o pipefail -o errexit
+
+cargo deny check

--- a/scripts/run-ci-locally.sh
+++ b/scripts/run-ci-locally.sh
@@ -20,3 +20,9 @@ if command -v cargo-audit >/dev/null; then
 else
     echo "INFO: Not running \`cargo audit\` because it is not installed"
 fi
+
+if command -v cargo-deny >/dev/null; then
+    scripts/cargo-deny.sh
+else
+    echo "INFO: Not running \`cargo deny\` because it is not installed"
+fi


### PR DESCRIPTION
Note that we allow MPL-2.0 for one of the dependencies. See https://github.com/frewsxcv/rust-crates-index/pull/90 and the PR diff for motivation