### PR TITLE
Auto-merge: Use EnselicCICD account to trigger CI

### DIFF
--- a/.github/workflows/Auto-merge-dependabot-PRs.yml
+++ b/.github/workflows/Auto-merge-dependabot-PRs.yml
@@ -10,11 +10,11 @@ jobs:
   auto-merge:
     if: github.repository == 'Enselic/cargo-public-api' && startsWith(github.head_ref, 'dependabot/')
     runs-on: ubuntu-latest
-    permissions:
-      contents: write # gh pr merge
-      pull-requests: write # gh pr review
+    environment:
+      name: CICD-fork # TODO: Rename to maybe 'EnselicCICD'
+      url: https://github.com/EnselicCICD
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.ENSELICCICD_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - run: |


### PR DESCRIPTION
Currently the auto-merge mechanism uses the default GitHub token to trigger CI. This token is not allowed to trigger workflows (to prevent recursive workflows, see https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow). This commit changes the token to the one of the EnselicCICD account. That way auto-merged PRs will also trigger "on: push" CI jobs to main.