### PR TITLE
Document and test diffing between two published versions of an arbitrary crate

### DIFF
--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -173,6 +173,10 @@ enum Subcommand {
     ///
     ///     cargo public-api diff latest
     ///
+    /// Diffing between two published versions of any crate:
+    ///
+    ///     cargo public-api -p example_api diff 0.1.0 0.2.0
+    ///
     /// Diffing working tree against a published version of a specific crate in the workspace:
     ///
     ///     cargo public-api -p specific-crate diff 1.2.3

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -747,6 +747,21 @@ fn diff_against_published_version() {
         .success();
 }
 
+/// Tests that we can diff between two published versions of an arbitrary crate
+/// that does not need to be in the current workspace.
+#[test]
+fn diff_between_two_published_versions() {
+    let mut cmd = TestCmd::new(); // NOTE: No `.with_test_repo()` !;
+    cmd.arg("-p");
+    cmd.arg("example_api");
+    cmd.arg("diff");
+    cmd.arg("0.1.0");
+    cmd.arg("0.2.0");
+    cmd.assert()
+        .stdout_or_update("./expected-output/example_api_diff_v0.1.0_to_v0.2.0.txt")
+        .success();
+}
+
 #[test]
 fn diff_against_latest_published_version() {
     // Create a test repo. It already is at the latest version

--- a/docs/long-diff-help.txt
+++ b/docs/long-diff-help.txt
@@ -23,6 +23,10 @@ Diffing the latest version of a crate against the current working tree:
 
     cargo public-api diff latest
 
+Diffing between two published versions of any crate:
+
+    cargo public-api -p example_api diff 0.1.0 0.2.0
+
 Diffing working tree against a published version of a specific crate in the workspace:
 
     cargo public-api -p specific-crate diff 1.2.3


### PR DESCRIPTION
I was about to add support for it, but it turned out it already works.