### PR TITLE
Add explicit variants of `--simplified` called `--omit blanket-impls | auto-trait-impls | auto-derived-impls`

### DIFF
--- a/cargo-public-api/src/api_source.rs
+++ b/cargo-public-api/src/api_source.rs
@@ -132,8 +132,8 @@ pub fn build_rustdoc_json(builder: rustdoc_json::Builder) -> Result<PathBuf> {
 fn get_options(args: &Args) -> Options {
     let mut options = Options::default();
     options.debug_sorting = args.debug_sorting;
-    options.omit_blanket_impls = args.simplified();
-    options.omit_auto_trait_impls = args.simplified();
+    options.omit_blanket_impls = args.omit_blanket_impls();
+    options.omit_auto_trait_impls = args.omit_auto_trait_impls();
     options.omit_auto_derived_impls = args.omit_auto_derived_impls();
     options
 }

--- a/cargo-public-api/src/arg_types.rs
+++ b/cargo-public-api/src/arg_types.rs
@@ -54,6 +54,24 @@ impl Color {
     }
 }
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq, clap::ValueEnum)]
+#[value(rename_all = "kebab-case")]
+#[allow(clippy::enum_variant_names)] // We might add support for omitting other things in the future
+pub enum Omit {
+    /// Omit items that belong to Blanket Implementations such as `impl<T> Any
+    /// for T`, `impl<T> Borrow<T> for T`, and `impl<T, U> Into<U> for T where
+    /// U: From<T>`.
+    BlanketImpls,
+
+    /// Omit items that belong to Auto Trait Implementations such as `impl Send
+    /// for ...`, `impl Sync for ...`, and `impl Unpin for ...`.
+    AutoTraitImpls,
+
+    /// Omit items that belong to Auto Derived Implementations such as `Clone`,
+    /// `Debug`, and `Eq`.
+    AutoDerivedImpls,
+}
+
 #[cfg(test)]
 mod tests {
     use super::DenyMethod;

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -45,11 +45,41 @@ fn list_public_items() {
 }
 
 #[test]
+fn list_public_items_omit_blanket_impls() {
+    let mut cmd = TestCmd::as_subcommand_without_args().with_test_repo();
+    cmd.arg("--omit");
+    cmd.arg("blanket-impls");
+    cmd.assert()
+        .stdout_or_update("./expected-output/omit-blanket-impls.txt")
+        .success();
+}
+
+#[test]
+fn list_public_items_omit_auto_trait_impls_impls() {
+    let mut cmd = TestCmd::as_subcommand_without_args().with_test_repo();
+    cmd.arg("--omit");
+    cmd.arg("auto-trait-impls");
+    cmd.assert()
+        .stdout_or_update("./expected-output/omit-auto-trait-impls.txt")
+        .success();
+}
+
+#[test]
 fn list_public_items_omit_auto_derived_impls() {
+    let mut cmd = TestCmd::as_subcommand_without_args().with_test_repo();
+    cmd.arg("--omit");
+    cmd.arg("auto-derived-impls");
+    cmd.assert()
+        .stdout_or_update("./expected-output/omit-auto-derived-impls.txt")
+        .success();
+}
+
+#[test]
+fn list_public_items_omit_auto_derived_impls_with_double_s() {
     let mut cmd = TestCmd::as_subcommand_without_args().with_test_repo();
     cmd.arg("-ss"); // Note the double -s
     cmd.assert()
-        .stdout_or_update("./expected-output/omit-auto-derived-impls.txt")
+        .stdout_or_update("./expected-output/omit-auto-derived-impls-with-double-s.txt")
         .success();
 }
 

--- a/cargo-public-api/tests/expected-output/omit-auto-derived-impls-with-double-s.txt
+++ b/cargo-public-api/tests/expected-output/omit-auto-derived-impls-with-double-s.txt
@@ -1,0 +1,6 @@
+pub mod example_api
+#[non_exhaustive] pub struct example_api::Struct
+pub example_api::Struct::v1_field: usize
+pub example_api::Struct::v2_field: usize
+pub struct example_api::StructV2
+pub example_api::StructV2::field: usize

--- a/cargo-public-api/tests/expected-output/omit-auto-trait-impls.txt
+++ b/cargo-public-api/tests/expected-output/omit-auto-trait-impls.txt
@@ -2,11 +2,8 @@ pub mod example_api
 #[non_exhaustive] pub struct example_api::Struct
 pub example_api::Struct::v1_field: usize
 pub example_api::Struct::v2_field: usize
-impl core::marker::Send for example_api::Struct
-impl core::marker::Sync for example_api::Struct
-impl core::marker::Unpin for example_api::Struct
-impl core::panic::unwind_safe::RefUnwindSafe for example_api::Struct
-impl core::panic::unwind_safe::UnwindSafe for example_api::Struct
+impl core::fmt::Debug for example_api::Struct
+pub fn example_api::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<T, U> core::convert::Into<U> for example_api::Struct where U: core::convert::From<T>
 pub fn example_api::Struct::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for example_api::Struct where U: core::convert::Into<T>
@@ -25,11 +22,6 @@ impl<T> core::convert::From<T> for example_api::Struct
 pub fn example_api::Struct::from(t: T) -> T
 pub struct example_api::StructV2
 pub example_api::StructV2::field: usize
-impl core::marker::Send for example_api::StructV2
-impl core::marker::Sync for example_api::StructV2
-impl core::marker::Unpin for example_api::StructV2
-impl core::panic::unwind_safe::RefUnwindSafe for example_api::StructV2
-impl core::panic::unwind_safe::UnwindSafe for example_api::StructV2
 impl<T, U> core::convert::Into<U> for example_api::StructV2 where U: core::convert::From<T>
 pub fn example_api::StructV2::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for example_api::StructV2 where U: core::convert::Into<T>

--- a/cargo-public-api/tests/expected-output/omit-blanket-impls.txt
+++ b/cargo-public-api/tests/expected-output/omit-blanket-impls.txt
@@ -1,0 +1,18 @@
+pub mod example_api
+#[non_exhaustive] pub struct example_api::Struct
+pub example_api::Struct::v1_field: usize
+pub example_api::Struct::v2_field: usize
+impl core::fmt::Debug for example_api::Struct
+pub fn example_api::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Send for example_api::Struct
+impl core::marker::Sync for example_api::Struct
+impl core::marker::Unpin for example_api::Struct
+impl core::panic::unwind_safe::RefUnwindSafe for example_api::Struct
+impl core::panic::unwind_safe::UnwindSafe for example_api::Struct
+pub struct example_api::StructV2
+pub example_api::StructV2::field: usize
+impl core::marker::Send for example_api::StructV2
+impl core::marker::Sync for example_api::StructV2
+impl core::marker::Unpin for example_api::StructV2
+impl core::panic::unwind_safe::RefUnwindSafe for example_api::StructV2
+impl core::panic::unwind_safe::UnwindSafe for example_api::StructV2

--- a/docs/long-help.txt
+++ b/docs/long-help.txt
@@ -25,13 +25,21 @@ Options:
           This makes the output significantly less noisy and repetitive, at the cost of not fully
           describing the public API.
           
-          Examples of Blanket Implementations: `impl<T> Any for T`, `impl<T> Borrow<T> for T`, and
-          `impl<T, U> Into<U> for T where U: From<T>`
-          
-          Examples of Auto Trait Implementations: `impl Send for Foo`, `impl Sync for Foo`, and
-          `impl Unpin for Foo`
-          
-          Examples of Auto Derived Implementations: `Clone`, `Debug`, `Eq`
+          Use `--omit ...` for more control.
+
+      --omit <OMIT>
+          Omit certain kinds of items from the output to make it less noisy
+
+          Possible values:
+          - blanket-impls:
+            Omit items that belong to Blanket Implementations such as `impl<T> Any for T`, `impl<T>
+            Borrow<T> for T`, and `impl<T, U> Into<U> for T where U: From<T>`
+          - auto-trait-impls:
+            Omit items that belong to Auto Trait Implementations such as `impl Send for ...`, `impl
+            Sync for ...`, and `impl Unpin for ...`
+          - auto-derived-impls:
+            Omit items that belong to Auto Derived Implementations such as `Clone`, `Debug`, and
+            `Eq`
 
   -F, --features <FEATURES>...
           Space or comma separated list of features to activate

--- a/docs/short-help.txt
+++ b/docs/short-help.txt
@@ -13,6 +13,8 @@ Options:
   -s, --simplified...           Omit items that belong to Blanket Implementations and Auto Trait
                                 Implementations (first use), and Auto Derived Implementations
                                 (second use)
+      --omit <OMIT>             Omit certain kinds of items from the output to make it less noisy [possible
+                                values: blanket-impls, auto-trait-impls, auto-derived-impls]
   -F, --features <FEATURES>...  Space or comma separated list of features to activate
       --all-features            Activate all available features
       --no-default-features     Do not activate the `default` feature


### PR DESCRIPTION
For day-to-day usage, the `--simplified` (`-s`) flag is still preferred. However, when you paste a `cargo public-api` invocation together with its output in e.g. a GitHub comment, the recipient of the comment is not necessarily familiar with `cargo public-api` and its day-to-day flags.

By adding these explicit flags, we remove the need to explain what `--simplified` means, because it becomes more or less obvious when these more explicit forms are used.