### PR TITLE
Stop enforcing pedantic clippy

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,7 +41,7 @@ jobs:
       - run: RUSTDOCFLAGS='--deny warnings' cargo doc --locked --no-deps --document-private-items
 
   cargo-clippy:
-    name: cargo clippy -- --deny clippy::all --deny clippy::pedantic ...
+    name: cargo clippy -- --deny clippy::all ...
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -1,5 +1,5 @@
 // deny in CI, only warn here
-#![warn(clippy::all, clippy::pedantic)]
+#![warn(clippy::all)]
 
 use std::ffi::OsString;
 use std::io::stdout;
@@ -31,7 +31,6 @@ mod vendor;
     long_about = "List and diff the public API of Rust library crates between releases and commits. Website: https://github.com/Enselic/cargo-public-api",
     bin_name = "cargo public-api"
 )]
-#[allow(clippy::struct_excessive_bools)]
 pub struct Args {
     /// Path to `Cargo.toml`.
     #[arg(long, value_name = "PATH", default_value = "Cargo.toml")]
@@ -76,7 +75,6 @@ pub struct Args {
     ///
     /// By default, `--color=auto` is active. Using just `--color` without an
     /// arg is equivalent to `--color=always`.
-    #[allow(clippy::option_option)]
     #[arg(long, value_enum)]
     color: Option<Option<Color>>,
 
@@ -134,7 +132,6 @@ pub struct Args {
 
 /// The subcommand used for diffing.
 #[derive(Parser, Debug)]
-#[allow(clippy::struct_excessive_bools)]
 struct DiffArgs {
     /// Exit with failure if the specified API diff is detected.
     ///

--- a/cargo-public-api/src/plain.rs
+++ b/cargo-public-api/src/plain.rs
@@ -82,7 +82,6 @@ fn print_item(args: &Args, w: &mut dyn Write, item: &PublicItem) -> Result<()> {
     }
 }
 
-#[allow(clippy::option_option)]
 fn color_active(color: Option<Option<crate::arg_types::Color>>) -> bool {
     match color {
         // An explicit color was specified: `--color=...`
@@ -117,7 +116,6 @@ fn color_item_token(token: &Token, bg: Option<Color>) -> AnsiString<'_> {
             |bg| color.on(bg).paint(text.to_string()),
         )
     };
-    #[allow(clippy::match_same_arms)]
     match token {
         Token::Symbol(text) => style(Style::default(), text),
         Token::Qualifier(text) => style(Color::Blue.into(), text),

--- a/cargo-public-api/src/published_crate.rs
+++ b/cargo-public-api/src/published_crate.rs
@@ -138,7 +138,6 @@ fn manifest_for(args: &Args, spec: &crates_index::Version) -> Result<String> {
 
 // We use curl to significantly reduce the number of needed deps compared to
 // e.g. reqwest.
-#[allow(clippy::similar_names)]
 fn http_get_crate(name: &str, verbose: bool) -> Result<Crate> {
     let mut body: Vec<u8> = vec![];
     let dep_path = cargo_util::registry::make_dep_path(name, false /* prefix_only */);

--- a/cargo-public-api/src/vendor/crates_index.rs
+++ b/cargo-public-api/src/vendor/crates_index.rs
@@ -267,7 +267,6 @@ impl Crate {
         mut bytes: &[u8],
         dedupe: &mut DedupeContext,
     ) -> io::Result<Crate> {
-        #[allow(clippy::trivially_copy_pass_by_ref)]
         fn is_newline(&c: &u8) -> bool {
             c == b'\n'
         }

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -1,5 +1,5 @@
 // deny in CI, only warn here
-#![warn(clippy::all, clippy::pedantic)]
+#![warn(clippy::all)]
 
 //! To update expected output it is in many cases sufficient to run
 //! ```bash
@@ -1173,7 +1173,6 @@ impl TestRepo {
         Self::new_with_variant(TestRepoVariant::default())
     }
 
-    #[allow(clippy::needless_pass_by_value)]
     fn new_with_variant(variant: TestRepoVariant) -> Self {
         let tempdir = tempfile::tempdir().unwrap();
         let dirs_and_tags: &[(&str, &str)] = match variant {

--- a/public-api/src/diff.rs
+++ b/public-api/src/diff.rs
@@ -39,7 +39,6 @@ impl ChangedPublicItem {
 /// ```txt
 /// println!("{:#?}", public_api_diff);
 /// ```
-#[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PublicApiDiff {
     /// Items that have been removed from the public API. A MAJOR change, in

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -32,7 +32,7 @@
 //! ```
 
 // deny in CI, only warn here
-#![warn(clippy::all, clippy::pedantic, missing_docs)]
+#![warn(clippy::all, missing_docs)]
 
 mod crate_wrapper;
 mod error;
@@ -74,7 +74,6 @@ pub const MINIMUM_RUSTDOC_JSON_VERSION: &str = MINIMUM_NIGHTLY_RUST_VERSION;
 
 /// See [`Builder`] method docs for what each field means.
 #[derive(Copy, Clone, Debug)]
-#[allow(clippy::struct_excessive_bools)]
 struct BuilderOptions {
     sorted: bool,
     debug_sorting: bool,
@@ -86,7 +85,6 @@ struct BuilderOptions {
 /// Builds [`PublicApi`]s. See the [top level][`crate`] module docs for example
 /// code.
 #[derive(Debug, Clone)]
-#[allow(clippy::struct_excessive_bools)]
 pub struct Builder {
     source: BuilderSource,
     options: BuilderOptions,
@@ -265,7 +263,6 @@ impl PublicApi {
         note = "Use `public_api::Builder::from_rustdoc_json(path).option1(arg1).option2(arg2)...` instead."
     )]
     #[allow(deprecated)]
-    #[allow(clippy::needless_pass_by_value)] // For API backwards compatibility
     pub fn from_rustdoc_json(path: impl AsRef<Path>, options: Options) -> Result<PublicApi> {
         Builder {
             source: BuilderSource::RustdocJson(path.as_ref().to_owned()),
@@ -285,7 +282,6 @@ impl PublicApi {
         note = "If you need this edge case API, you need to write your JSON to a temporary file and then use `PublicApi::from_rustdoc_json()` instead."
     )]
     #[allow(deprecated)]
-    #[allow(clippy::needless_pass_by_value)] // For API backwards compatibility
     pub fn from_rustdoc_json_str(
         rustdoc_json_str: impl AsRef<str>,
         options: Options,

--- a/public-api/src/render.rs
+++ b/public-api/src/render.rs
@@ -35,7 +35,6 @@ pub struct RenderingContext<'c> {
 }
 
 impl<'c> RenderingContext<'c> {
-    #[allow(clippy::too_many_lines)]
     pub fn token_stream(&self, public_item: &IntermediatePublicItem<'c>) -> Vec<Token> {
         let item = public_item.item();
         let item_path = public_item.path();
@@ -283,7 +282,6 @@ impl<'c> RenderingContext<'c> {
         (output, push_a_separator)
     }
 
-    #[allow(clippy::needless_pass_by_value)]
     fn render_sequence<T>(
         &self,
         start: Vec<Token>,
@@ -295,7 +293,6 @@ impl<'c> RenderingContext<'c> {
         self.render_sequence_impl(start, end, between, false, sequence, render)
     }
 
-    #[allow(clippy::needless_pass_by_value)]
     fn render_sequence_if_not_empty<T>(
         &self,
         start: Vec<Token>,
@@ -307,7 +304,6 @@ impl<'c> RenderingContext<'c> {
         self.render_sequence_impl(start, end, between, true, sequence, render)
     }
 
-    #[allow(clippy::needless_pass_by_value)]
     fn render_sequence_impl<T>(
         &self,
         start: Vec<Token>,
@@ -339,7 +335,6 @@ impl<'c> RenderingContext<'c> {
         (self.render_type(ty), true)
     }
 
-    #[allow(clippy::ref_option_ref, clippy::trivially_copy_pass_by_ref)] // Because of `render_sequence()` arg types
     fn render_option_type(&self, ty: &Option<&Type>) -> Vec<Token> {
         let Some(ty) = ty else { return vec![Token::symbol("_")] }; // The `_` in `EnumWithStrippedTupleVariants::DoubleFirstHidden(_, bool)`
         match ty {
@@ -1335,7 +1330,6 @@ mod test {
         );
     }
 
-    #[allow(clippy::needless_pass_by_value)]
     fn assert_render(
         render_fn: impl Fn(RenderingContext) -> Vec<Token>,
         expected: Vec<Token>,

--- a/public-api/tests/public-api-lib-tests.rs
+++ b/public-api/tests/public-api-lib-tests.rs
@@ -1,5 +1,5 @@
 // deny in CI, only warn here
-#![warn(clippy::all, clippy::pedantic)]
+#![warn(clippy::all)]
 
 use std::{
     fs,

--- a/repo-tests/tests/repo-tests.rs
+++ b/repo-tests/tests/repo-tests.rs
@@ -1,5 +1,5 @@
 // deny in CI, only warn here
-#![warn(clippy::all, clippy::pedantic)]
+#![warn(clippy::all)]
 
 use std::{ffi::OsStr, fs::read_to_string, path::PathBuf};
 

--- a/rustdoc-json/src/builder.rs
+++ b/rustdoc-json/src/builder.rs
@@ -173,7 +173,6 @@ fn package_name(manifest_path: impl AsRef<Path>) -> Result<String, BuildError> {
 
 /// Builds rustdoc JSON. There are many build options. Refer to the docs to
 /// learn about them all. See [top-level docs](crate) for an example on how to use this builder.
-#[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug)]
 pub struct Builder {
     toolchain: Option<String>,

--- a/rustdoc-json/src/lib.rs
+++ b/rustdoc-json/src/lib.rs
@@ -18,7 +18,7 @@
 //! [here](https://github.com/Enselic/cargo-public-api/blob/main/rustdoc-json/examples/build-rustdoc-json.rs)
 
 // deny in CI, only warn here
-#![warn(clippy::all, clippy::pedantic, missing_docs)]
+#![warn(clippy::all, missing_docs)]
 
 use std::path::PathBuf;
 

--- a/rustup-toolchain/src/lib.rs
+++ b/rustup-toolchain/src/lib.rs
@@ -55,7 +55,6 @@ pub fn install(toolchain: impl AsRef<str>) -> Result<()> {
 }
 
 /// Deprecated
-#[allow(clippy::missing_errors_doc)]
 #[deprecated(since = "0.1.4", note = "Renamed to `install()` for brevity.")]
 pub fn ensure_installed(toolchain: &str) -> Result<()> {
     install(toolchain)

--- a/scripts/cargo-clippy.sh
+++ b/scripts/cargo-clippy.sh
@@ -11,7 +11,6 @@ cargo clippy \
     --all-features \
     -- \
     --deny clippy::all \
-    --deny clippy::pedantic \
     --deny warnings \
     --deny unsafe_code \
 


### PR DESCRIPTION
Over time I have ended up finding it more annoying than helpful to have pedantic clippy. In other words, I have come over to your side Emil (see https://github.com/Enselic/cargo-public-api/pull/117#pullrequestreview-1087455759). (I'm even skeptical about enabling specific pedantic lints now.)