### PR TITLE
Revert "dependabot.yml: Temporarily change to 'daily'"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - "category-exclude"
       - "dependencies"


### PR DESCRIPTION
Reverts Enselic/cargo-public-api#392

Auto-merge of dependabot PRs **AND** triggering of CI after push to main seems to work now.