### PR TITLE
Make auto-merge status checks properly handle cargo-test matrix job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,12 +12,19 @@ env:
 
 jobs:
   all-jobs:
+    if: always()
     name: all-jobs
     runs-on: ubuntu-latest
     needs:
-      [cargo-fmt, cargo-doc, cargo-clippy, cargo-audit, cargo-deny, cargo-test]
+      - cargo-fmt
+      - cargo-doc
+      - cargo-clippy
+      - cargo-audit
+      - cargo-deny
+      - cargo-test
     steps:
-      - run: echo "All jobs completed"
+      - run: |
+          [ "${{ needs.cargo-test.result }}" = "success" ]
 
   cargo-fmt:
     name: cargo fmt -- --check


### PR DESCRIPTION
Make auto-merge status checks properly handle cargo-test matrix job

A job that needs a matrix job that fails is _skipped_, not _failed_. A
skipped job is OK in terms "status checks must pass before merge". See
https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution

> Note: A job that is skipped will report its status as "Success". It
> will not prevent a pull request from merging, even if it is a required
> check.

So make sure that the `all-jobs` job _fails_ if any of the sub-jobs to
the cargo-test matrix job fails. See
https://docs.github.com/en/actions/learn-github-actions/contexts#needs-context