### PR TITLE
Support `cargo public-api diff highest` (highest = highest semver version)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_NET_GIT_FETCH_WITH_CLI: true # Workaround from https://github.com/rust-lang/cargo/issues/11014
 
 jobs:
   cargo-fmt:

--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_NET_GIT_FETCH_WITH_CLI: true # Workaround from https://github.com/rust-lang/cargo/issues/11014
 
 jobs:
   # The purpose of this job is to detect problems like

--- a/.github/workflows/Release-cargo-public-api.yml
+++ b/.github/workflows/Release-cargo-public-api.yml
@@ -5,7 +5,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_NET_GIT_FETCH_WITH_CLI: true # Workaround from https://github.com/rust-lang/cargo/issues/11014
 
 jobs:
   ci:

--- a/.github/workflows/Release-rustdoc-json.yml
+++ b/.github/workflows/Release-rustdoc-json.yml
@@ -5,7 +5,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_NET_GIT_FETCH_WITH_CLI: true # Workaround from https://github.com/rust-lang/cargo/issues/11014
 
 jobs:
   ci:

--- a/.github/workflows/Release-rustup-toolchain.yml
+++ b/.github/workflows/Release-rustup-toolchain.yml
@@ -5,7 +5,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_NET_GIT_FETCH_WITH_CLI: true # Workaround from https://github.com/rust-lang/cargo/issues/11014
 
 jobs:
   ci:

--- a/README.md
+++ b/README.md
@@ -54,18 +54,15 @@ $ cargo public-api diff 1.6.0
 ```console
 $ cargo public-api diff latest
 Resolved `diff latest` to `diff 1.7.1`
+...
+```
 
-Removed items from the public API
-=================================
-(none)
+### … Against the Highest Published Semver Version
 
-Changed items in the public API
-===============================
-(none)
-
-Added items to the public API
-=============================
-(none)
+```console
+$ cargo public-api diff highest
+Resolved `diff highest` to `diff 1.7.1`
+...
 ```
 
 ### … Between Git Refs

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -172,6 +172,10 @@ enum Subcommand {
     ///
     ///     cargo public-api diff latest
     ///
+    /// Diffing the highest published version of a crate against the current working tree:
+    ///
+    ///     cargo public-api diff highest
+    ///
     /// Diffing working tree against a published version of a specific crate in the workspace:
     ///
     ///     cargo public-api -p specific-crate diff 1.2.3
@@ -234,9 +238,13 @@ pub enum Action {
     RestoreBranch { name: String },
 }
 
-/// The string used by users to request a diff of the latest published version
-/// of a given crate.
+/// The string used by users to request a diff of the latest (in calendar terms)
+/// published version of a given crate.
 const LATEST_VERSION_ARG: &str = "latest";
+
+/// The string used by users to request a diff of the highest (in semver terms)
+/// published version of a given crate.
+const HIGHEST_VERSION_ARG: &str = "highest";
 
 fn main_() -> Result<()> {
     let args = get_args();
@@ -356,7 +364,9 @@ for more.
             )
         }
         (Some(first), None)
-            if semver::Version::parse(first).is_ok() || first == LATEST_VERSION_ARG =>
+            if semver::Version::parse(first).is_ok()
+                || first == LATEST_VERSION_ARG
+                || first == HIGHEST_VERSION_ARG =>
         {
             MainTask::print_diff(PublishedCrate::new(first).boxed(), CurrentDir.boxed())
         }

--- a/cargo-public-api/src/published_crate.rs
+++ b/cargo-public-api/src/published_crate.rs
@@ -2,7 +2,7 @@
 //! rustdoc JSON for. We then build rustdoc JSON for the crate using this dummy
 //! project.
 
-use crate::{Args, LATEST_VERSION_ARG};
+use crate::{Args, HIGHEST_VERSION_ARG, LATEST_VERSION_ARG};
 use anyhow::{anyhow, Result};
 use std::path::PathBuf;
 
@@ -10,9 +10,10 @@ pub fn build_rustdoc_json(version: impl Into<String>, args: &Args) -> Result<Pat
     let package_name = package_name_from_args(args).ok_or_else(|| anyhow!("You must specify a package with either `-p package-name` or `--manifest-path path/to/Cargo.toml`"))?;
 
     let mut version = version.into();
