### PR TITLE
Enable DependaBot for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
To reduce the need for manual work (see e.g. https://github.com/Enselic/cargo-public-api/pull/254) to make life a bit easier for clients and ourselves.

I'm a bit concerned of this causing too much PR "spam", but I think we should try. In general it is good to keep dependencies up to date.

I think that at a later point I will set up auto-merge of DependaBot PRs that pass CI. But first I want to see how well this works.