### PR TITLE
Change `rustdoc_json::Builder::toolchain(...)` to take `Into<String>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ fn public_api() {
 
     // Build rustdoc JSON
     let rustdoc_json = rustdoc_json::Builder::default()
-        .toolchain(public_api::MINIMUM_NIGHTLY_VERSION.to_owned())
+        .toolchain(public_api::MINIMUM_NIGHTLY_VERSION)
         .build()
         .unwrap();
 

--- a/cargo-public-api/src/api_source.rs
+++ b/cargo-public-api/src/api_source.rs
@@ -141,11 +141,13 @@ fn get_options(args: &Args) -> Options {
 /// Creates a rustdoc JSON builder based on the args to this program.
 pub fn builder_from_args(args: &Args) -> rustdoc_json::Builder {
     let mut builder = rustdoc_json::Builder::default()
-        .toolchain(args.toolchain.clone())
         .manifest_path(&args.manifest_path)
         .all_features(args.all_features)
         .no_default_features(args.no_default_features)
         .features(&args.features);
+    if let Some(toolchain) = &args.toolchain {
+        builder = builder.toolchain(toolchain);
+    }
     if let Some(target_dir) = &args.target_dir {
         builder = builder.target_dir(target_dir.clone());
     }

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -900,7 +900,7 @@ fn rustdoc_json_builder_for_crate(
 ) -> rustdoc_json::Builder {
     rustdoc_json::Builder::default()
         .manifest_path(format!("{test_crate}/Cargo.toml"))
-        .toolchain("nightly".to_owned())
+        .toolchain("nightly")
         .target_dir(target_dir)
         .quiet(true)
 }

--- a/public-api/examples/diff_public_api.rs
+++ b/public-api/examples/diff_public_api.rs
@@ -6,13 +6,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     let options = Options::default();
 
     let old_json = rustdoc_json::Builder::default()
-        .toolchain(String::from("nightly"))
+        .toolchain("nightly")
         .manifest_path("test-apis/example_api-v0.1.0/Cargo.toml")
         .build()?;
     let old = PublicApi::from_rustdoc_json(old_json, options)?;
 
     let new_json = rustdoc_json::Builder::default()
-        .toolchain(String::from("nightly"))
+        .toolchain("nightly")
         .manifest_path("test-apis/example_api-v0.2.0/Cargo.toml")
         .build()?;
     let new = PublicApi::from_rustdoc_json(new_json, options)?;

--- a/public-api/examples/list_public_api.rs
+++ b/public-api/examples/list_public_api.rs
@@ -4,7 +4,7 @@ use public_api::{Options, PublicApi};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let json_path = rustdoc_json::Builder::default()
-        .toolchain(String::from("nightly"))
+        .toolchain("nightly")
         .manifest_path("test-apis/example_api-v0.2.0/Cargo.toml")
         .build()?;
 

--- a/public-api/tests/common/mod.rs
+++ b/public-api/tests/common/mod.rs
@@ -16,7 +16,7 @@ pub fn rustdoc_json_path_for_crate(
 
     rustdoc_json::Builder::default()
         .manifest_path(&manifest_path)
-        .toolchain("nightly".to_owned())
+        .toolchain("nightly")
         .target_dir(target_dir)
         .quiet(true)
         .build()

--- a/public-api/tests/public-api-lib-tests.rs
+++ b/public-api/tests/public-api-lib-tests.rs
@@ -17,7 +17,7 @@ use common::{rustdoc_json_path_for_crate, rustdoc_json_path_for_temp_crate};
 #[test]
 fn public_api() -> Result<(), Box<dyn std::error::Error>> {
     let rustdoc_json = rustdoc_json::Builder::default()
-        .toolchain("nightly".to_owned())
+        .toolchain("nightly")
         .build()?;
 
     let public_api = PublicApi::from_rustdoc_json(rustdoc_json, Options::default())?;

--- a/rustdoc-json/CHANGELOG.md
+++ b/rustdoc-json/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased v0.8.0
+* Change `Builder::toolchain(...)` to take `Into<String>` instead of `Into<Option<String>>` to make client code nicer in 99% of cases. Introduce `Builder::clear_toolchain()` for the 1%.
+
 ## v0.7.4
 * Correctly determine json path for `Builder::default().package("crate@1.0.0")`
 * Add `Builder::package_target()` and `PackageTarget`

--- a/rustdoc-json/README.md
+++ b/rustdoc-json/README.md
@@ -8,7 +8,7 @@ To build rustdoc JSON for a library with the manifest path `project/Cargo.toml`,
 
 ```rust
 let json_path = rustdoc_json::Builder::default()
-    .toolchain("nightly".to_owned())
+    .toolchain("nightly")
     .manifest_path("project/Cargo.toml")
     .build()
     .unwrap();

--- a/rustdoc-json/examples/build-rustdoc-json.rs
+++ b/rustdoc-json/examples/build-rustdoc-json.rs
@@ -5,7 +5,7 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Build it
     let json_path = rustdoc_json::Builder::default()
-        .toolchain("nightly".to_owned())
+        .toolchain("nightly")
         .manifest_path(std::env::args().nth(1).unwrap())
         .build()?;
     println!("Built and wrote rustdoc JSON to {:?}", &json_path);

--- a/rustdoc-json/public-api.txt
+++ b/rustdoc-json/public-api.txt
@@ -85,6 +85,7 @@ pub const fn rustdoc_json::Builder::all_features(self, all_features: bool) -> Se
 pub fn rustdoc_json::Builder::build(self) -> core::result::Result<std::path::PathBuf, rustdoc_json::BuildError>
 pub fn rustdoc_json::Builder::cap_lints(self, cap_lints: core::option::Option<impl core::convert::AsRef<str>>) -> Self
 pub fn rustdoc_json::Builder::clear_target_dir(self) -> Self
