### PR TITLE
Introduce `public_api::Builder`, deprecate `PublicApi::from_rustdoc_json()` and `Options`

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ fn public_api() {
         .unwrap();
 
     // Derive the public API from the rustdoc JSON
-    let public_api =
-        public_api::PublicApi::from_rustdoc_json(rustdoc_json, public_api::Options::default())
-            .unwrap();
+    let public_api = public_api::Builder::from_rustdoc_json(rustdoc_json)
+        .build()
+        .unwrap();
 
     // Assert that the public API looks correct
     expect_test::expect_file!["public-api.txt"].assert_eq(&public_api.to_string());

--- a/cargo-public-api/tests/expected-output/list_public_items.txt
+++ b/cargo-public-api/tests/expected-output/list_public_items.txt
@@ -96,6 +96,24 @@ impl !core::panic::unwind_safe::UnwindSafe for public_api::Error
 impl core::marker::Send for public_api::Error
 impl core::marker::Sync for public_api::Error
 impl core::marker::Unpin for public_api::Error
+pub struct public_api::Builder
+impl public_api::Builder
+pub fn public_api::Builder::build(self) -> public_api::Result<public_api::PublicApi>
+pub fn public_api::Builder::debug_sorting(self, debug_sorting: bool) -> Self
+pub fn public_api::Builder::from_rustdoc_json(path: impl core::convert::Into<std::path::PathBuf>) -> Self
+pub fn public_api::Builder::omit_auto_derived_impls(self, omit_auto_derived_impls: bool) -> Self
+pub fn public_api::Builder::omit_auto_trait_impls(self, omit_auto_trait_impls: bool) -> Self
+pub fn public_api::Builder::omit_blanket_impls(self, omit_blanket_impls: bool) -> Self
+pub fn public_api::Builder::sorted(self, sorted: bool) -> Self
+impl core::clone::Clone for public_api::Builder
+pub fn public_api::Builder::clone(&self) -> public_api::Builder
+impl core::fmt::Debug for public_api::Builder
+pub fn public_api::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Send for public_api::Builder
+impl core::marker::Sync for public_api::Builder
+impl core::marker::Unpin for public_api::Builder
+impl core::panic::unwind_safe::RefUnwindSafe for public_api::Builder
+impl core::panic::unwind_safe::UnwindSafe for public_api::Builder
 #[non_exhaustive] pub struct public_api::Options
 pub public_api::Options::debug_sorting: bool
 pub public_api::Options::omit_auto_derived_impls: bool

--- a/cargo-public-api/tests/expected-output/subcommand_invocation_public_api_arg.txt
+++ b/cargo-public-api/tests/expected-output/subcommand_invocation_public_api_arg.txt
@@ -76,6 +76,19 @@ impl core::fmt::Display for public_api::Error
 pub fn public_api::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Debug for public_api::Error
 pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct public_api::Builder
+impl public_api::Builder
+pub fn public_api::Builder::build(self) -> public_api::Result<public_api::PublicApi>
+pub fn public_api::Builder::debug_sorting(self, debug_sorting: bool) -> Self
+pub fn public_api::Builder::from_rustdoc_json(path: impl core::convert::Into<std::path::PathBuf>) -> Self
+pub fn public_api::Builder::omit_auto_derived_impls(self, omit_auto_derived_impls: bool) -> Self
+pub fn public_api::Builder::omit_auto_trait_impls(self, omit_auto_trait_impls: bool) -> Self
+pub fn public_api::Builder::omit_blanket_impls(self, omit_blanket_impls: bool) -> Self
+pub fn public_api::Builder::sorted(self, sorted: bool) -> Self
+impl core::clone::Clone for public_api::Builder
+pub fn public_api::Builder::clone(&self) -> public_api::Builder
+impl core::fmt::Debug for public_api::Builder
+pub fn public_api::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 #[non_exhaustive] pub struct public_api::Options
 pub public_api::Options::debug_sorting: bool
 pub public_api::Options::omit_auto_derived_impls: bool

--- a/public-api/CHANGELOG.md
+++ b/public-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `public-api` changelog
 
+## Unreleased v0.27.4
+* Deprecate `PublicApi::from_rustdoc_json()`. Use `public_api::Builder::from_rustdoc_json()` instead.
+* Deprecate `Options`. Use `public_api::Builder` methods instead.
+
 ## v0.27.3
 * Bump deps
 

--- a/public-api/examples/diff_public_api.rs
+++ b/public-api/examples/diff_public_api.rs
@@ -1,21 +1,19 @@
 use std::error::Error;
 
-use public_api::{diff::PublicApiDiff, Options, PublicApi};
+use public_api::diff::PublicApiDiff;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let options = Options::default();
-
     let old_json = rustdoc_json::Builder::default()
         .toolchain("nightly")
         .manifest_path("test-apis/example_api-v0.1.0/Cargo.toml")
         .build()?;
-    let old = PublicApi::from_rustdoc_json(old_json, options)?;
+    let old = public_api::Builder::from_rustdoc_json(old_json).build()?;
 
     let new_json = rustdoc_json::Builder::default()
         .toolchain("nightly")
         .manifest_path("test-apis/example_api-v0.2.0/Cargo.toml")
         .build()?;
-    let new = PublicApi::from_rustdoc_json(new_json, options)?;
+    let new = public_api::Builder::from_rustdoc_json(new_json).build()?;
 
     let diff = PublicApiDiff::between(old, new);
     println!("{diff:#?}");

--- a/public-api/examples/list_public_api.rs
+++ b/public-api/examples/list_public_api.rs
@@ -1,14 +1,12 @@
 use std::error::Error;
 
-use public_api::{Options, PublicApi};
-
 fn main() -> Result<(), Box<dyn Error>> {
     let json_path = rustdoc_json::Builder::default()
         .toolchain("nightly")
         .manifest_path("test-apis/example_api-v0.2.0/Cargo.toml")
         .build()?;
 
-    let public_api = PublicApi::from_rustdoc_json(json_path, Options::default())?;
+    let public_api = public_api::Builder::from_rustdoc_json(json_path).build()?;
 
     for public_item in public_api.items() {
         println!("{public_item}");

--- a/public-api/src/diff.rs
+++ b/public-api/src/diff.rs
@@ -61,7 +61,7 @@ impl PublicApiDiff {
     /// Allows you to diff the public API between two arbitrary versions of a
     /// library, e.g. different releases. The input parameters `old` and `new`
     /// is the output of two different invocations of
-    /// [`crate::PublicApi::from_rustdoc_json`].
+    /// [`crate::Builder::build`].
     #[must_use]
     pub fn between(old: PublicApi, new: PublicApi) -> Self {
         // We must use a HashBag, because with a HashSet we would lose public

--- a/public-api/src/item_processor.rs
+++ b/public-api/src/item_processor.rs
@@ -1,7 +1,7 @@
 use super::intermediate_public_item::NameableItem;
 use crate::{
     crate_wrapper::CrateWrapper, intermediate_public_item::IntermediatePublicItem,
-    public_item::PublicItem, render::RenderingContext, Options, PublicApi,
+    public_item::PublicItem, render::RenderingContext, BuilderOptions as Options, PublicApi,
 };
 use rustdoc_types::{
     Crate, Id, Impl, Import, Item, ItemEnum, Module, Struct, StructKind, VariantKind,
@@ -53,7 +53,7 @@ pub struct ItemProcessor<'c> {
 }
 
 impl<'c> ItemProcessor<'c> {
-    pub fn new(crate_: &'c Crate, options: Options) -> Self {
+    pub(crate) fn new(crate_: &'c Crate, options: Options) -> Self {
         ItemProcessor {
             crate_: CrateWrapper::new(crate_),
             options,
@@ -386,7 +386,7 @@ pub fn impls_for_item(item: &Item) -> Option<&[Id]> {
     }
 }
 
-pub fn public_api_in_crate(crate_: &Crate, options: Options) -> super::PublicApi {
+pub(crate) fn public_api_in_crate(crate_: &Crate, options: Options) -> super::PublicApi {
     let mut item_processor = ItemProcessor::new(crate_, options);
     item_processor.add_to_work_queue(vec![], &crate_.root);
     item_processor.run();

--- a/public-api/src/render.rs
+++ b/public-api/src/render.rs
@@ -1,8 +1,7 @@
 #![allow(clippy::unused_self)]
-use crate::{
-    intermediate_public_item::{IntermediatePublicItem, NameableItem},
-    Options,
-};
+use crate::intermediate_public_item::{IntermediatePublicItem, NameableItem};
+use crate::tokens::Token;
+use crate::BuilderOptions as Options;
 use std::ops::Deref;
 use std::{cmp::Ordering, collections::HashMap, vec};
 
@@ -20,8 +19,6 @@ macro_rules! ws {
     };
 }
 
-use crate::tokens::Token;
-
 /// When we render an item, it might contain references to other parts of the
 /// public API. For such cases, the rendering code can use the fields in this
 /// struct.
@@ -32,7 +29,7 @@ pub struct RenderingContext<'c> {
     /// Given a rustdoc JSON ID, keeps track of what public items that have this Id.
     pub id_to_items: HashMap<&'c Id, Vec<&'c IntermediatePublicItem<'c>>>,
 
-    pub options: Options,
+    pub(crate) options: Options,
 }
 
 impl<'c> RenderingContext<'c> {
@@ -1316,10 +1313,11 @@ mod test {
             external_crates: HashMap::new(),
             format_version: 0,
         };
+        let builder = crate::Builder::from_rustdoc_json("N/A");
         let context = RenderingContext {
             crate_: &crate_,
             id_to_items: HashMap::new(),
-            options: Options::default(),
+            options: builder.options,
         };
 
         let actual = render_fn(context);

--- a/public-api/tests/common/mod.rs
+++ b/public-api/tests/common/mod.rs
@@ -2,6 +2,25 @@
 
 use std::path::{Path, PathBuf};
 
+pub fn builder_for_crate(
+    test_crate: impl AsRef<Path>,
+    target_dir: impl AsRef<Path>,
+) -> public_api::Builder {
+    let json = rustdoc_json_path_for_crate(test_crate, target_dir);
+    public_api::Builder::from_rustdoc_json(json)
+}
+
+/// Returns a builder for a so called "simplified" API, which is an API without
+/// Auto Trait or Blanket impls, to reduce public item noise.
+pub fn simplified_builder_for_crate(
+    test_crate: impl AsRef<Path>,
+    target_dir: impl AsRef<Path>,
+) -> public_api::Builder {
+    builder_for_crate(test_crate, target_dir)
+        .omit_blanket_impls(true)
+        .omit_auto_trait_impls(true)
+}
+
 /// Builds rustdoc JSON for the given test crate.
 ///
 /// Output of child processes are not captured by the Rust test framework (see

--- a/public-api/tests/public-api.txt
+++ b/public-api/tests/public-api.txt
@@ -176,6 +176,44 @@ impl<T> core::borrow::BorrowMut<T> for public_api::Error where T: core::marker::
 pub fn public_api::Error::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for public_api::Error
 pub fn public_api::Error::from(t: T) -> T
+pub struct public_api::Builder
+impl public_api::Builder
+pub fn public_api::Builder::build(self) -> public_api::Result<public_api::PublicApi>
+pub fn public_api::Builder::debug_sorting(self, debug_sorting: bool) -> Self
+pub fn public_api::Builder::from_rustdoc_json(path: impl core::convert::Into<std::path::PathBuf>) -> Self
+pub fn public_api::Builder::omit_auto_derived_impls(self, omit_auto_derived_impls: bool) -> Self
+pub fn public_api::Builder::omit_auto_trait_impls(self, omit_auto_trait_impls: bool) -> Self
+pub fn public_api::Builder::omit_blanket_impls(self, omit_blanket_impls: bool) -> Self
+pub fn public_api::Builder::sorted(self, sorted: bool) -> Self
+impl core::clone::Clone for public_api::Builder
+pub fn public_api::Builder::clone(&self) -> public_api::Builder
+impl core::fmt::Debug for public_api::Builder
+pub fn public_api::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Send for public_api::Builder
+impl core::marker::Sync for public_api::Builder
+impl core::marker::Unpin for public_api::Builder
+impl core::panic::unwind_safe::RefUnwindSafe for public_api::Builder
+impl core::panic::unwind_safe::UnwindSafe for public_api::Builder
+impl<T, U> core::convert::Into<U> for public_api::Builder where U: core::convert::From<T>
+pub fn public_api::Builder::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for public_api::Builder where U: core::convert::Into<T>
+pub type public_api::Builder::Error = core::convert::Infallible
+pub fn public_api::Builder::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for public_api::Builder where U: core::convert::TryFrom<T>
+pub type public_api::Builder::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn public_api::Builder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for public_api::Builder where T: core::clone::Clone
+pub type public_api::Builder::Owned = T
+pub fn public_api::Builder::clone_into(&self, target: &mut T)
+pub fn public_api::Builder::to_owned(&self) -> T
+impl<T> core::any::Any for public_api::Builder where T: 'static + core::marker::Sized
+pub fn public_api::Builder::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for public_api::Builder where T: core::marker::Sized
+pub fn public_api::Builder::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for public_api::Builder where T: core::marker::Sized
+pub fn public_api::Builder::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for public_api::Builder
+pub fn public_api::Builder::from(t: T) -> T
 #[non_exhaustive] pub struct public_api::Options
 pub public_api::Options::debug_sorting: bool
 pub public_api::Options::omit_auto_derived_impls: bool

--- a/rustdoc-json/tests/rustdoc-json-lib-tests.rs
+++ b/rustdoc-json/tests/rustdoc-json-lib-tests.rs
@@ -1,4 +1,3 @@
-use public_api::{Options, PublicApi};
 use rustdoc_json::PackageTarget;
 
 #[test]
@@ -7,7 +6,7 @@ fn public_api() -> Result<(), Box<dyn std::error::Error>> {
         .toolchain("nightly")
         .build()?;
 
-    let public_api = PublicApi::from_rustdoc_json(rustdoc_json, Options::default())?;
+    let public_api = public_api::Builder::from_rustdoc_json(rustdoc_json).build()?;
 
     expect_test::expect_file!["public-api.txt"].assert_eq(&public_api.to_string());
 

--- a/rustup-toolchain/tests/rustup-toolchain-lib-tests.rs
+++ b/rustup-toolchain/tests/rustup-toolchain-lib-tests.rs
@@ -11,9 +11,9 @@ fn public_api() {
         .unwrap();
 
     // Derive the public API from the rustdoc JSON
-    let public_api =
-        public_api::PublicApi::from_rustdoc_json(rustdoc_json, public_api::Options::default())
-            .unwrap();
+    let public_api = public_api::Builder::from_rustdoc_json(rustdoc_json)
+        .build()
+        .unwrap();
 
     // Assert that the public API looks correct
     expect_test::expect_file!["public-api.txt"].assert_eq(&public_api.to_string());


### PR DESCRIPTION
Instead of this public API:

    // Derive the public API from the rustdoc JSON
    let mut options = public_api::Options::default();
    options.omit_blanket_impls = true;
    options.omit_auto_trait_impls = true;
    let public_api = public_api::PublicApi::from_rustdoc_json(path, options).unwrap();

The public API is now this:

    // Derive the public API from the rustdoc JSON
    let public_api = public_api::Builder::from_rustdoc_json(path)
        .omit_blanket_impls(true)
        .omit_auto_trait_impls(true)
        .build()
        .unwrap();

which has the following benefits:
 * nicer and simpler API
 * symmetry with the `rustdoc_json::Builder` API

Closes #318
