### PR TITLE
rustup-toolchain: Remove deprecation of `is_installed()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "rustup-toolchain"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "expect-test",
  "public-api",

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -44,7 +44,7 @@ version = "0.30.0"
 
 [dev-dependencies.rustup-toolchain]
 path = "../rustup-toolchain"
-version = "0.1.4"
+version = "0.1.5"
 
 [dev-dependencies.predicates]
 version = "3.0.3"

--- a/rustup-toolchain/CHANGELOG.md
+++ b/rustup-toolchain/CHANGELOG.md
@@ -1,5 +1,8 @@
 # rustup-toolchain
 
+## v0.1.5
+* Remove deprecation of `is_installed()` since there are legitimate use cases for it.
+
 ## v0.1.4
 * Rename `ensure_installed()` to `install()` for brevity
 * Deprecate `is_installed()` to make it clear it is not needed around `install()`

--- a/rustup-toolchain/Cargo.toml
+++ b/rustup-toolchain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "rustup-toolchain"
-version = "0.1.4"
+version = "0.1.5"
 description = "Utilities for working with rustup toolchains."
 homepage = "https://github.com/Enselic/cargo-public-api/tree/main/rustup-toolchain"
 documentation = "https://docs.rs/rustup-toolchain"

--- a/rustup-toolchain/src/lib.rs
+++ b/rustup-toolchain/src/lib.rs
@@ -47,7 +47,6 @@ pub fn install(toolchain: impl AsRef<str>) -> Result<()> {
     // The reason we check if the toolchain is installed rather than always
     // doing `rustup install toolchain` is because otherwise there will be noisy
     // "already installed" output from `rustup install toolchain`.
-    #[allow(deprecated)]
     if !is_installed(toolchain.as_ref())? {
         run_rustup_install(toolchain)?;
     }
@@ -62,12 +61,16 @@ pub fn ensure_installed(toolchain: &str) -> Result<()> {
     install(toolchain)
 }
 
-/// Deprecated
-#[allow(clippy::missing_errors_doc)]
-#[deprecated(
-    since = "0.1.4",
-    note = "Not needed, because `install()` already checks if the toolchain is installed already."
-)]
+/// Check if a toolchain is installed.
+///
+/// As a workaround [Rustup (including proxies) is not safe for concurrent
+/// use](https://github.com/rust-lang/rustup/issues/988) this function is
+/// protected by a process-global lock. If you use multiple processes, you need
+/// to prevent concurrent `rustup` usage yourself.
+///
+/// # Errors
+///
+/// If `rustup` is not installed on your system, for example.
 pub fn is_installed(toolchain: &str) -> Result<bool> {
     let _guard = RUSTUP_MUTEX.lock().map_err(|_| Error::StdSyncPoisonError)?;
 


### PR DESCRIPTION
There are legitimate use cases for it. I might want to make `cargo public-api` auto install `nightly` if `nightly` is not installed.