### PR TITLE
public-api: Rename `MINIMUM_NIGHTLY_VERSION` to `MINIMUM_NIGHTLY_RUST_VERSION`

### DIFF
--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -26,7 +26,7 @@ jobs:
 
   # If Rust nightly changes output, auto-create a PR with the new blessed
   # output, which maintainers can conveniently merge after manual review. Note
-  # that we must also bump MINIMUM_NIGHTLY_VERSION_FOR_TESTS to this
+  # that we must also bump MINIMUM_NIGHTLY_RUST_VERSION_FOR_TESTS to this
   # version, otherwise tests will fail.
   auto-bless:
     environment:
@@ -42,7 +42,7 @@ jobs:
       - id: latest-nightly
         run: echo "version=nightly-$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
       - run: |
-          [ -z "$(git status --porcelain)" ] || echo "${{ steps.latest-nightly.outputs.version }}" > cargo-public-api/MINIMUM_NIGHTLY_VERSION_FOR_TESTS
+          [ -z "$(git status --porcelain)" ] || echo "${{ steps.latest-nightly.outputs.version }}" > cargo-public-api/MINIMUM_NIGHTLY_RUST_VERSION_FOR_TESTS
       - uses: peter-evans/create-pull-request@v4
         with:
           title: Bless `${{ steps.latest-nightly.outputs.version }}` output

--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ Then add the following test to your project. As the author of the below test cod
 #[test]
 fn public_api() {
     // Install a proper nightly toolchain if it is missing
-    rustup_toolchain::ensure_installed(public_api::MINIMUM_NIGHTLY_VERSION).unwrap();
+    rustup_toolchain::ensure_installed(public_api::MINIMUM_NIGHTLY_RUST_VERSION).unwrap();
 
     // Build rustdoc JSON
     let rustdoc_json = rustdoc_json::Builder::default()
-        .toolchain(public_api::MINIMUM_NIGHTLY_VERSION)
+        .toolchain(public_api::MINIMUM_NIGHTLY_RUST_VERSION)
         .build()
         .unwrap();
 

--- a/cargo-public-api/src/api_source.rs
+++ b/cargo-public-api/src/api_source.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Context, Result};
 use rustdoc_json::BuildError;
 use std::path::{Path, PathBuf};
 
-use public_api::{PublicApi, MINIMUM_NIGHTLY_VERSION};
+use public_api::{PublicApi, MINIMUM_NIGHTLY_RUST_VERSION};
 
 use crate::{git_utils, Args, Subcommand};
 
