### PR TITLE
Update `proc-macro2` to fix build with `nightly-2023-06-30`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/113152

Fixes this error when running tests:

       Compiling proc-macro2 v1.0.56
    error[E0635]: unknown feature `proc_macro_span_shrink`
      --> /home/martin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.56/src/lib.rs:92:30
       |
    92 |     feature(proc_macro_span, proc_macro_span_shrink)
       |                              ^^^^^^^^^^^^^^^^^^^^^^