### PR TITLE
Rename `MINIMUM_RUSTDOC_JSON_VERSION` to `MINIMUM_NIGHTLY_VERSION` for clarity

### DIFF
--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -27,7 +27,7 @@ jobs:
 
   # If Rust nightly changes output, auto-create a PR with the new blessed
   # output, which maintainers can conveniently merge after manual review. Note
-  # that we must also bump MINIMUM_RUSTDOC_JSON_VERSION_FOR_TESTS to this
+  # that we must also bump MINIMUM_NIGHTLY_VERSION_FOR_TESTS to this
   # version, otherwise tests will fail.
   auto-bless:
     environment:
@@ -42,7 +42,7 @@ jobs:
       - id: latest-nightly
         run: echo "version=nightly-$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
       - run: |
-          [ -z "$(git status --porcelain)" ] || echo "${{ steps.latest-nightly.outputs.version }}" > cargo-public-api/MINIMUM_RUSTDOC_JSON_VERSION_FOR_TESTS
+          [ -z "$(git status --porcelain)" ] || echo "${{ steps.latest-nightly.outputs.version }}" > cargo-public-api/MINIMUM_NIGHTLY_VERSION_FOR_TESTS
       - uses: peter-evans/create-pull-request@v4
         with:
           title: Bless `${{ steps.latest-nightly.outputs.version }}` output

--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ Then add the following test to your project. As the author of the below test cod
 #[test]
 fn public_api() {
     // Install a proper nightly toolchain if it is missing
-    rustup_toolchain::ensure_installed(public_api::MINIMUM_RUSTDOC_JSON_VERSION).unwrap();
+    rustup_toolchain::ensure_installed(public_api::MINIMUM_NIGHTLY_VERSION).unwrap();
 
     // Build rustdoc JSON
     let rustdoc_json = rustdoc_json::Builder::default()
-        .toolchain(public_api::MINIMUM_RUSTDOC_JSON_VERSION.to_owned())
+        .toolchain(public_api::MINIMUM_NIGHTLY_VERSION.to_owned())
         .build()
         .unwrap();
 

--- a/cargo-public-api/src/api_source.rs
+++ b/cargo-public-api/src/api_source.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Context, Result};
 use rustdoc_json::BuildError;
 use std::path::{Path, PathBuf};
 
-use public_api::{Options, PublicApi, MINIMUM_RUSTDOC_JSON_VERSION};
+use public_api::{Options, PublicApi, MINIMUM_NIGHTLY_VERSION};
 
 use crate::{git_utils, Args};
 
@@ -182,7 +182,7 @@ fn public_api_from_rustdoc_json_path(
             to install the latest version with `cargo install cargo-public-api`. If the\n\
             issue remains, please report at\n\n    https://github.com/Enselic/cargo-public-api/issues",
             json_path.as_ref(),
-            MINIMUM_RUSTDOC_JSON_VERSION,
+            MINIMUM_NIGHTLY_VERSION,
         )
     })?;
 

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -18,7 +18,7 @@ use assert_cmd::assert::Assert;
 use assert_cmd::Command;
 use predicates::str::contains;
 
-use public_api::MINIMUM_RUSTDOC_JSON_VERSION;
+use public_api::MINIMUM_NIGHTLY_VERSION;
 use tempfile::tempdir;
 
 #[path = "../src/git_utils.rs"] // Say NO to copy-paste!
