### PR TITLE
public-api bin: Remove --print-minimum-nightly-rust-version

### DIFF
--- a/public-api/src/main.rs
+++ b/public-api/src/main.rs
@@ -25,16 +25,11 @@ type Result<T> = std::result::Result<T, Error>;
 struct Args {
     help: bool,
     simplified: bool,
-    print_minimum_nightly_rust_version: bool,
     files: Vec<PathBuf>,
 }
 
 fn main_() -> Result<()> {
     let args = args();
-    if args.print_minimum_nightly_rust_version {
-        println!("{MINIMUM_NIGHTLY_RUST_VERSION}");
-        return Ok(());
-    }
 
     let files = &args.files;
     if args.help || files.is_empty() || files.len() > 2 {
@@ -156,8 +151,6 @@ fn args() -> Args {
     for arg in std::env::args_os().skip(1) {
         if arg == "--simplified" {
             args.simplified = true;
-        } else if arg == "--print-minimum-nightly-rust-version" {
-            args.print_minimum_nightly_rust_version = true;
         } else if arg == "--help" || arg == "-h" {
             args.help = true;
         } else {

--- a/public-api/tests/public-api-bin-tests.rs
+++ b/public-api/tests/public-api-bin-tests.rs
@@ -141,16 +141,6 @@ fn no_args_shows_help() {
 }
 
 #[test]
-fn print_minimum_nightly_rust_version() {
-    let mut cmd = Command::cargo_bin("public-api").unwrap();
-    cmd.arg("--print-minimum-nightly-rust-version");
-    cmd.assert()
-        .stdout(format!("{MINIMUM_NIGHTLY_RUST_VERSION}\n"))
-        .stderr("")
-        .success();
-}
-
-#[test]
 fn too_many_args_shows_help() {
     let mut cmd = Command::cargo_bin("public-api").unwrap();
     cmd.args(["too", "many", "args"]);


### PR DESCRIPTION
It was originally added for `scripts/test-invocation-variants.sh`, but we have since then converted that script to regular `cargo test` tests, so this flag is not needed any longer.

My intention is to eventually get rid of the public-api bin completely, because I never use it, and I don't think anyone else does either. `cargo public-api` is simply much better.

This commit is the first step on that journey.

Marking as `category-exclude`, because I can't imagine any users using this (so there is no point in mentioning it in the auto-generated release notes).