### PR TITLE
Bump to v0.31.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-public-api"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "public-api"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.30.0"
+version = "0.31.0"
 
 [workspace]
 members = [

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ pub fn bat::PrettyPrinter::input_files<I, P>(&mut self, paths: I) -> &mut Self w
 
 | cargo-public-api | Understands the rustdoc JSON output of  |
 | ---------------- | --------------------------------------- |
-| 0.30.x           | nightly-2023-05-24 —                    |
+| 0.30.x - 0.31.x  | nightly-2023-05-24 —                    |
 | 0.26.x — 0.29.x  | nightly-2023-01-04 — nightly-2023-05-23 |
 | 0.20.x — 0.25.x  | nightly-2022-09-28 — nightly-2023-01-03 |
 | 0.19.x           | nightly-2022-09-08 — nightly-2022-09-27 |

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -40,7 +40,7 @@ version = "0.8.6"
 
 [dependencies.public-api]
 path = "../public-api"
-version = "0.30.0"
+version = "0.31.0"
 
 [dev-dependencies.rustup-toolchain]
 path = "../rustup-toolchain"

--- a/public-api/CHANGELOG.md
+++ b/public-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `public-api` changelog
 
+## v0.31.0
+* Change rendering of `impl` items to include generic args of the implementor
+* Ignore `!` when sorting `impl`s to make `Send` and `Sync` order stable
+
 ## v0.30.0
 * Support `nightly-2023-05-24` and later
 

--- a/repo-tests/Cargo.toml
+++ b/repo-tests/Cargo.toml
@@ -7,5 +7,5 @@ license = "MIT"
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.30.0"
+version = "0.31.0"
 

--- a/rustdoc-json/Cargo.toml
+++ b/rustdoc-json/Cargo.toml
@@ -27,4 +27,4 @@ default-features = false
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.30.0"
+version = "0.31.0"

--- a/rustup-toolchain/Cargo.toml
+++ b/rustup-toolchain/Cargo.toml
@@ -21,4 +21,4 @@ version = "0.8.6"
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.30.0"
+version = "0.31.0"


### PR DESCRIPTION
We must bump 0.x.0 version since we change how items are rendered, so if we only bumped 0.0.x version we would break people's CI test since the CI test expects different output. (See https://github.com/Enselic/cargo-public-api/blob/main/docs/MAINTAINER.md#versioning-strategy)