+pub fn rustdoc_json::Builder::clear_toolchain(self) -> Self
 pub fn rustdoc_json::Builder::document_private_items(self, document_private_items: bool) -> Self
 pub fn rustdoc_json::Builder::features<I: core::iter::traits::collect::IntoIterator<Item = S>, S: core::convert::AsRef<str>>(self, features: I) -> Self
 pub fn rustdoc_json::Builder::manifest_path(self, manifest_path: impl core::convert::AsRef<std::path::Path>) -> Self
@@ -95,7 +96,7 @@ pub const fn rustdoc_json::Builder::quiet(self, quiet: bool) -> Self
 pub const fn rustdoc_json::Builder::silent(self, silent: bool) -> Self
 pub fn rustdoc_json::Builder::target(self, target: alloc::string::String) -> Self
 pub fn rustdoc_json::Builder::target_dir(self, target_dir: impl core::convert::AsRef<std::path::Path>) -> Self
-pub fn rustdoc_json::Builder::toolchain(self, toolchain: impl core::convert::Into<core::option::Option<alloc::string::String>>) -> Self
+pub fn rustdoc_json::Builder::toolchain(self, toolchain: impl core::convert::Into<alloc::string::String>) -> Self
 impl core::default::Default for rustdoc_json::Builder
 pub fn rustdoc_json::Builder::default() -> Self
 impl core::clone::Clone for rustdoc_json::Builder

--- a/rustdoc-json/src/builder.rs
+++ b/rustdoc-json/src/builder.rs
@@ -234,8 +234,15 @@ impl Builder {
     /// mechanism sets. See <https://rust-lang.github.io/rustup/overrides.html>
     /// for more info on how the active toolchain is determined.
     #[must_use]
-    pub fn toolchain(mut self, toolchain: impl Into<Option<String>>) -> Self {
-        self.toolchain = toolchain.into();
+    pub fn toolchain(mut self, toolchain: impl Into<String>) -> Self {
+        self.toolchain = Some(toolchain.into());
+        self
+    }
+
+    /// Clear a toolchain previously set with [`Self::toolchain`].
+    #[must_use]
+    pub fn clear_toolchain(mut self) -> Self {
+        self.target_dir = None;
         self
     }
 

--- a/rustdoc-json/src/lib.rs
+++ b/rustdoc-json/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! ```no_run
 //! let json_path = rustdoc_json::Builder::default()
-//!     .toolchain("nightly".to_owned())
+//!     .toolchain("nightly")
 //!     .manifest_path("Cargo.toml")
 //!     .build()
 //!     .unwrap();

--- a/rustdoc-json/tests/rustdoc-json-lib-tests.rs
+++ b/rustdoc-json/tests/rustdoc-json-lib-tests.rs
@@ -4,7 +4,7 @@ use rustdoc_json::PackageTarget;
 #[test]
 fn public_api() -> Result<(), Box<dyn std::error::Error>> {
     let rustdoc_json = rustdoc_json::Builder::default()
-        .toolchain("nightly".to_owned())
+        .toolchain("nightly")
         .build()?;
 
     let public_api = PublicApi::from_rustdoc_json(rustdoc_json, Options::default())?;
@@ -19,7 +19,7 @@ fn public_api() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn ensure_workspace_inheritance_works() {
     let path = rustdoc_json::Builder::default()
-        .toolchain("nightly".to_owned())
+        .toolchain("nightly")
         .manifest_path("../test-apis/workspace-inheritance/package-with-inheritance/Cargo.toml")
         .quiet(true) // Make it less noisy to run tests
         .build()
@@ -64,7 +64,7 @@ fn test_alternative_package_target(package_target: PackageTarget) {
     let target_dir = tempfile::tempdir().unwrap();
 
     let path = rustdoc_json::Builder::default()
-        .toolchain("nightly".to_owned())
+        .toolchain("nightly")
         .manifest_path("tests/test_crates/test_crate/Cargo.toml")
         .quiet(true) // Make it less noisy to run tests
         .package_target(package_target)
@@ -80,7 +80,7 @@ fn test_specified_dependency_version() {
     let target_dir = tempfile::tempdir().unwrap();
 
     let builder = rustdoc_json::Builder::default()
-        .toolchain("nightly".to_owned())
+        .toolchain("nightly")
         .manifest_path("tests/test_crates/test_crate/Cargo.toml")
         .quiet(true) // Make it less noisy to run tests
         .target_dir(&target_dir);

--- a/rustup-toolchain/tests/rustup-toolchain-lib-tests.rs
+++ b/rustup-toolchain/tests/rustup-toolchain-lib-tests.rs
@@ -3,7 +3,7 @@ use public_api::{Options, PublicApi};
 #[test]
 fn public_api() -> Result<(), Box<dyn std::error::Error>> {
     let rustdoc_json = rustdoc_json::Builder::default()
-        .toolchain("nightly".to_owned())
+        .toolchain("nightly")
         .build()?;
 
     let public_api = PublicApi::from_rustdoc_json(rustdoc_json, Options::default())?;


### PR DESCRIPTION
Also add `clear_toolchain()`. (We already have `clear_target_dir()`.)

This makes the `fn public_api` test in `README.md` look nicer.

Don't bother to go through a deprecation cycle because that adds too much complexity and overhead in this case.