### PR TITLE
Nightly.yml: Install zsh also for auto-bless

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - run: zsh --version || (sudo apt install -y zsh && zsh --version)
+      - run: zsh --version || (sudo apt-get install -y zsh && zsh --version)
         if: runner.os != 'Windows'
       - run: rustup install --profile minimal nightly
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: rustup install --profile minimal nightly
       - uses: Swatinem/rust-cache@v2
+      - run: sudo apt-get install -y zsh && zsh --version
       - run: ./scripts/bless-expected-output-for-tests.sh
       - id: latest-nightly
         run: echo "version=nightly-$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -883,6 +883,11 @@ fn long_help_wraps() {
     }
 }
 
+/// Test zsh completion script generation.
+///
+/// NOTE: This test requires zsh to be installed on the system. It is installed
+/// by default on macOS, and is generally either already installed on your Linux
+/// distribution or very easy to install.
 #[test]
 #[cfg_attr(
     target_family = "windows",


### PR DESCRIPTION
Use `apt-get` to fix

    WARNING: apt does not have a stable CLI interface. Use with caution in scripts.