@@ -173,7 +173,7 @@ fn public_api_from_rustdoc_json(path: impl AsRef<Path>, args: &Args) -> Result<P
     let public_api = public_api_builder_from_args(json_path, args).build().with_context(|| {
         format!(
             "Failed to parse rustdoc JSON at {json_path:?}.\n\
-            This version of `cargo public-api` requires at least:\n\n    {MINIMUM_NIGHTLY_VERSION}\n\n\
+            This version of `cargo public-api` requires at least:\n\n    {MINIMUM_NIGHTLY_RUST_VERSION}\n\n\
             If you have that, it might be `cargo public-api` that is out of date. Try\n\
             to install the latest version with `cargo install cargo-public-api`. If the\n\
             issue remains, please report at\n\n    https://github.com/Enselic/cargo-public-api/issues",

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -20,7 +20,7 @@ use assert_cmd::Command;
 use predicates::prelude::PredicateBooleanExt;
 use predicates::str::contains;
 
-use public_api::MINIMUM_NIGHTLY_VERSION;
+use public_api::MINIMUM_NIGHTLY_RUST_VERSION;
 use tempfile::tempdir;
 
 #[path = "../src/git_utils.rs"] // Say NO to copy-paste!
@@ -286,10 +286,10 @@ fn subcommand_invocation_public_api_arg() {
 /// required for tests is not the same as required for users, so allow tests to
 /// use a different toolchain if needed
 fn get_minimum_toolchain() -> String {
-    std::fs::read_to_string("../cargo-public-api/MINIMUM_NIGHTLY_VERSION_FOR_TESTS")
+    std::fs::read_to_string("../cargo-public-api/MINIMUM_NIGHTLY_RUST_VERSION_FOR_TESTS")
         .map(|s| s.trim().to_owned())
         .ok()
-        .unwrap_or_else(|| MINIMUM_NIGHTLY_VERSION.to_owned())
+        .unwrap_or_else(|| MINIMUM_NIGHTLY_RUST_VERSION.to_owned())
 }
 
 #[test]

--- a/cargo-public-api/tests/expected-output/list_public_items.txt
+++ b/cargo-public-api/tests/expected-output/list_public_items.txt
@@ -168,6 +168,7 @@ impl core::marker::Sync for public_api::PublicItem
 impl core::marker::Unpin for public_api::PublicItem
 impl core::panic::unwind_safe::RefUnwindSafe for public_api::PublicItem
 impl core::panic::unwind_safe::UnwindSafe for public_api::PublicItem
-pub const public_api::MINIMUM_NIGHTLY_VERSION: &str
-pub const public_api::MINIMUM_RUSTDOC_JSON_VERSION: MINIMUM_NIGHTLY_VERSION
+pub const public_api::MINIMUM_NIGHTLY_RUST_VERSION: &str
+pub const public_api::MINIMUM_NIGHTLY_VERSION: MINIMUM_NIGHTLY_RUST_VERSION
+pub const public_api::MINIMUM_RUSTDOC_JSON_VERSION: MINIMUM_NIGHTLY_RUST_VERSION
 pub type public_api::Result<T> = core::result::Result<T, public_api::Error>

--- a/cargo-public-api/tests/expected-output/subcommand_invocation_public_api_arg.txt
+++ b/cargo-public-api/tests/expected-output/subcommand_invocation_public_api_arg.txt
@@ -128,6 +128,7 @@ impl core::hash::Hash for public_api::PublicItem
 pub fn public_api::PublicItem::hash<H: core::hash::Hasher>(&self, state: &mut H)
 impl core::clone::Clone for public_api::PublicItem
 pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
-pub const public_api::MINIMUM_NIGHTLY_VERSION: &str
-pub const public_api::MINIMUM_RUSTDOC_JSON_VERSION: MINIMUM_NIGHTLY_VERSION
+pub const public_api::MINIMUM_NIGHTLY_RUST_VERSION: &str
+pub const public_api::MINIMUM_NIGHTLY_VERSION: MINIMUM_NIGHTLY_RUST_VERSION
+pub const public_api::MINIMUM_RUSTDOC_JSON_VERSION: MINIMUM_NIGHTLY_RUST_VERSION
 pub type public_api::Result<T> = core::result::Result<T, public_api::Error>

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -9,7 +9,7 @@
         * **Cargo.toml** `[workspace.package.version]`
         * Dependents that you find with `git grep -A1 'path = "../public-api"'`
     2. If you bump 0.x.0 version, also update the [compatibility matrix](https://github.com/Enselic/cargo-public-api#compatibility-matrix).
-    1. If `MINIMUM_NIGHTLY_VERSION` must be bumped, bump it. If you bump it, also
+    1. If `MINIMUM_NIGHTLY_RUST_VERSION` must be bumped, bump it. If you bump it, also
         *  bump it in [compatibility matrix](https://github.com/Enselic/cargo-public-api#compatibility-matrix)
         *  bump it in `cargo-public-api` [installation instructions](https://github.com/Enselic/cargo-public-api#installation)
         * `rm cargo-public-api/MINIMUM_NIGHTLY_VERSION_FOR_TESTS`

--- a/public-api/CHANGELOG.md
+++ b/public-api/CHANGELOG.md
@@ -1,6 +1,7 @@
 # `public-api` changelog
 
 ## Unreleased v0.27.4
+* Rename `MINIMUM_NIGHTLY_VERSION` to `MINIMUM_NIGHTLY_RUST_VERSION` for clarity
 * Deprecate `PublicApi::from_rustdoc_json()`. Use `public_api::Builder::from_rustdoc_json()` instead.
 * Deprecate `Options`. Use `public_api::Builder` methods instead.
 

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -56,11 +56,15 @@ pub use public_item::PublicItem;
 /// The rustdoc JSON format is still changing, so every now and then we update
 /// this library to support the latest format. If you use this version of
 /// nightly or later, you should be fine.
-pub const MINIMUM_NIGHTLY_VERSION: &str = "nightly-2023-01-04";
+pub const MINIMUM_NIGHTLY_RUST_VERSION: &str = "nightly-2023-01-04";
 
-/// Deprecated, use [`MINIMUM_NIGHTLY_VERSION`] instead.
-#[deprecated(since = "0.27.0", note = "Use MINIMUM_NIGHTLY_VERSION instead")]
-pub const MINIMUM_RUSTDOC_JSON_VERSION: &str = MINIMUM_NIGHTLY_VERSION;
+/// Deprecated, use [`MINIMUM_NIGHTLY_RUST_VERSION`] instead.
+#[deprecated(since = "0.27.4", note = "Use MINIMUM_NIGHTLY_RUST_VERSION instead")]
+pub const MINIMUM_NIGHTLY_VERSION: &str = MINIMUM_NIGHTLY_RUST_VERSION;
+
+/// Deprecated, use [`MINIMUM_NIGHTLY_RUST_VERSION`] instead.
+#[deprecated(since = "0.27.0", note = "Use MINIMUM_NIGHTLY_RUST_VERSION instead")]
+pub const MINIMUM_RUSTDOC_JSON_VERSION: &str = MINIMUM_NIGHTLY_RUST_VERSION;
 
 /// See [`Builder`] method docs for what each field means.
 #[derive(Copy, Clone, Debug)]

--- a/public-api/src/main.rs
+++ b/public-api/src/main.rs
@@ -8,7 +8,7 @@ use std::io::{stdout, ErrorKind, Write};
 use std::path::{Path, PathBuf};
 
 use public_api::diff::PublicApiDiff;
-use public_api::{PublicApi, MINIMUM_NIGHTLY_VERSION};
+use public_api::{PublicApi, MINIMUM_NIGHTLY_RUST_VERSION};
 
 #[derive(thiserror::Error, Debug)]
 enum Error {
@@ -25,14 +25,14 @@ type Result<T> = std::result::Result<T, Error>;
 struct Args {
     help: bool,
     simplified: bool,
-    print_minimum_nightly_version: bool,
+    print_minimum_nightly_rust_version: bool,
     files: Vec<PathBuf>,
 }
 
 fn main_() -> Result<()> {
     let args = args();
-    if args.print_minimum_nightly_version {
-        println!("{MINIMUM_NIGHTLY_VERSION}");
+    if args.print_minimum_nightly_rust_version {
+        println!("{MINIMUM_NIGHTLY_RUST_VERSION}");
         return Ok(());
     }
 
@@ -137,7 +137,7 @@ commit and then pass the path of both files to this utility:
 
 ",
         env!("CARGO_PKG_VERSION"),
-        MINIMUM_NIGHTLY_VERSION,
+        MINIMUM_NIGHTLY_RUST_VERSION,
     )
 }
 
@@ -156,8 +156,8 @@ fn args() -> Args {
     for arg in std::env::args_os().skip(1) {
         if arg == "--simplified" {
             args.simplified = true;
-        } else if arg == "--print-minimum-nightly-version" {
-            args.print_minimum_nightly_version = true;
+        } else if arg == "--print-minimum-nightly-rust-version" {
+            args.print_minimum_nightly_rust_version = true;
         } else if arg == "--help" || arg == "-h" {
             args.help = true;
         } else {

--- a/public-api/tests/public-api-bin-tests.rs
+++ b/public-api/tests/public-api-bin-tests.rs
@@ -6,7 +6,7 @@ use std::{io::BufRead, str::from_utf8};
 
 use assert_cmd::assert::Assert;
 use assert_cmd::Command;
-use public_api::MINIMUM_NIGHTLY_VERSION;
+use public_api::MINIMUM_NIGHTLY_RUST_VERSION;
 
 use tempfile::{tempdir, TempDir};
 
@@ -141,11 +141,11 @@ fn no_args_shows_help() {
 }
 
 #[test]
-fn print_minimum_nightly_version() {
+fn print_minimum_nightly_rust_version() {
     let mut cmd = Command::cargo_bin("public-api").unwrap();
-    cmd.arg("--print-minimum-nightly-version");
+    cmd.arg("--print-minimum-nightly-rust-version");
     cmd.assert()
-        .stdout(format!("{MINIMUM_NIGHTLY_VERSION}\n"))
+        .stdout(format!("{MINIMUM_NIGHTLY_RUST_VERSION}\n"))
         .stderr("")
         .success();
 }
@@ -190,7 +190,7 @@ commit and then pass the path of both files to this utility:
 
 ",
         env!("CARGO_PKG_VERSION"),
-        MINIMUM_NIGHTLY_VERSION,
+        MINIMUM_NIGHTLY_RUST_VERSION,
     )
 }
 

--- a/public-api/tests/public-api.txt
+++ b/public-api/tests/public-api.txt
@@ -328,6 +328,7 @@ impl<T> core::borrow::BorrowMut<T> for public_api::PublicItem where T: core::mar
 pub fn public_api::PublicItem::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for public_api::PublicItem
 pub fn public_api::PublicItem::from(t: T) -> T
-pub const public_api::MINIMUM_NIGHTLY_VERSION: &str
-pub const public_api::MINIMUM_RUSTDOC_JSON_VERSION: MINIMUM_NIGHTLY_VERSION
+pub const public_api::MINIMUM_NIGHTLY_RUST_VERSION: &str
+pub const public_api::MINIMUM_NIGHTLY_VERSION: MINIMUM_NIGHTLY_RUST_VERSION
+pub const public_api::MINIMUM_RUSTDOC_JSON_VERSION: MINIMUM_NIGHTLY_RUST_VERSION
 pub type public_api::Result<T> = core::result::Result<T, public_api::Error>

--- a/repo-tests/tests/repo-tests.rs
+++ b/repo-tests/tests/repo-tests.rs
@@ -3,7 +3,7 @@
 
 use std::{ffi::OsStr, fs::read_to_string, path::PathBuf};
 
-use public_api::MINIMUM_NIGHTLY_VERSION;
+use public_api::MINIMUM_NIGHTLY_RUST_VERSION;
 
 #[test]
 fn newline_at_end_of_all_files() {
@@ -66,6 +66,6 @@ fn newline_at_end_of_all_files() {
 fn installation_instructions_in_toplevel_readme() {
     let readme = include_str!("../../README.md");
     let expected_installation_instruction =
-        format!("Ensure **{MINIMUM_NIGHTLY_VERSION}** or later");
+        format!("Ensure **{MINIMUM_NIGHTLY_RUST_VERSION}** or later");
     assert!(readme.contains(&expected_installation_instruction));
 }

--- a/rustup-toolchain/tests/rustup-toolchain-lib-tests.rs
+++ b/rustup-toolchain/tests/rustup-toolchain-lib-tests.rs
@@ -2,11 +2,11 @@
 #[test]
 fn public_api() {
     // Install a proper nightly toolchain if it is missing
-    rustup_toolchain::ensure_installed(public_api::MINIMUM_NIGHTLY_VERSION).unwrap();
+    rustup_toolchain::ensure_installed(public_api::MINIMUM_NIGHTLY_RUST_VERSION).unwrap();
 
     // Build rustdoc JSON
     let rustdoc_json = rustdoc_json::Builder::default()
-        .toolchain(public_api::MINIMUM_NIGHTLY_VERSION)
+        .toolchain(public_api::MINIMUM_NIGHTLY_RUST_VERSION)
         .build()
         .unwrap();
 


### PR DESCRIPTION
So that it becomes clear that `public_api::MINIMUM_NIGHTLY_VERSION` is not referring to a version of `public_api` itself.

It actually seems like "Rust nightly" is a more common term than "nightly Rust", but I feel like `MINIMUM_RUST_NIGHTLY_VERSION` sounds too strange. So we'll go with `MINIMUM_NIGHTLY_RUST_VERSION`.