### PR TITLE
Try again to fix the all-jobs job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   all-jobs:
-    if: always()
+    if: always() # Otherwise this job is skipped if the matrix job fails
     name: all-jobs
     runs-on: ubuntu-latest
     needs:
@@ -23,8 +23,7 @@ jobs:
       - cargo-deny
       - cargo-test
     steps:
-      - run: |
-          [ "${{ needs.cargo-test.result }}" = "success" ]
+      - run: jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'
 
   cargo-fmt:
     name: cargo fmt -- --check


### PR DESCRIPTION
We must use `always()`, because the default `success()` will evaluate to
`skipped` if a needed matrix job fails, and a required status check for a
job is considered OK if it is skipped. And since we use `always()`, we
must check the result of each job manually.