### PR TITLE
Add context when running command fails

### DIFF
--- a/rustdoc-json/src/builder.rs
+++ b/rustdoc-json/src/builder.rs
@@ -17,7 +17,14 @@ pub fn run_cargo_rustdoc(options: Builder) -> Result<PathBuf, BuildError> {
     if options.verbose {
         eprintln!("Running: {:?}", cmd);
     }
-    if cmd.status()?.success() {
+    let command_result = cmd
+        .status()
+        .map_err(|source| BuildError::CannotRunCommand {
+            command: cmd,
+            source,
+        })?;
+
+    if command_result.success() {
         rustdoc_json_path_for_manifest_path(
             options.manifest_path,
             options.package.as_deref(),

--- a/rustdoc-json/src/lib.rs
+++ b/rustdoc-json/src/lib.rs
@@ -46,6 +46,17 @@ pub enum BuildError {
     #[error(transparent)]
     CargoMetadataError(#[from] cargo_metadata::Error),
 
+    /// Cannot run a command dues to std::io::Error
+    #[error("Cannot run command {:?}", .command.get_program())]
+    CannotRunCommand {
+        /// The command that failed
+        command: std::process::Command,
+
+        /// The underlying IO error
+        #[source]
+        source: std::io::Error,
+    },
+
     /// Some kind of IO error occurred.
     #[error(transparent)]
     IoError(#[from] std::io::Error),


### PR DESCRIPTION
Closes #512 

Please have a look.
This does not remove the transparent IO error (yet), but its a good start I guess.