### PR TITLE
deny.toml: Deny multiple-versions except for toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -25,5 +25,7 @@ exceptions = [
 ]
 
 [bans]
-# multiple-versions = "deny"
+multiple-versions = "deny"
 wildcards = "deny"
+[[bans.skip]]
+name = "toml"


### PR DESCRIPTION
See https://github.com/Enselic/cargo-public-api/pull/303#discussion_r1086279545