### PR TITLE
Use expect-test for published_crate.rs tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,6 @@ dependencies = [
  "is-terminal",
  "nu-ansi-term",
  "predicates",
- "pretty_assertions",
  "public-api",
  "remove_dir_all",
  "rustdoc-json",
@@ -327,16 +326,6 @@ dependencies = [
  "serde_json",
  "smol_str",
  "toml 0.7.3",
-]
-
-[[package]]
-name = "ctor"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
-dependencies = [
- "quote",
- "syn 1.0.107",
 ]
 
 [[package]]
@@ -752,15 +741,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
-name = "output_vt100"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,18 +781,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pretty_assertions"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
-dependencies = [
- "ctor",
- "diff",
- "output_vt100",
- "yansi",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,7 +799,6 @@ dependencies = [
  "hashbag",
  "itertools",
  "predicates",
- "pretty_assertions",
  "rustdoc-json",
  "rustdoc-types",
  "serde",
@@ -1435,9 +1402,3 @@ checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "yansi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -65,7 +65,6 @@ features = ["std"]
 [dev-dependencies]
 assert_cmd = "2.0.10"
 expect-test = "1.4.1"
-pretty_assertions = "1.3.0"
 remove_dir_all = "0.8.2"
 tempfile = "3.5.0"
 cargo_metadata = "0.15.4"

--- a/cargo-public-api/src/published_crate.rs
+++ b/cargo-public-api/src/published_crate.rs
@@ -207,7 +207,7 @@ impl PackageSpec {
 mod tests {
     use super::*;
     use clap::Parser as _;
-    use pretty_assertions::assert_eq;
+    use expect_test::expect_file;
 
     #[test]
     fn manifest_simple() {
@@ -220,20 +220,7 @@ mod tests {
         )
         .unwrap()
         .0;
-        assert_eq!(
-            manifest,
-            r#"[lib]
-path = "lib.rs"
-
-[package]
-edition = "2021"
-name = "crate-downloader"
-version = "0.1.0"
-
-[dependencies.example-api]
-version = "=0.1.1"
-"#
-        );
+        expect_file!("../tests/expected-output/manifest_simple.txt").assert_eq(&manifest);
     }
 
     #[test]
@@ -294,19 +281,6 @@ version = "=0.1.1"
             &package,
         )
         .unwrap();
-        assert_eq!(
-            manifest,
-            r#"[lib]
-path = "lib.rs"
-
-[package]
-edition = "2021"
-name = "crate-downloader"
-version = "0.1.0"
-
-[dependencies.example-api]
-version = "=0.1.1"
-"#
-        );
+        expect_file!("../tests/expected-output/manifest_with_info.txt").assert_eq(&manifest);
     }
 }

--- a/cargo-public-api/tests/expected-output/manifest_simple.txt
+++ b/cargo-public-api/tests/expected-output/manifest_simple.txt
@@ -1,0 +1,10 @@
+[lib]
+path = "lib.rs"
+
+[package]
+edition = "2021"
+name = "crate-downloader"
+version = "0.1.0"
+
+[dependencies.example-api]
+version = "=0.1.1"

--- a/cargo-public-api/tests/expected-output/manifest_with_info.txt
+++ b/cargo-public-api/tests/expected-output/manifest_with_info.txt
@@ -1,0 +1,10 @@
+[lib]
+path = "lib.rs"
+
+[package]
+edition = "2021"
+name = "crate-downloader"
+version = "0.1.0"
+
+[dependencies.example-api]
+version = "=0.1.1"

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -29,7 +29,6 @@ version = "0.20.0"
 anyhow = "1.0.70"
 assert_cmd = "2.0.10"
 expect-test = "1.4.1"
-pretty_assertions = "1.3.0"
 tempfile = "3.5.0"
 itertools = { version = "0.10.5", default-features = false }
 

--- a/scripts/bless-expected-output-for-tests.sh
+++ b/scripts/bless-expected-output-for-tests.sh
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
 set -o nounset -o pipefail -o errexit
 
-UPDATE_EXPECT=1 cargo test --test '*' \
-    -p public-api \
-    -p cargo-public-api \
-    -p rustdoc-json \
-    -p rustup-toolchain \
+UPDATE_EXPECT=1 cargo test


### PR DESCRIPTION
So it is easier to bless the new output when it changes e.g. due to dependency bumps.