### PR TITLE
Ignore `!` when sorting `impl`s to make `Send` and `Sync` order stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ exclude = [
     # https://stackoverflow.com/questions/56713877/why-do-proc-macros-have-to-be-defined-in-proc-macro-crate
     "test-apis/comprehensive_api_proc_macro",
 
+    # Tests that requires auto traits. Normally we omit auto trait impls because
+    # they make the output very repetitive.
+    "test-apis/auto_traits",
+
     # Contains different versions of the same small API. Used mainly to test
     # test the API-diffing functionality of this library.
     "test-apis/example_api-v0.1.0",

--- a/cargo-public-api/tests/expected-output/list_public_items.txt
+++ b/cargo-public-api/tests/expected-output/list_public_items.txt
@@ -91,11 +91,11 @@ impl core::fmt::Display for public_api::Error
 pub fn public_api::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Debug for public_api::Error
 pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl !core::panic::unwind_safe::RefUnwindSafe for public_api::Error
-impl !core::panic::unwind_safe::UnwindSafe for public_api::Error
 impl core::marker::Send for public_api::Error
 impl core::marker::Sync for public_api::Error
 impl core::marker::Unpin for public_api::Error
+impl !core::panic::unwind_safe::RefUnwindSafe for public_api::Error
+impl !core::panic::unwind_safe::UnwindSafe for public_api::Error
 pub struct public_api::Builder
 impl public_api::Builder
 pub fn public_api::Builder::build(self) -> public_api::Result<public_api::PublicApi>

--- a/public-api/src/intermediate_public_item.rs
+++ b/public-api/src/intermediate_public_item.rs
@@ -37,11 +37,14 @@ impl<'c> NameableItem<'c> {
         if let Some(name) = self.name() {
             sortable_name.push_str(name);
         } else if let ItemEnum::Impl(impl_) = &self.item.inner {
-            // In order for items of impls to be grouped together with its
-            // impl, add the "name" of the impl to the sorting prefix.
-            sortable_name.push_str(&crate::tokens::tokens_to_string(
-                &context.render_impl(impl_, &[]),
-            ));
+            // In order for items of impls to be grouped together with its impl,
+            // add the "name" of the impl to the sorting prefix. Ignore `!` when
+            // sorting however, because that just messes the expected order up.
+            sortable_name.push_str(&crate::tokens::tokens_to_string(&context.render_impl(
+                impl_,
+                &[],
+                true, /* disregard_negativity */
+            )));
 
             // If this is an inherent impl, additionally add the concatenated
             // names of all associated items to the "name" of the impl. This makes

--- a/public-api/src/render.rs
+++ b/public-api/src/render.rs
@@ -99,7 +99,9 @@ impl<'c> RenderingContext<'c> {
             ),
             ItemEnum::Trait(trait_) => self.render_trait(trait_, item_path),
             ItemEnum::TraitAlias(_) => self.render_simple(&["trait", "alias"], item_path),
-            ItemEnum::Impl(impl_) => self.render_impl(impl_, item_path),
+            ItemEnum::Impl(impl_) => {
+                self.render_impl(impl_, item_path, false /* disregard_negativity */)
+            }
             ItemEnum::Typedef(inner) => {
                 let mut output = self.render_simple(&["type"], item_path);
                 output.extend(self.render_generics(&inner.generics));
@@ -591,7 +593,12 @@ impl<'c> RenderingContext<'c> {
         output
     }
 
-    pub(crate) fn render_impl(&self, impl_: &Impl, path: &[NameableItem]) -> Vec<Token> {
+    pub(crate) fn render_impl(
+        &self,
+        impl_: &Impl,
+        path: &[NameableItem],
+        disregard_negativity: bool,
+    ) -> Vec<Token> {
         let mut output = vec![];
 
         if self.options.debug_sorting {
@@ -610,7 +617,7 @@ impl<'c> RenderingContext<'c> {
         output.push(ws!());
 
         if let Some(trait_) = &impl_.trait_ {
-            if impl_.negative {
+            if !disregard_negativity && impl_.negative {
                 output.push(Token::symbol("!"));
             }
             output.extend(self.render_resolved_path(trait_));

--- a/public-api/tests/expected-output/auto_traits.txt
+++ b/public-api/tests/expected-output/auto_traits.txt
@@ -1,0 +1,19 @@
+pub mod auto_traits
+pub struct auto_traits::NotSendNorSync
+impl !core::marker::Send for auto_traits::NotSendNorSync
+impl !core::marker::Sync for auto_traits::NotSendNorSync
+impl core::marker::Unpin for auto_traits::NotSendNorSync
+impl core::panic::unwind_safe::RefUnwindSafe for auto_traits::NotSendNorSync
+impl core::panic::unwind_safe::UnwindSafe for auto_traits::NotSendNorSync
+pub struct auto_traits::SendAndSync
+impl core::marker::Send for auto_traits::SendAndSync
+impl core::marker::Sync for auto_traits::SendAndSync
+impl core::marker::Unpin for auto_traits::SendAndSync
+impl core::panic::unwind_safe::RefUnwindSafe for auto_traits::SendAndSync
+impl core::panic::unwind_safe::UnwindSafe for auto_traits::SendAndSync
+pub struct auto_traits::SendNotSync
+impl core::marker::Send for auto_traits::SendNotSync
+impl !core::marker::Sync for auto_traits::SendNotSync
+impl core::marker::Unpin for auto_traits::SendNotSync
+impl !core::panic::unwind_safe::RefUnwindSafe for auto_traits::SendNotSync
+impl core::panic::unwind_safe::UnwindSafe for auto_traits::SendNotSync

--- a/public-api/tests/public-api-lib-tests.rs
+++ b/public-api/tests/public-api-lib-tests.rs
@@ -176,6 +176,17 @@ fn comprehensive_api_proc_macro() {
     );
 }
 
+#[test]
+fn auto_traits() {
+    // Create independent build dir so all tests can run in parallel
+    let build_dir = tempdir().unwrap();
+
+    assert_public_api(
+        builder_for_crate("../test-apis/auto_traits", &build_dir).omit_blanket_impls(true),
+        "./expected-output/auto_traits.txt",
+    );
+}
+
 /// Test that `debug_sorting` does not result in stack overflow because of
 /// recursion. This can quite easily happen unless we test for it continuously.
 /// We don't care what the exact output is, just that we don't crash.

--- a/public-api/tests/public-api.txt
+++ b/public-api/tests/public-api.txt
@@ -151,11 +151,11 @@ impl core::fmt::Display for public_api::Error
 pub fn public_api::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Debug for public_api::Error
 pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl !core::panic::unwind_safe::RefUnwindSafe for public_api::Error
-impl !core::panic::unwind_safe::UnwindSafe for public_api::Error
 impl core::marker::Send for public_api::Error
 impl core::marker::Sync for public_api::Error
 impl core::marker::Unpin for public_api::Error
+impl !core::panic::unwind_safe::RefUnwindSafe for public_api::Error
+impl !core::panic::unwind_safe::UnwindSafe for public_api::Error
 impl<E> core::any::Provider for public_api::Error where E: core::error::Error + core::marker::Sized
 pub fn public_api::Error::provide<'a>(&'a self, demand: &mut core::any::Demand<'a>)
 impl<T, U> core::convert::Into<U> for public_api::Error where U: core::convert::From<T>

--- a/rustdoc-json/tests/public-api.txt
+++ b/rustdoc-json/tests/public-api.txt
@@ -17,11 +17,11 @@ impl core::fmt::Display for rustdoc_json::BuildError
 pub fn rustdoc_json::BuildError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Debug for rustdoc_json::BuildError
 pub fn rustdoc_json::BuildError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl !core::panic::unwind_safe::RefUnwindSafe for rustdoc_json::BuildError
-impl !core::panic::unwind_safe::UnwindSafe for rustdoc_json::BuildError
 impl core::marker::Send for rustdoc_json::BuildError
 impl core::marker::Sync for rustdoc_json::BuildError
 impl core::marker::Unpin for rustdoc_json::BuildError
+impl !core::panic::unwind_safe::RefUnwindSafe for rustdoc_json::BuildError
+impl !core::panic::unwind_safe::UnwindSafe for rustdoc_json::BuildError
 impl<E> core::any::Provider for rustdoc_json::BuildError where E: core::error::Error + core::marker::Sized
 pub fn rustdoc_json::BuildError::provide<'a>(&'a self, demand: &mut core::any::Demand<'a>)
 impl<T, U> core::convert::Into<U> for rustdoc_json::BuildError where U: core::convert::From<T>

--- a/rustup-toolchain/tests/public-api.txt
+++ b/rustup-toolchain/tests/public-api.txt
@@ -11,11 +11,11 @@ impl core::fmt::Display for rustup_toolchain::Error
 pub fn rustup_toolchain::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Debug for rustup_toolchain::Error
 pub fn rustup_toolchain::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl !core::panic::unwind_safe::RefUnwindSafe for rustup_toolchain::Error
-impl !core::panic::unwind_safe::UnwindSafe for rustup_toolchain::Error
 impl core::marker::Send for rustup_toolchain::Error
 impl core::marker::Sync for rustup_toolchain::Error
 impl core::marker::Unpin for rustup_toolchain::Error
+impl !core::panic::unwind_safe::RefUnwindSafe for rustup_toolchain::Error
+impl !core::panic::unwind_safe::UnwindSafe for rustup_toolchain::Error
 impl<E> core::any::Provider for rustup_toolchain::Error where E: core::error::Error + core::marker::Sized
 pub fn rustup_toolchain::Error::provide<'a>(&'a self, demand: &mut core::any::Demand<'a>)
 impl<T, U> core::convert::Into<U> for rustup_toolchain::Error where U: core::convert::From<T>

--- a/test-apis/auto_traits/Cargo.toml
+++ b/test-apis/auto_traits/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+edition = "2021"
+name = "auto_traits"
+version = "0.1.0"
+description = "Example API used in the cargo-public-api test suite."
+homepage = "https://github.com/Enselic/cargo-public-api/tree/main/test-apis/auto_traits"
+documentation = "https://docs.rs/auto_traits"
+readme = "../auto_traits/README.md"
+license = "MIT"
+repository = "https://github.com/Enselic/cargo-public-api/tree/main/test-apis/auto_traits"

--- a/test-apis/auto_traits/src/lib.rs
+++ b/test-apis/auto_traits/src/lib.rs
@@ -1,0 +1,11 @@
+pub struct NotSendNorSync {
+    pointer: *const (),
+}
+
+pub struct SendAndSync {
+    x: usize,
+}
+
+pub struct SendNotSync {
+    x: std::cell::Cell<usize>,
+}


### PR DESCRIPTION
We especially do this for auto traits so that they remain in the same order no matter if some of them are negative impls or not.

If there are no objections, we should still wait with merging this, because we need to bump 0.x.0 when we release this: https://github.com/Enselic/cargo-public-api/blob/main/docs/MAINTAINER.md#versioning-strategy. And I'd like to also fix #429 as part of next 0.x.0 bump.