### PR TITLE
dependabot: Ignore patch updates of widely used packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,12 @@ updates:
     labels:
       - "category-exclude"
       - "dependencies"
+    ignore:
+      - dependency-name: "semver"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "serde"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "serde_json"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "thiserror"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
E.g. serde gets updates basically every week, which is quite spammy for us. If there is a problem with serde, someone else will notice. So we don't need to stay on top of patch updates. Do the same for some more deps.

For less widely used deps there is a risk that patch updates accidentally introduces regressions, so keep dependabot patch updates for those.