### PR TITLE
Support for selecting features with `cargo public-api diff x.y.z`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,8 +97,11 @@ dependencies = [
  "rustdoc-json",
  "rustup-toolchain",
  "semver",
+ "serde",
+ "serde_json",
  "tempfile",
  "thiserror",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ exclude = [
     "test-apis/example_api-v0.1.0",
     "test-apis/example_api-v0.1.1",
     "test-apis/example_api-v0.2.0",
+    "test-apis/example_api-v0.2.1",
     "test-apis/example_api-v0.3.0",
 
     # To test that we pass --cap-lints when building rustdoc JSON

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -27,6 +27,9 @@ dirs = "4.0.0"
 home = "0.5.4"
 semver = "1.0.16"
 thiserror = "1.0.38"
+cargo_metadata = "0.15.2"
+toml = "0.5.10"
+serde = { version = "1.0.152", features = ["derive"] }
 
 [dependencies.clap]
 version = "4.0.32"
@@ -60,3 +63,4 @@ pretty_assertions = "1.3.0"
 remove_dir_all = "0.5.3"
 tempfile = "3.3.0"
 cargo_metadata = "0.15.2"
+serde_json = "1.0.91"

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -689,6 +689,19 @@ fn diff_published_explicit_package() {
 }
 
 #[test]
+fn diff_published_with_all_features() {
+    let mut cmd = TestCmd::new().with_test_repo();
+    cmd.arg("-p");
+    cmd.arg("example_api");
+    cmd.arg("--all-features");
+    cmd.arg("diff");
+    cmd.arg("0.2.1");
+    cmd.assert()
+        .stdout_or_update("./expected-output/diff_published_with_features.txt")
+        .success();
+}
+
+#[test]
 fn list_public_items_from_json_file() {
     // Create independent build dir so all tests can run in parallel
     let build_dir = tempdir().unwrap();

--- a/cargo-public-api/tests/expected-output/diff_published_with_features.txt
+++ b/cargo-public-api/tests/expected-output/diff_published_with_features.txt
@@ -1,0 +1,14 @@
+Removed items from the public API
+=================================
+-pub example_api::Struct::v1_2_field_gated: usize
+-pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize)
+
+Changed items in the public API
+===============================
+-pub struct example_api::Struct
++#[non_exhaustive] pub struct example_api::Struct
+
+Added items to the public API
+=============================
+(none)
+

--- a/test-apis/example_api-v0.2.1/Cargo.toml
+++ b/test-apis/example_api-v0.2.1/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+edition = "2021"
+name = "example_api"
+version = "0.2.1"
+description = "Example API used in the cargo-public-api test suite"
+homepage = "https://github.com/Enselic/cargo-public-api/tree/main/test-apis/example_api-v0.2.1"
+readme = "../example_api-v0.1.0/README.md"
+license = "MIT"
+repository = "https://github.com/Enselic/cargo-public-api/tree/main/test-apis/example_api-v0.2.1"
+[features]
+feature = []

--- a/test-apis/example_api-v0.2.1/src/lib.rs
+++ b/test-apis/example_api-v0.2.1/src/lib.rs
@@ -1,0 +1,17 @@
+// Allow stuff that prevents us from testing unidiomatic but valid public APIs
+#![allow(unused_variables, dead_code)]
+#![no_std] // Reduces rustdoc JSON size by 70%
+
+#[derive(Debug)]
+pub struct Struct {
+    pub v1_field: usize,
+    pub v2_field: usize,
+    #[cfg(feature = "feature")]
+    pub v1_2_field_gated: usize,
+}
+
+pub struct StructV2 {
+    pub field: usize,
+}
+
+pub fn function(v1_param: Struct, v2_param: usize) {}


### PR DESCRIPTION
resolves #282

continuation of #285 