### PR TITLE
Replace `PublicApi::from_rustdoc_json(path, options)` with `public_api::Builder`

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ fn public_api() {
         .unwrap();
 
     // Derive the public API from the rustdoc JSON
-    let public_api =
-        public_api::PublicApi::from_rustdoc_json(rustdoc_json, public_api::Options::default())
-            .unwrap();
+    let public_api = public_api::Builder::from_rustdoc_json(rustdoc_json)
+        .build()
+        .unwrap();
 
     // Assert that the public API looks correct
     expect_test::expect_file!["public-api.txt"].assert_eq(&public_api.to_string());

--- a/cargo-public-api/tests/expected-output/public_api_list.txt
+++ b/cargo-public-api/tests/expected-output/public_api_list.txt
@@ -76,23 +76,21 @@ impl core::fmt::Display for public_api::Error
 pub fn public_api::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Debug for public_api::Error
 pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-#[non_exhaustive] pub struct public_api::Options
-pub public_api::Options::debug_sorting: bool
-pub public_api::Options::omit_auto_derived_impls: bool
-pub public_api::Options::omit_auto_trait_impls: bool
-pub public_api::Options::omit_blanket_impls: bool
-pub public_api::Options::sorted: bool
-impl core::default::Default for public_api::Options
-pub fn public_api::Options::default() -> Self
-impl core::clone::Clone for public_api::Options
-pub fn public_api::Options::clone(&self) -> public_api::Options
-impl core::fmt::Debug for public_api::Options
-pub fn public_api::Options::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::Copy for public_api::Options
+pub struct public_api::Builder
+impl public_api::Builder
+pub fn public_api::Builder::build(self) -> public_api::Result<public_api::PublicApi>
+pub fn public_api::Builder::debug_sorting(self, debug_sorting: bool) -> Self
+pub fn public_api::Builder::from_rustdoc_json(path: impl core::convert::Into<std::path::PathBuf>) -> Self
+pub fn public_api::Builder::omit_auto_derived_impls(self, omit_auto_derived_impls: bool) -> Self
+pub fn public_api::Builder::omit_auto_trait_impls(self, omit_auto_trait_impls: bool) -> Self
+pub fn public_api::Builder::omit_blanket_impls(self, omit_blanket_impls: bool) -> Self
+pub fn public_api::Builder::sorted(self, sorted: bool) -> Self
+impl core::clone::Clone for public_api::Builder
+pub fn public_api::Builder::clone(&self) -> public_api::Builder
+impl core::fmt::Debug for public_api::Builder
+pub fn public_api::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 #[non_exhaustive] pub struct public_api::PublicApi
 impl public_api::PublicApi
-pub fn public_api::PublicApi::from_rustdoc_json(path: impl core::convert::AsRef<std::path::Path>, options: public_api::Options) -> public_api::Result<public_api::PublicApi>
-pub fn public_api::PublicApi::from_rustdoc_json_str(rustdoc_json_str: impl core::convert::AsRef<str>, options: public_api::Options) -> public_api::Result<public_api::PublicApi>
 pub fn public_api::PublicApi::into_items(self) -> impl core::iter::traits::iterator::Iterator<Item = public_api::PublicItem>
 pub fn public_api::PublicApi::items(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::PublicItem>
 pub fn public_api::PublicApi::missing_item_ids(&self) -> impl core::iter::traits::iterator::Iterator<Item = &alloc::string::String>

--- a/public-api/examples/diff_public_api.rs
+++ b/public-api/examples/diff_public_api.rs
@@ -1,21 +1,19 @@
 use std::error::Error;
 
-use public_api::{diff::PublicApiDiff, Options, PublicApi};
+use public_api::diff::PublicApiDiff;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let options = Options::default();
-
     let old_json = rustdoc_json::Builder::default()
         .toolchain("nightly")
         .manifest_path("test-apis/example_api-v0.1.0/Cargo.toml")
         .build()?;
-    let old = PublicApi::from_rustdoc_json(old_json, options)?;
+    let old = public_api::Builder::from_rustdoc_json(old_json).build()?;
 
     let new_json = rustdoc_json::Builder::default()
         .toolchain("nightly")
         .manifest_path("test-apis/example_api-v0.2.0/Cargo.toml")
         .build()?;
-    let new = PublicApi::from_rustdoc_json(new_json, options)?;
+    let new = public_api::Builder::from_rustdoc_json(new_json).build()?;
 
     let diff = PublicApiDiff::between(old, new);
     println!("{diff:#?}");

--- a/public-api/examples/list_public_api.rs
+++ b/public-api/examples/list_public_api.rs
@@ -1,14 +1,12 @@
 use std::error::Error;
 
-use public_api::{Options, PublicApi};
-
 fn main() -> Result<(), Box<dyn Error>> {
     let json_path = rustdoc_json::Builder::default()
         .toolchain("nightly")
         .manifest_path("test-apis/example_api-v0.2.0/Cargo.toml")
         .build()?;
 
-    let public_api = PublicApi::from_rustdoc_json(json_path, Options::default())?;
+    let public_api = public_api::Builder::from_rustdoc_json(json_path).build()?;
 
     for public_item in public_api.items() {
         println!("{public_item}");

--- a/public-api/src/diff.rs
+++ b/public-api/src/diff.rs
@@ -61,7 +61,7 @@ impl PublicApiDiff {
     /// Allows you to diff the public API between two arbitrary versions of a
     /// library, e.g. different releases. The input parameters `old` and `new`
     /// is the output of two different invocations of
-    /// [`crate::PublicApi::from_rustdoc_json_str`].
+    /// [`crate::Builder::build`].
     #[must_use]
     pub fn between(old: PublicApi, new: PublicApi) -> Self {
         // We must use a HashBag, because with a HashSet we would lose public

--- a/public-api/tests/common/mod.rs
+++ b/public-api/tests/common/mod.rs
@@ -2,6 +2,25 @@
 
 use std::path::{Path, PathBuf};
 
+pub fn builder_for_crate(
+    test_crate: impl AsRef<Path>,
+    target_dir: impl AsRef<Path>,
+) -> public_api::Builder {
+    let json = rustdoc_json_path_for_crate(test_crate, target_dir);
+    public_api::Builder::from_rustdoc_json(json)
+}
+
+/// Returns a builder for a so called "simplified" API, which is an API without
+/// Auto Trait or Blanket impls, to reduce public item noise.
+pub fn simplified_builder_for_crate(
+    test_crate: impl AsRef<Path>,
+    target_dir: impl AsRef<Path>,
+) -> public_api::Builder {
+    builder_for_crate(test_crate, target_dir)
+        .omit_blanket_impls(true)
+        .omit_auto_trait_impls(true)
+}
+
 /// Builds rustdoc JSON for the given test crate.
 ///
 /// Output of child processes are not captured by the Rust test framework (see

--- a/public-api/tests/public-api-lib-tests.rs
+++ b/public-api/tests/public-api-lib-tests.rs
@@ -1,18 +1,22 @@
 // deny in CI, only warn here
 #![warn(clippy::all, clippy::pedantic)]
 
+use std::io::Write;
 use std::{
     fs,
     path::{Path, PathBuf},
 };
 
 use expect_test::expect_file;
-use public_api::{Error, Options, PublicApi};
+use public_api::Error;
 
-use tempfile::{tempdir, TempDir};
+use tempfile::{tempdir, NamedTempFile, TempDir};
 
 mod common;
-use common::{rustdoc_json_path_for_crate, rustdoc_json_path_for_temp_crate};
+use common::{
+    builder_for_crate, rustdoc_json_path_for_crate, rustdoc_json_path_for_temp_crate,
+    simplified_builder_for_crate,
+};
 
 #[test]
 fn public_api() -> Result<(), Box<dyn std::error::Error>> {
@@ -20,7 +24,7 @@ fn public_api() -> Result<(), Box<dyn std::error::Error>> {
         .toolchain("nightly")
         .build()?;
 
-    let public_api = PublicApi::from_rustdoc_json(rustdoc_json, Options::default())?;
+    let public_api = public_api::Builder::from_rustdoc_json(rustdoc_json).build()?;
 
     expect_test::expect_file!["public-api.txt"].assert_eq(&public_api.to_string());
 
@@ -33,9 +37,8 @@ fn not_simplified() {
     let build_dir = tempdir().unwrap();
 
     assert_public_api(
-        rustdoc_json_path_for_crate("../test-apis/example_api-v0.2.0", &build_dir),
+        builder_for_crate("../test-apis/example_api-v0.2.0", &build_dir),
         "./expected-output/example_api-v0.2.0-not-simplified.txt",
-        Options::default(),
     );
 }
 
@@ -44,13 +47,12 @@ fn simplified_without_auto_derived_impls() {
     // Create independent build dir so all tests can run in parallel
     let build_dir = tempdir().unwrap();
 
-    let mut options = simplified();
-    options.omit_auto_derived_impls = true;
-
     assert_public_api(
-        rustdoc_json_path_for_crate("../test-apis/example_api-v0.2.0", &build_dir),
+        builder_for_crate("../test-apis/example_api-v0.2.0", &build_dir)
+            .omit_auto_derived_impls(true)
+            .omit_blanket_impls(true)
+            .omit_auto_trait_impls(true),
         "./expected-output/example_api-v0.2.0-simplified_without_auto_derived_impls.txt",
-        options,
     );
 }
 
@@ -59,13 +61,9 @@ fn omit_blanket_impls() {
     // Create independent build dir so all tests can run in parallel
     let build_dir = tempdir().unwrap();
 
-    let mut options = Options::default();
-    options.omit_blanket_impls = true;
-
     assert_public_api(
-        rustdoc_json_path_for_crate("../test-apis/example_api-v0.2.0", &build_dir),
+        builder_for_crate("../test-apis/example_api-v0.2.0", &build_dir).omit_blanket_impls(true),
         "./expected-output/example_api-v0.2.0-omit_blanket_impls.txt",
-        options,
     );
 }
 
@@ -74,13 +72,10 @@ fn omit_auto_trait_impls() {
     // Create independent build dir so all tests can run in parallel
     let build_dir = tempdir().unwrap();
 
-    let mut options = Options::default();
-    options.omit_auto_trait_impls = true;
-
     assert_public_api(
-        rustdoc_json_path_for_crate("../test-apis/example_api-v0.2.0", &build_dir),
+        builder_for_crate("../test-apis/example_api-v0.2.0", &build_dir)
+            .omit_auto_trait_impls(true),
         "./expected-output/example_api-v0.2.0-omit_auto_trait_impls.txt",
-        options,
     );
 }
 
@@ -164,8 +159,8 @@ fn comprehensive_api() {
     // Create independent build dir so all tests can run in parallel
     let build_dir = tempdir().unwrap();
 
-    assert_simplified_public_api(
-        rustdoc_json_path_for_crate("../test-apis/comprehensive_api", &build_dir),
+    assert_public_api(
+        simplified_builder_for_crate("../test-apis/comprehensive_api", &build_dir),
         "./expected-output/comprehensive_api.txt",
     );
 }
@@ -175,8 +170,8 @@ fn comprehensive_api_proc_macro() {
     // Create independent build dir so all tests can run in parallel
     let build_dir = tempdir().unwrap();
 
-    assert_simplified_public_api(
-        rustdoc_json_path_for_crate("../test-apis/comprehensive_api_proc_macro", &build_dir),
+    assert_public_api(
+        simplified_builder_for_crate("../test-apis/comprehensive_api_proc_macro", &build_dir),
         "./expected-output/comprehensive_api_proc_macro.txt",
     );
 }
@@ -189,28 +184,20 @@ fn comprehensive_api_debug_sorting_no_stack_overflow() {
     // Create independent build dir so all tests can run in parallel
     let build_dir = tempdir().unwrap();
 
-    let mut options = Options::default();
-    options.debug_sorting = true;
     let rustdoc_json = rustdoc_json_path_for_crate("../test-apis/comprehensive_api", &build_dir);
-    let _api = PublicApi::from_rustdoc_json(rustdoc_json, options)
+    let _api = public_api::Builder::from_rustdoc_json(rustdoc_json)
+        .debug_sorting(true)
+        .build()
         .unwrap()
         .to_string();
 }
 
 #[test]
 fn invalid_json() {
-    let result = PublicApi::from_rustdoc_json_str("}}}}}}}}}", Options::default());
+    let invalid_json = NamedTempFile::new().unwrap();
+    write!(invalid_json.as_file(), "}}}}}}}}}}").unwrap();
+    let result = public_api::Builder::from_rustdoc_json(invalid_json.path()).build();
     assert!(matches!(result, Err(Error::SerdeJsonError(_))));
-}
-
-#[test]
-fn options() {
-    let options = Options::default();
-
-    // If we don't do this, we will not have code coverage 100% of functions in
-    // lib.rs, which is more annoying than doing this clone
-    #[allow(clippy::clone_on_copy)]
-    let _ = options.clone();
 }
 
 struct LibWithJson {
@@ -249,44 +236,25 @@ fn rustdoc_json_for_lib(lib: &str) -> LibWithJson {
 }
 
 fn assert_public_api_diff(
-    old_json: impl AsRef<Path>,
-    new_json: impl AsRef<Path>,
+    old_json: impl Into<PathBuf>,
+    new_json: impl Into<PathBuf>,
     expected: impl AsRef<Path>,
 ) {
-    let options = Options::default();
-    let old = PublicApi::from_rustdoc_json(old_json, options).unwrap();
-    let new = PublicApi::from_rustdoc_json(new_json, options).unwrap();
+    let old = public_api::Builder::from_rustdoc_json(old_json)
+        .build()
+        .unwrap();
+    let new = public_api::Builder::from_rustdoc_json(new_json)
+        .build()
+        .unwrap();
 
     let diff = public_api::diff::PublicApiDiff::between(old, new);
     expect_file![expected.as_ref()].assert_debug_eq(&diff);
 }
 
 /// Asserts that the public API of the crate in the given rustdoc JSON file
-/// matches the expected output. For brevity, Auto Trait or Blanket impls are
-/// not included.
-fn assert_simplified_public_api(json: impl AsRef<Path>, expected: impl AsRef<Path>) {
-    assert_public_api(json, expected, simplified());
-}
-
-/// Asserts that the public API of the crate in the given rustdoc JSON file
 /// matches the expected output.
-fn assert_public_api(
-    rustdoc_json: impl AsRef<Path>,
-    expected_output: impl AsRef<Path>,
-    options: Options,
-) {
-    let api = PublicApi::from_rustdoc_json(rustdoc_json, options)
-        .unwrap()
-        .to_string();
+fn assert_public_api(builder: public_api::Builder, expected_output: impl AsRef<Path>) {
+    let api = builder.build().unwrap().to_string();
 
     expect_file![expected_output.as_ref()].assert_eq(&api);
-}
-
-/// Returns options for a so called "simplified" API, which is an API without
-/// Auto Trait or Blanket impls, to reduce public item noise.
-fn simplified() -> Options {
-    let mut options = Options::default();
-    options.omit_blanket_impls = true;
-    options.omit_auto_trait_impls = true;
-    options
 }

--- a/public-api/tests/public-api.txt
+++ b/public-api/tests/public-api.txt
@@ -176,48 +176,46 @@ impl<T> core::borrow::BorrowMut<T> for public_api::Error where T: core::marker::
 pub fn public_api::Error::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for public_api::Error
 pub fn public_api::Error::from(t: T) -> T
-#[non_exhaustive] pub struct public_api::Options
-pub public_api::Options::debug_sorting: bool
-pub public_api::Options::omit_auto_derived_impls: bool
-pub public_api::Options::omit_auto_trait_impls: bool
-pub public_api::Options::omit_blanket_impls: bool
-pub public_api::Options::sorted: bool
-impl core::default::Default for public_api::Options
-pub fn public_api::Options::default() -> Self
-impl core::clone::Clone for public_api::Options
-pub fn public_api::Options::clone(&self) -> public_api::Options
-impl core::fmt::Debug for public_api::Options
-pub fn public_api::Options::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::Copy for public_api::Options
-impl core::marker::Send for public_api::Options
-impl core::marker::Sync for public_api::Options
-impl core::marker::Unpin for public_api::Options
-impl core::panic::unwind_safe::RefUnwindSafe for public_api::Options
-impl core::panic::unwind_safe::UnwindSafe for public_api::Options
-impl<T, U> core::convert::Into<U> for public_api::Options where U: core::convert::From<T>
-pub fn public_api::Options::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for public_api::Options where U: core::convert::Into<T>
-pub type public_api::Options::Error = core::convert::Infallible
-pub fn public_api::Options::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for public_api::Options where U: core::convert::TryFrom<T>
-pub type public_api::Options::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn public_api::Options::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for public_api::Options where T: core::clone::Clone
-pub type public_api::Options::Owned = T
-pub fn public_api::Options::clone_into(&self, target: &mut T)
-pub fn public_api::Options::to_owned(&self) -> T
-impl<T> core::any::Any for public_api::Options where T: 'static + core::marker::Sized
-pub fn public_api::Options::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for public_api::Options where T: core::marker::Sized
-pub fn public_api::Options::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for public_api::Options where T: core::marker::Sized
-pub fn public_api::Options::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for public_api::Options
-pub fn public_api::Options::from(t: T) -> T
+pub struct public_api::Builder
+impl public_api::Builder
+pub fn public_api::Builder::build(self) -> public_api::Result<public_api::PublicApi>
+pub fn public_api::Builder::debug_sorting(self, debug_sorting: bool) -> Self
+pub fn public_api::Builder::from_rustdoc_json(path: impl core::convert::Into<std::path::PathBuf>) -> Self
+pub fn public_api::Builder::omit_auto_derived_impls(self, omit_auto_derived_impls: bool) -> Self
+pub fn public_api::Builder::omit_auto_trait_impls(self, omit_auto_trait_impls: bool) -> Self
+pub fn public_api::Builder::omit_blanket_impls(self, omit_blanket_impls: bool) -> Self
+pub fn public_api::Builder::sorted(self, sorted: bool) -> Self
+impl core::clone::Clone for public_api::Builder
+pub fn public_api::Builder::clone(&self) -> public_api::Builder
+impl core::fmt::Debug for public_api::Builder
+pub fn public_api::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Send for public_api::Builder
+impl core::marker::Sync for public_api::Builder
+impl core::marker::Unpin for public_api::Builder
+impl core::panic::unwind_safe::RefUnwindSafe for public_api::Builder
+impl core::panic::unwind_safe::UnwindSafe for public_api::Builder
+impl<T, U> core::convert::Into<U> for public_api::Builder where U: core::convert::From<T>
+pub fn public_api::Builder::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for public_api::Builder where U: core::convert::Into<T>
+pub type public_api::Builder::Error = core::convert::Infallible
+pub fn public_api::Builder::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for public_api::Builder where U: core::convert::TryFrom<T>
+pub type public_api::Builder::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn public_api::Builder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for public_api::Builder where T: core::clone::Clone
+pub type public_api::Builder::Owned = T
+pub fn public_api::Builder::clone_into(&self, target: &mut T)
+pub fn public_api::Builder::to_owned(&self) -> T
+impl<T> core::any::Any for public_api::Builder where T: 'static + core::marker::Sized
+pub fn public_api::Builder::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for public_api::Builder where T: core::marker::Sized
+pub fn public_api::Builder::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for public_api::Builder where T: core::marker::Sized
+pub fn public_api::Builder::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for public_api::Builder
+pub fn public_api::Builder::from(t: T) -> T
 #[non_exhaustive] pub struct public_api::PublicApi
 impl public_api::PublicApi
-pub fn public_api::PublicApi::from_rustdoc_json(path: impl core::convert::AsRef<std::path::Path>, options: public_api::Options) -> public_api::Result<public_api::PublicApi>
-pub fn public_api::PublicApi::from_rustdoc_json_str(rustdoc_json_str: impl core::convert::AsRef<str>, options: public_api::Options) -> public_api::Result<public_api::PublicApi>
 pub fn public_api::PublicApi::into_items(self) -> impl core::iter::traits::iterator::Iterator<Item = public_api::PublicItem>
 pub fn public_api::PublicApi::items(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::PublicItem>
 pub fn public_api::PublicApi::missing_item_ids(&self) -> impl core::iter::traits::iterator::Iterator<Item = &alloc::string::String>

--- a/rustdoc-json/tests/rustdoc-json-lib-tests.rs
+++ b/rustdoc-json/tests/rustdoc-json-lib-tests.rs
@@ -1,4 +1,3 @@
-use public_api::{Options, PublicApi};
 use rustdoc_json::PackageTarget;
 
 #[test]
@@ -7,7 +6,7 @@ fn public_api() -> Result<(), Box<dyn std::error::Error>> {
         .toolchain("nightly")
         .build()?;
 
-    let public_api = PublicApi::from_rustdoc_json(rustdoc_json, Options::default())?;
+    let public_api = public_api::Builder::from_rustdoc_json(rustdoc_json).build()?;
 
     expect_test::expect_file!["public-api.txt"].assert_eq(&public_api.to_string());
 

--- a/rustup-toolchain/tests/rustup-toolchain-lib-tests.rs
+++ b/rustup-toolchain/tests/rustup-toolchain-lib-tests.rs
@@ -1,4 +1,4 @@
-/// Keep this code in sync with the code in `../../README.md` -->
+/// Keep this code in sync with the code in ./README.md -->
 #[test]
 fn public_api() {
     // Install a proper nightly toolchain if it is missing
@@ -11,9 +11,9 @@ fn public_api() {
         .unwrap();
 
     // Derive the public API from the rustdoc JSON
-    let public_api =
-        public_api::PublicApi::from_rustdoc_json(rustdoc_json, public_api::Options::default())
-            .unwrap();
+    let public_api = public_api::Builder::from_rustdoc_json(rustdoc_json)
+        .build()
+        .unwrap();
 
     // Assert that the public API looks correct
     expect_test::expect_file!["public-api.txt"].assert_eq(&public_api.to_string());


### PR DESCRIPTION
Purpose of this draft PR: To announce my intention to replace the current `PublicApi::from_rustdoc_json(path, options)` API with a `public_api::Builder` based API.

Benefits of doing this API change:
* Nicer API
* More symmetry with the `rustdoc_json::Builder` API

 TODO:
* Keep prototyping a bit more
* Figure out deprecation/migration strategy for clients
* Split up into smaller increments that are easier to review
* Should we have `public_api::Builder::default().rustdoc_json(path)` instead of `public_api::Builder::from_rustdoc_json(path)` perhaps?