### PR TITLE
deny.toml: Allow multiple versions

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -11,7 +11,4 @@ copyleft = "deny"
 default = "deny"
 
 [bans]
-multiple-versions = "deny"
 wildcards = "deny"
-[[bans.skip]]
-name = "toml"


### PR DESCRIPTION
I want to make use of dependabot as much as possible. If we disallow multiple versions, we can't make use of dependabot in situations where we temporarily need two versions of a dep.

So stop disallowing multiple versions.