### PR TITLE
Introduce `rustup_toolchain::Installer` to make API future proof and configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,10 @@ Then add the following test to your project. As the author of the below test cod
 #[test]
 fn public_api() {
     // Install a proper nightly toolchain if it is missing
-    rustup_toolchain::ensure_installed(public_api::MINIMUM_NIGHTLY_VERSION).unwrap();
+    rustup_toolchain::Installer::default()
+        .toolchain(public_api::MINIMUM_NIGHTLY_VERSION)
+        .run()
+        .unwrap();
 
     // Build rustdoc JSON
     let rustdoc_json = rustdoc_json::Builder::default()

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -1223,7 +1223,10 @@ impl TestCmd {
     /// `cargo +toolchain public-api --simplified`
     /// Also installs the toolchain if it is not installed.
     fn with_proxy_toolchain(toolchain: &str) -> Self {
-        rustup_toolchain::ensure_installed(toolchain).unwrap();
+        rustup_toolchain::Installer::default()
+            .toolchain(toolchain)
+            .run()
+            .unwrap();
         Self::new_impl(
             TestCmdType::Subcommand {
                 toolchain: Some(toolchain),
@@ -1239,7 +1242,10 @@ impl TestCmd {
     }
 
     fn with_toolchain(mut self, toolchain: &str) -> Self {
-        rustup_toolchain::ensure_installed(toolchain).unwrap();
+        rustup_toolchain::Installer::default()
+            .toolchain(toolchain)
+            .run()
+            .unwrap();
         self.cmd.arg("--toolchain").arg(toolchain);
         self
     }

--- a/rustup-toolchain/CHANGELOG.md
+++ b/rustup-toolchain/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 If a version is not listed below, it means it had no API changes.
 
+## v0.1.4
+* Add `rustup_toolchain::Installer` to make the API more future-proof and configurable. For starters, the `--profile` can now be chosen by clients.
+* Deprecate `rustup_toolchain::ensure_installed(...)`. Use `rustup_toolchain::Installer::default().toolchain(...).run()` instead.
+
+## v0.1.3
+* Bump all deps
+
+## v0.1.2
+* Bump all deps
+
 ## v0.1.1
 * Bump all deps
 

--- a/rustup-toolchain/tests/public-api.txt
+++ b/rustup-toolchain/tests/public-api.txt
@@ -36,6 +36,42 @@ impl<T> core::borrow::BorrowMut<T> for rustup_toolchain::Error where T: core::ma
 pub fn rustup_toolchain::Error::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for rustup_toolchain::Error
 pub fn rustup_toolchain::Error::from(t: T) -> T
+pub struct rustup_toolchain::Installer
+impl rustup_toolchain::Installer
+pub fn rustup_toolchain::Installer::profile(self, profile: impl core::convert::Into<alloc::string::String>) -> Self
+pub fn rustup_toolchain::Installer::run(self) -> rustup_toolchain::Result<()>
+pub fn rustup_toolchain::Installer::toolchain(self, toolchain: impl core::convert::Into<alloc::string::String>) -> Self
+impl core::default::Default for rustup_toolchain::Installer
+pub fn rustup_toolchain::Installer::default() -> Self
+impl core::clone::Clone for rustup_toolchain::Installer
+pub fn rustup_toolchain::Installer::clone(&self) -> rustup_toolchain::Installer
+impl core::fmt::Debug for rustup_toolchain::Installer
+pub fn rustup_toolchain::Installer::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Send for rustup_toolchain::Installer
+impl core::marker::Sync for rustup_toolchain::Installer
+impl core::marker::Unpin for rustup_toolchain::Installer
+impl core::panic::unwind_safe::RefUnwindSafe for rustup_toolchain::Installer
+impl core::panic::unwind_safe::UnwindSafe for rustup_toolchain::Installer
+impl<T, U> core::convert::Into<U> for rustup_toolchain::Installer where U: core::convert::From<T>
+pub fn rustup_toolchain::Installer::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for rustup_toolchain::Installer where U: core::convert::Into<T>
+pub type rustup_toolchain::Installer::Error = core::convert::Infallible
+pub fn rustup_toolchain::Installer::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for rustup_toolchain::Installer where U: core::convert::TryFrom<T>
+pub type rustup_toolchain::Installer::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn rustup_toolchain::Installer::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for rustup_toolchain::Installer where T: core::clone::Clone
+pub type rustup_toolchain::Installer::Owned = T
+pub fn rustup_toolchain::Installer::clone_into(&self, target: &mut T)
+pub fn rustup_toolchain::Installer::to_owned(&self) -> T
+impl<T> core::any::Any for rustup_toolchain::Installer where T: 'static + core::marker::Sized
+pub fn rustup_toolchain::Installer::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for rustup_toolchain::Installer where T: core::marker::Sized
+pub fn rustup_toolchain::Installer::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for rustup_toolchain::Installer where T: core::marker::Sized
+pub fn rustup_toolchain::Installer::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for rustup_toolchain::Installer
+pub fn rustup_toolchain::Installer::from(t: T) -> T
 pub fn rustup_toolchain::ensure_installed(toolchain: &str) -> rustup_toolchain::Result<()>
 pub fn rustup_toolchain::is_installed(toolchain: &str) -> rustup_toolchain::Result<bool>
 pub type rustup_toolchain::Result<T> = core::result::Result<T, rustup_toolchain::Error>

--- a/rustup-toolchain/tests/rustup-toolchain-lib-tests.rs
+++ b/rustup-toolchain/tests/rustup-toolchain-lib-tests.rs
@@ -2,7 +2,10 @@
 #[test]
 fn public_api() {
     // Install a proper nightly toolchain if it is missing
-    rustup_toolchain::ensure_installed(public_api::MINIMUM_NIGHTLY_VERSION).unwrap();
+    rustup_toolchain::Installer::default()
+        .toolchain(public_api::MINIMUM_NIGHTLY_VERSION)
+        .run()
+        .unwrap();
 
     // Build rustdoc JSON
     let rustdoc_json = rustdoc_json::Builder::default()


### PR DESCRIPTION
I'm a bit unsure of exactly how the API should look though. In the PR it looks like this:

```rust
    rustup_toolchain::Installer::default()
        .toolchain(toolchain)
        .run()
        .unwrap();
```

but maybe it should look like this:

```rust
    rustup_toolchain::Installer::of(toolchain)
        .run()
        .unwrap();
```

but I like the way `Installer::default()` communicates "I am using a sane set of defaults for you and you can use this as-is if you don't want any other changes". On the other hand, very few is going to want to use the default `--profile minimal stable` toolchain installer...