-    if version == LATEST_VERSION_ARG {
-        version = most_recent_version_for_package(&package_name)?;
-        eprintln!("Resolved `diff {LATEST_VERSION_ARG}` to `diff {version}`");
+    if version == LATEST_VERSION_ARG || version == HIGHEST_VERSION_ARG {
+        let arg = version;
+        version = recent_or_highest_version_for_package(&package_name, &arg)?;
+        eprintln!("Resolved `diff {arg}` to `diff {version}`");
     }
 
     let spec = PackageSpec {
@@ -46,20 +47,30 @@ pub fn build_rustdoc_json(version: impl Into<String>, args: &Args) -> Result<Pat
 
 /// Gets the most recent version for the given package, by querying the
 /// crates.io index that users have locally.
-fn most_recent_version_for_package(package_name: &str) -> Result<String> {
+fn recent_or_highest_version_for_package(package_name: &str, arg: &str) -> Result<String> {
     #[cfg(feature = "diff-latest")]
     {
         let index = crates_index::Index::new_cargo_default()?;
         let crate_ = index.crate_(package_name).ok_or_else(|| {
             anyhow!("Could not find crate `{package_name}` in the crates.io index")
         })?;
-        let version = crate_.most_recent_version();
+
+        let version = match arg {
+            LATEST_VERSION_ARG => crate_.most_recent_version(),
+            HIGHEST_VERSION_ARG => crate_.highest_version(),
+            _ => {
+                return Err(anyhow!(
+                    "Unknown version alias: `{arg}`. Expected either `{LATEST_VERSION_ARG}` or `{HIGHEST_VERSION_ARG}`"
+                ))
+            }
+        };
+
         Ok(version.version().to_string())
     }
     #[cfg(not(feature = "diff-latest"))]
     {
         Err(anyhow!(
-            "Can not find latest version of `{package_name}`; the `diff-latest` feature needs to be enabled for `cargo-public-api`"
+            "Can not find `{arg}` version of `{package_name}`; the `diff-latest` feature needs to be enabled for `cargo-public-api`"
         ))
     }
 }

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -672,7 +672,25 @@ fn diff_against_latest_published_version() {
     cmd.arg("latest");
     cmd.assert()
         .stdout_or_update("./expected-output/diff-latest.txt")
-        .stderr(contains("Resolved `diff latest` to `diff 0.3.0`"))
+        .stderr(contains("Resolved `diff latest` to `diff 0.2.1`"))
+        .success();
+}
+
+#[test]
+fn diff_against_highest_published_version() {
+    // Create a test repo. It already is at the latest version
+    let test_repo = TestRepo::new();
+
+    // Add a new item to the public API
+    append_to_lib_rs_in_test_repo(&test_repo, "pub struct AddedSinceLatest;");
+
+    let mut cmd = TestCmd::new().with_separate_target_dir();
+    cmd.current_dir(test_repo.path());
+    cmd.arg("diff");
+    cmd.arg("highest");
+    cmd.assert()
+        .stdout_or_update("./expected-output/diff-highest.txt")
+        .stderr(contains("Resolved `diff highest` to `diff 0.3.0`"))
         .success();
 }
 

--- a/cargo-public-api/tests/expected-output/diff-highest.txt
+++ b/cargo-public-api/tests/expected-output/diff-highest.txt
@@ -1,11 +1,10 @@
 Removed items from the public API
 =================================
--pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize)
+(none)
 
 Changed items in the public API
 ===============================
--pub struct example_api::Struct
-+#[non_exhaustive] pub struct example_api::Struct
+(none)
 
 Added items to the public API
 =============================

--- a/docs/long-diff-help.txt
+++ b/docs/long-diff-help.txt
@@ -23,6 +23,10 @@ Diffing the latest published version of a crate against the current working tree
 
     cargo public-api diff latest
 
+Diffing the highest published version of a crate against the current working tree:
+
+    cargo public-api diff highest
+
 Diffing working tree against a published version of a specific crate in the workspace:
 
     cargo public-api -p specific-crate diff 1.2.3


### PR DESCRIPTION
This also fixes CI since 0.3.0 is not latest any longer, now 0.2.1 is latest. I'm confused how scheduled nightly didn't fail, because locally the test fails for me.

CC @Emilgardis  (no worries :)

Since CI is broken I will merge this as soon as CI pass in this PR.