### PR TITLE
Set workspace.resolver to 2 to fix warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 version = "0.31.1"
 
 [workspace]
+resolver = "2"
 members = [
     # Helper crate to build rustdoc JSON
     "rustdoc-json",


### PR DESCRIPTION
Fixes this warning:

```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```