### PR TITLE
Bump to v0.28.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-public-api"
-version = "0.27.3"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "public-api"
-version = "0.27.3"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.27.3"
+version = "0.28.0"
 
 [workspace]
 members = [

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ pub fn bat::PrettyPrinter::input_files<I, P>(&mut self, paths: I) -> &mut Self w
 
 | cargo-public-api | Understands the rustdoc JSON output of  |
 | ---------------- | --------------------------------------- |
-| 0.26.x — 0.27.x  | nightly-2023-01-04 —                    |
+| 0.26.x — 0.28.x  | nightly-2023-01-04 —                    |
 | 0.20.x — 0.25.x  | nightly-2022-09-28 — nightly-2023-01-03 |
 | 0.19.x           | nightly-2022-09-08 — nightly-2022-09-27 |
 | 0.18.x           | nightly-2022-09-07                      |

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -47,7 +47,7 @@ version = "0.8.2"
 
 [dependencies.public-api]
 path = "../public-api"
-version = "0.27.3"
+version = "0.28.0"
 
 [dev-dependencies.rustup-toolchain]
 path = "../rustup-toolchain"

--- a/public-api/CHANGELOG.md
+++ b/public-api/CHANGELOG.md
@@ -1,6 +1,6 @@
 # `public-api` changelog
 
-## Unreleased v0.27.4
+## v0.28.0
 * Rename `MINIMUM_NIGHTLY_VERSION` to `MINIMUM_NIGHTLY_RUST_VERSION` for clarity
 * Deprecate `PublicApi::from_rustdoc_json()`. Use `public_api::Builder::from_rustdoc_json()` instead.
 * Deprecate `Options`. Use `public_api::Builder` methods instead.

--- a/repo-tests/Cargo.toml
+++ b/repo-tests/Cargo.toml
@@ -7,5 +7,5 @@ license = "MIT"
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.27.3"
+version = "0.28.0"
 

--- a/rustdoc-json/Cargo.toml
+++ b/rustdoc-json/Cargo.toml
@@ -27,4 +27,4 @@ default-features = false
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.27.3"
+version = "0.28.0"

--- a/rustup-toolchain/Cargo.toml
+++ b/rustup-toolchain/Cargo.toml
@@ -21,4 +21,4 @@ version = "0.8.2"
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.27.3"
+version = "0.28.0"


### PR DESCRIPTION
Since we changed the meaning of `-ss` in `cargo public-api -ss` we bump 0.x.0 version rather than 0.0.x version, since it is a kind of incompatible change (see #344)