### PR TITLE
Use granular GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/Auto-merge-dependabot-PRs.yml
+++ b/.github/workflows/Auto-merge-dependabot-PRs.yml
@@ -10,6 +10,8 @@ jobs:
   auto-merge:
     if: github.repository == 'Enselic/cargo-public-api' && startsWith(github.head_ref, 'dependabot/')
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # gh pr merge
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/Release-cargo-public-api.yml
+++ b/.github/workflows/Release-cargo-public-api.yml
@@ -57,6 +57,8 @@ jobs:
   release:
     needs: publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # softprops/action-gh-release
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/Release-rustdoc-json.yml
+++ b/.github/workflows/Release-rustdoc-json.yml
@@ -16,6 +16,8 @@ jobs:
       name: crates.io
       url: https://crates.io/crates/rustdoc-json
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # git push
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/Release-rustup-toolchain.yml
+++ b/.github/workflows/Release-rustup-toolchain.yml
@@ -16,6 +16,8 @@ jobs:
       name: crates.io
       url: https://crates.io/crates/rustup-toolchain
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # git push
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
The default setting in new repos of "Workflow permissions" in https://github.com/Enselic/cargo-public-api/settings/actions is "read-only". Our setting is currently the non-default "write-all".

Harden our setup slightly by using more granular permissions.

This might cause some short-term problems if I have set the wrong permissions, but such problems should be easy to fix.