### PR TITLE
rustup-toolchain: Rename `ensure_installed()` to `install()` and deprecate `is_installed()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Then add the following test to your project. As the author of the below test cod
 ```rust
 #[test]
 fn public_api() {
-    // Install a proper nightly toolchain if it is missing
-    rustup_toolchain::ensure_installed(public_api::MINIMUM_NIGHTLY_RUST_VERSION).unwrap();
+    // Install a compatible nightly toolchain if it is missing
+    rustup_toolchain::install(public_api::MINIMUM_NIGHTLY_RUST_VERSION).unwrap();
 
     // Build rustdoc JSON
     let rustdoc_json = rustdoc_json::Builder::default()

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -1223,7 +1223,7 @@ impl TestCmd {
     /// `cargo +toolchain public-api --simplified`
     /// Also installs the toolchain if it is not installed.
     fn with_proxy_toolchain(toolchain: &str) -> Self {
-        rustup_toolchain::ensure_installed(toolchain).unwrap();
+        rustup_toolchain::install(toolchain).unwrap();
         Self::new_impl(
             TestCmdType::Subcommand {
                 toolchain: Some(toolchain),
@@ -1239,7 +1239,7 @@ impl TestCmd {
     }
 
     fn with_toolchain(mut self, toolchain: &str) -> Self {
-        rustup_toolchain::ensure_installed(toolchain).unwrap();
+        rustup_toolchain::install(toolchain).unwrap();
         self.cmd.arg("--toolchain").arg(toolchain);
         self
     }

--- a/rustup-toolchain/CHANGELOG.md
+++ b/rustup-toolchain/CHANGELOG.md
@@ -1,6 +1,14 @@
 # rustup-toolchain
 
-If a version is not listed below, it means it had no API changes.
+## v0.1.4
+* Rename `ensure_installed()` to `install()` for brevity
+* Deprecate `is_installed()` to make it clear it is not needed around `install()`
+
+## v0.1.3
+* Bump deps
+
+## v0.1.2
+* Bump deps
 
 ## v0.1.1
 * Bump all deps

--- a/rustup-toolchain/tests/public-api.txt
+++ b/rustup-toolchain/tests/public-api.txt
@@ -37,5 +37,6 @@ pub fn rustup_toolchain::Error::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for rustup_toolchain::Error
 pub fn rustup_toolchain::Error::from(t: T) -> T
 pub fn rustup_toolchain::ensure_installed(toolchain: &str) -> rustup_toolchain::Result<()>
+pub fn rustup_toolchain::install(toolchain: impl core::convert::AsRef<str>) -> rustup_toolchain::Result<()>
 pub fn rustup_toolchain::is_installed(toolchain: &str) -> rustup_toolchain::Result<bool>
 pub type rustup_toolchain::Result<T> = core::result::Result<T, rustup_toolchain::Error>

--- a/rustup-toolchain/tests/rustup-toolchain-lib-tests.rs
+++ b/rustup-toolchain/tests/rustup-toolchain-lib-tests.rs
@@ -1,8 +1,8 @@
 /// Keep this code in sync with the code in `../../README.md`
 #[test]
 fn public_api() {
-    // Install a proper nightly toolchain if it is missing
-    rustup_toolchain::ensure_installed(public_api::MINIMUM_NIGHTLY_RUST_VERSION).unwrap();
+    // Install a compatible nightly toolchain if it is missing
+    rustup_toolchain::install(public_api::MINIMUM_NIGHTLY_RUST_VERSION).unwrap();
 
     // Build rustdoc JSON
     let rustdoc_json = rustdoc_json::Builder::default()


### PR DESCRIPTION
Rename `ensure_installed()` to `install()` for brevity. Deprecate `is_installed()` to make it clear it is not needed around `install()`.