### PR TITLE
Remove diffing from `public-api` bin (NOT from `cargo public-api`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,6 +734,7 @@ dependencies = [
  "expect-test",
  "hashbag",
  "itertools",
+ "predicates",
  "pretty_assertions",
  "rustdoc-json",
  "rustdoc-types",

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -36,3 +36,7 @@ itertools = { version = "0.10.5", default-features = false }
 [dev-dependencies.rustdoc-json]
 path = "../rustdoc-json"
 version = "0.8.4"
+
+[dev-dependencies.predicates]
+version = "3.0.2"
+default-features = false


### PR DESCRIPTION
I never use the `public-api` bin, and I suspect nobody else does it either. If they do, they should switch to `cargo public-api`.

Remove diffing support to test the hypothesis that nobody uses it. If no one complains, it indicates that nobody uses it.