### PR TITLE
CI: Use plain `rustup install` instead of `dtolnay/rust-toolchain`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,10 +53,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@e645b0cf01249a964ec099494d38d2da0f0b349f
-        with:
-          toolchain: nightly
-      - run: rustup default stable
+      - run: rustup install --profile minimal nightly
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --locked
       - run: cargo build --locked --no-default-features # Build without "diff-latest" feature

--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -33,10 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@e645b0cf01249a964ec099494d38d2da0f0b349f
-        with:
-          toolchain: nightly
-      - run: rustup default stable
+      - run: rustup install --profile minimal nightly
       - uses: Swatinem/rust-cache@v2
       - run: ./scripts/bless-expected-output-for-tests.sh
       - id: latest-nightly

--- a/docs/CI-EXAMPLES.md
+++ b/docs/CI-EXAMPLES.md
@@ -19,10 +19,7 @@ jobs:
           fetch-depth: 0
 
       # Install nightly (stable is already installed)
-      # Note that dtolnay/rust-toolchain also sets this toolchain as the default, change with `rustup default <toolchain>`
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly
+      - run: rustup install --profile minimal nightly
 
       # Install and run cargo public-api and deny any API diff
       - run: cargo install cargo-public-api
@@ -49,10 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Install nightly (stable is already installed)
-      # Note that dtolnay/rust-toolchain also sets this toolchain as the default, change with `rustup default <toolchain>`
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly
+      - run: rustup install --profile minimal nightly
 
       # Install and run cargo public-api and deny any API diff
       - run: cargo install cargo-public-api@0.22.0


### PR DESCRIPTION
@Emilgardis As you pointed out, we can use plain `rustup install`. After thinking some more, I think I prefer this. The motivation goes something like this:

> The less we depend on third party code, the easier it is to understand our own systems. Not only for ourselves, but also for people new to the project. And the lower the barrier, the higher the chance of getting contributions. In addition, third party code always increases the attack surfaces for malicious actors.

I appreciate the capability of `dtolnay/rust-toolchain` to specify `toolchain: stable minus 8 releases`, but I don't see us needing that. Having a generous MSRV takes time to maintain, and IMHO it is not worth it.

If you strongly prefer us to keep using `dtolnay/rust-toolchain` then I am fine with that too. Feel free to close this PR in that case.