@@ -213,10 +213,10 @@ fn subcommand_invocation_public_api_arg() {
 /// required for tests is not the same as required for users, so allow tests to
 /// use a different toolchain if needed
 fn get_minimum_toolchain() -> String {
-    std::fs::read_to_string("../cargo-public-api/MINIMUM_RUSTDOC_JSON_VERSION_FOR_TESTS")
+    std::fs::read_to_string("../cargo-public-api/MINIMUM_NIGHTLY_VERSION_FOR_TESTS")
         .map(|s| s.trim().to_owned())
         .ok()
-        .unwrap_or_else(|| MINIMUM_RUSTDOC_JSON_VERSION.to_owned())
+        .unwrap_or_else(|| MINIMUM_NIGHTLY_VERSION.to_owned())
 }
 
 #[test]

--- a/cargo-public-api/tests/expected-output/public_api_list.txt
+++ b/cargo-public-api/tests/expected-output/public_api_list.txt
@@ -115,5 +115,6 @@ impl core::hash::Hash for public_api::PublicItem
 pub fn public_api::PublicItem::hash<H: core::hash::Hasher>(&self, state: &mut H)
 impl core::clone::Clone for public_api::PublicItem
 pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
-pub const public_api::MINIMUM_RUSTDOC_JSON_VERSION: &str
+pub const public_api::MINIMUM_NIGHTLY_VERSION: &str
+pub const public_api::MINIMUM_RUSTDOC_JSON_VERSION: MINIMUM_NIGHTLY_VERSION
 pub type public_api::Result<T> = core::result::Result<T, public_api::Error>

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -9,10 +9,10 @@
         * **Cargo.toml** `[workspace.package.version]`
         * Dependents that you find with `git grep -A1 'path = "../public-api"'`
     2. If you bump 0.x.0 version, also update the [compatibility matrix](https://github.com/Enselic/cargo-public-api#compatibility-matrix).
-    1. If `MINIMUM_RUSTDOC_JSON_VERSION` must be bumped, bump it. If you bump it, also
+    1. If `MINIMUM_NIGHTLY_VERSION` must be bumped, bump it. If you bump it, also
         *  bump it in [compatibility matrix](https://github.com/Enselic/cargo-public-api#compatibility-matrix)
         *  bump it in `cargo-public-api` [installation instructions](https://github.com/Enselic/cargo-public-api#installation)
-        * `rm cargo-public-api/MINIMUM_RUSTDOC_JSON_VERSION_FOR_TESTS`
+        * `rm cargo-public-api/MINIMUM_NIGHTLY_VERSION_FOR_TESTS`
 
 1. Preview what the auto-generated release-notes will look like by going [here](https://github.com/cargo-public-api/cargo-public-api.github.io/blob/main/release-notes-preview.md). It is automatically updated, but you can also trigger manually [here](https://github.com/Enselic/cargo-public-api/actions/workflows/Preview-release-notes.yml)
     * The target audience for the release notes is users of the `cargo-public-api` CLI. But we also want to credit contributors to our libraries with a mention in the release notes, so we should also include such PRs in the release notes. For libs we also want to update the corresponding `CHANGELOG.md` file though.

--- a/public-api/CHANGELOG.md
+++ b/public-api/CHANGELOG.md
@@ -5,6 +5,7 @@ If a version is not listed below, it means it had no API changes.
 ## Unreleased v0.27.0
 * Make `Eq` and `Hash` for `PublicItem` only take tokens into account, to make diffing insensitive to internal data that has no bearing on public API surface of a crate
 * Remove `Ord` and `PartialOrd` impls of `PublicItem` and `ChangedPublicItem`. Use `PublicItem::grouping_cmp` and `ChangedPublicItem::grouping_cmp` instead.
+* Rename `MINIMUM_RUSTDOC_JSON_VERSION` to `MINIMUM_NIGHTLY_VERSION` for clarity
 
 ## v0.26.0
 * Put auto-derived impls (`Clone`, `Debug`, etc) in a separate group, right after normal `impl`s

--- a/public-api/public-api.txt
+++ b/public-api/public-api.txt
@@ -290,5 +290,6 @@ impl<T> core::borrow::BorrowMut<T> for public_api::PublicItem where T: core::mar
 pub fn public_api::PublicItem::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for public_api::PublicItem
 pub fn public_api::PublicItem::from(t: T) -> T
-pub const public_api::MINIMUM_RUSTDOC_JSON_VERSION: &str
+pub const public_api::MINIMUM_NIGHTLY_VERSION: &str
+pub const public_api::MINIMUM_RUSTDOC_JSON_VERSION: MINIMUM_NIGHTLY_VERSION
 pub type public_api::Result<T> = core::result::Result<T, public_api::Error>

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -68,7 +68,11 @@ pub use public_item::PublicItem;
 /// The rustdoc JSON format is still changing, so every now and then we update
 /// this library to support the latest format. If you use this version of
 /// nightly or later, you should be fine.
-pub const MINIMUM_RUSTDOC_JSON_VERSION: &str = "nightly-2023-01-04";
+pub const MINIMUM_NIGHTLY_VERSION: &str = "nightly-2023-01-04";
+
+/// Deprecated, use [`MINIMUM_NIGHTLY_VERSION`] instead.
+#[deprecated(since = "0.27.0", note = "Use MINIMUM_NIGHTLY_VERSION instead")]
+pub const MINIMUM_RUSTDOC_JSON_VERSION: &str = MINIMUM_NIGHTLY_VERSION;
 
 /// Contains various options that you can pass to [`PublicApi::from_rustdoc_json_str`].
 #[derive(Copy, Clone, Debug)]

--- a/public-api/src/main.rs
+++ b/public-api/src/main.rs
@@ -8,7 +8,7 @@ use std::io::{stdout, ErrorKind, Write};
 use std::path::{Path, PathBuf};
 
 use public_api::diff::PublicApiDiff;
-use public_api::{Options, PublicApi, MINIMUM_RUSTDOC_JSON_VERSION};
+use public_api::{Options, PublicApi, MINIMUM_NIGHTLY_VERSION};
 
 #[derive(thiserror::Error, Debug)]
 enum Error {
@@ -25,14 +25,14 @@ type Result<T> = std::result::Result<T, Error>;
 struct Args {
     help: bool,
     simplified: bool,
-    print_minimum_rustdoc_json_version: bool,
+    print_minimum_nightly_version: bool,
     files: Vec<PathBuf>,
 }
 
 fn main_() -> Result<()> {
     let args = args();
-    if args.print_minimum_rustdoc_json_version {
-        println!("{MINIMUM_RUSTDOC_JSON_VERSION}");
+    if args.print_minimum_nightly_version {
+        println!("{MINIMUM_NIGHTLY_VERSION}");
         return Ok(());
     }
 
@@ -144,7 +144,7 @@ commit and then pass the path of both files to this utility:
 
 ",
         env!("CARGO_PKG_VERSION"),
-        MINIMUM_RUSTDOC_JSON_VERSION,
+        MINIMUM_NIGHTLY_VERSION,
     )
 }
 
@@ -163,8 +163,8 @@ fn args() -> Args {
     for arg in std::env::args_os().skip(1) {
         if arg == "--simplified" {
             args.simplified = true;
-        } else if arg == "--print-minimum-rustdoc-json-version" {
-            args.print_minimum_rustdoc_json_version = true;
+        } else if arg == "--print-minimum-nightly-version" {
+            args.print_minimum_nightly_version = true;
         } else if arg == "--help" || arg == "-h" {
             args.help = true;
         } else {

--- a/public-api/tests/public-api-bin-tests.rs
+++ b/public-api/tests/public-api-bin-tests.rs
@@ -6,7 +6,7 @@ use std::{io::BufRead, str::from_utf8};
 
 use assert_cmd::assert::Assert;
 use assert_cmd::Command;
-use public_api::MINIMUM_RUSTDOC_JSON_VERSION;
+use public_api::MINIMUM_NIGHTLY_VERSION;
 
 use tempfile::{tempdir, TempDir};
 
@@ -138,11 +138,11 @@ fn no_args_shows_help() {
 }
 
 #[test]
-fn print_minimum_rustdoc_json_version() {
+fn print_minimum_nightly_version() {
     let mut cmd = Command::cargo_bin("public-api").unwrap();
-    cmd.arg("--print-minimum-rustdoc-json-version");
+    cmd.arg("--print-minimum-nightly-version");
     cmd.assert()
-        .stdout(format!("{MINIMUM_RUSTDOC_JSON_VERSION}\n"))
+        .stdout(format!("{MINIMUM_NIGHTLY_VERSION}\n"))
         .stderr("")
         .success();
 }
@@ -187,7 +187,7 @@ commit and then pass the path of both files to this utility:
 
 ",
         env!("CARGO_PKG_VERSION"),
-        MINIMUM_RUSTDOC_JSON_VERSION,
+        MINIMUM_NIGHTLY_VERSION,
     )
 }
 

--- a/repo-tests/tests/repo-tests.rs
+++ b/repo-tests/tests/repo-tests.rs
@@ -3,7 +3,7 @@
 
 use std::{ffi::OsStr, fs::read_to_string, path::PathBuf};
 
-use public_api::MINIMUM_RUSTDOC_JSON_VERSION;
+use public_api::MINIMUM_NIGHTLY_VERSION;
 
 #[test]
 fn newline_at_end_of_all_files() {
@@ -67,6 +67,6 @@ fn newline_at_end_of_all_files() {
 fn installation_instructions_in_toplevel_readme() {
     let readme = include_str!("../../README.md");
     let expected_installation_instruction =
-        format!("Ensure **{MINIMUM_RUSTDOC_JSON_VERSION}** or later");
+        format!("Ensure **{MINIMUM_NIGHTLY_VERSION}** or later");
     assert!(readme.contains(&expected_installation_instruction));
 }


### PR DESCRIPTION
Mainly to make the example test in README.md clearer.