### PR TITLE
Bump rustdoc-types from 0.20.0 to 0.21.0 (`nightly-2023-05-09`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "rustdoc-types"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f59b848e09e1631f0f8711fcdcb65d4481597b869372cca5d6755737b21501"
+checksum = "98758d8af20330e1af8baa7cde41a2853d637baf0d3744a238ee1c8490c0ffa5"
 dependencies = [
  "serde",
 ]

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -23,7 +23,7 @@ features = ["unbounded_depth"]
 
 [dependencies.rustdoc-types]
 # path = "/Users/martin/src/rustdoc-types"
-version = "0.20.0"
+version = "0.21.0"
 
 [dev-dependencies]
 anyhow = "1.0.71"


### PR DESCRIPTION
The bump adds rustdoc JSON support for [inherent associated types](https://github.com/rust-lang/rust/pull/109410) which changed rustdoc JSON format in `nightly-2023-05-09` if used.

Note that that is only supported in unstable Rust, so it is too early for us to add a regression test.

I'm a bit unsure if we should bump to 0.30.0 and make a release, bump to 0.29.2 and make a release, or wait with making a release, since this should only affect unstable Rust.

I think I will wait with making a release until  and if someone complains. I find it highly unlikely that someone is using inherent associated types for something serious.
