### PR TITLE
Make `diff-latest` feature mandatory

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -79,4 +79,3 @@ jobs:
       - run: rustup install --profile minimal nightly
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --locked
-      - run: cargo build --locked --no-default-features # Build without "diff-latest" feature

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -11,12 +11,6 @@ categories = ["command-line-utilities", "development-tools::cargo-plugins"]
 license = "MIT"
 repository = "https://github.com/Enselic/cargo-public-api"
 
-[features]
-default = ["diff-latest"]
-# Enable `cargo public-api diff latest`. Requires 33 more deps (most notably the
-# `git2` crate) so that the crates.io index can be updated and read.
-diff-latest = ["dep:crates-index"]
-
 [dependencies]
 nu-ansi-term = "0.47.0"
 anyhow = "1.0.70"
@@ -39,7 +33,6 @@ features = ["derive", "wrap_help"]
 [dependencies.crates-index]
 version = "0.19.7"
 default-features = false
-optional = true
 
 [dependencies.rustdoc-json]
 path = "../rustdoc-json"

--- a/cargo-public-api/src/published_crate.rs
+++ b/cargo-public-api/src/published_crate.rs
@@ -69,22 +69,13 @@ pub fn build_rustdoc_json(version: Option<&str>, args: &Args) -> Result<PathBuf>
 /// Gets the most recent version for the given package, by querying the
 /// crates.io index that users have locally.
 fn latest_version_for_package(package_name: &str) -> Result<String> {
-    #[cfg(feature = "diff-latest")]
-    {
-        let index = crates_index::Index::new_cargo_default()?;
-        let crate_ = index.crate_(package_name).ok_or_else(|| {
-            anyhow!("Could not find crate `{package_name}` in the crates.io index")
-        })?;
+    let index = crates_index::Index::new_cargo_default()?;
+    let crate_ = index
+        .crate_(package_name)
+        .ok_or_else(|| anyhow!("Could not find crate `{package_name}` in the crates.io index"))?;
 
-        let version = crate_.highest_version();
-        Ok(version.version().to_string())
-    }
-    #[cfg(not(feature = "diff-latest"))]
-    {
-        Err(anyhow!(
-            "Can not find `latest` version of `{package_name}`; the `diff-latest` feature needs to be enabled for `cargo-public-api`"
-        ))
-    }
+    let version = crate_.highest_version();
+    Ok(version.version().to_string())
 }
 
 /// Returns the package name from `-p package-name` or from inside

--- a/scripts/run-ci-locally.sh
+++ b/scripts/run-ci-locally.sh
@@ -14,8 +14,6 @@ RUSTDOCFLAGS='--deny warnings' cargo doc --locked --no-deps --document-private-i
 
 scripts/cargo-clippy.sh
 
-cargo build --locked --no-default-features # Build without "diff-latest" feature
-
 cargo build --locked # Build with default features
 
 cargo test --locked


### PR DESCRIPTION
I think by now this feature is a corner-stone of cargo-public-api, and I do not think it is worth the overhead to support cargo-public-api with such a useful feature disabled.

Now is a good time to do this change since we need to bump 0.x.0 version for other reasons anyway.