### PR TITLE
Bump `crates-index` to `0.19.1` to get rid of MPL:ed `smartstring`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "crates-index"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75096e85e0ce07c430da88f21b404734f81c873d107177004f2ca97fc4baa267"
+checksum = "519e0791b7175923a30dd40548b8c80da1182b15d78d710712f1c2ecd50c0b93"
 dependencies = [
  "git2",
  "hex",
@@ -187,7 +187,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "smartstring",
+ "smol_str",
  "toml 0.6.0",
 ]
 
@@ -815,22 +815,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "smartstring"
-version = "1.0.1"
+name = "smol_str"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+checksum = "7475118a28b7e3a2e157ce0131ba8c5526ea96e90ee601d9f6bb2e286a35ab44"
 dependencies = [
- "autocfg",
  "serde",
- "static_assertions",
- "version_check",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -36,7 +36,7 @@ version = "4.0.32"
 features = ["derive", "wrap_help"]
 
 [dependencies.crates-index]
-version = "0.19.0"
+version = "0.19.1"
 default-features = false
 optional = true
 

--- a/deny.toml
+++ b/deny.toml
@@ -10,20 +10,6 @@ unlicensed = "deny"
 copyleft = "deny"
 default = "deny"
 
-exceptions = [
-    # Allowed because:
-    #  * MPL-2.0 is a weak/non-viral copyleft license that doesn't cause much
-    #    trouble in practice
-    #  * Only affects the `cargo-public-api` binary and not any of our libraries
-    #    (`public-api`, `rustdoc-json`, `rustup-toolchain`). The dependency
-    #    chain is: `cargo-public-api` -> `crates-index` -> `smartstring`
-    #  * Can be opted out from by disabling the `diff-latest` feature
-    #  * Upstream is hesitant to remove the dependency because of better
-    #    performance than alternatives:
-    #    https://github.com/frewsxcv/rust-crates-index/pull/90
-    { name = "smartstring", allow = ["MPL-2.0"] },
-]
-
 [bans]
 multiple-versions = "deny"
 wildcards = "deny"


### PR DESCRIPTION
Upstream changed their mind and changed to `smol_str` again. See https://github.com/frewsxcv/rust-crates-index/pull/90 and https://github.com/frewsxcv/rust-crates-index/pull/92.