### PR TITLE
Avoid textual API diff when changing inherent impl to auto-derived impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,6 +811,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +839,7 @@ dependencies = [
  "hashbag",
  "itertools 0.12.0",
  "predicates",
+ "pretty_assertions",
  "rustdoc-json",
  "rustdoc-types",
  "serde",
@@ -1501,3 +1512,9 @@ checksum = "81fac9742fd1ad1bd9643b991319f72dd031016d44b77039a26977eb667141e7"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/cargo-public-api/tests/expected-output/list_public_items.txt
+++ b/cargo-public-api/tests/expected-output/list_public_items.txt
@@ -3,8 +3,6 @@ pub mod public_api::diff
 pub struct public_api::diff::ChangedPublicItem
 pub public_api::diff::ChangedPublicItem::new: public_api::PublicItem
 pub public_api::diff::ChangedPublicItem::old: public_api::PublicItem
-impl public_api::diff::ChangedPublicItem
-pub fn public_api::diff::ChangedPublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
 impl core::clone::Clone for public_api::diff::ChangedPublicItem
 pub fn public_api::diff::ChangedPublicItem::clone(&self) -> public_api::diff::ChangedPublicItem
 impl core::cmp::Eq for public_api::diff::ChangedPublicItem
@@ -14,6 +12,8 @@ impl core::fmt::Debug for public_api::diff::ChangedPublicItem
 pub fn public_api::diff::ChangedPublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralEq for public_api::diff::ChangedPublicItem
 impl core::marker::StructuralPartialEq for public_api::diff::ChangedPublicItem
+impl public_api::diff::ChangedPublicItem
+pub fn public_api::diff::ChangedPublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
 impl core::marker::Send for public_api::diff::ChangedPublicItem
 impl core::marker::Sync for public_api::diff::ChangedPublicItem
 impl core::marker::Unpin for public_api::diff::ChangedPublicItem
@@ -23,9 +23,6 @@ pub struct public_api::diff::PublicApiDiff
 pub public_api::diff::PublicApiDiff::added: alloc::vec::Vec<public_api::PublicItem>
 pub public_api::diff::PublicApiDiff::changed: alloc::vec::Vec<public_api::diff::ChangedPublicItem>
 pub public_api::diff::PublicApiDiff::removed: alloc::vec::Vec<public_api::PublicItem>
-impl public_api::diff::PublicApiDiff
-pub fn public_api::diff::PublicApiDiff::between(old: public_api::PublicApi, new: public_api::PublicApi) -> Self
-pub fn public_api::diff::PublicApiDiff::is_empty(&self) -> bool
 impl core::clone::Clone for public_api::diff::PublicApiDiff
 pub fn public_api::diff::PublicApiDiff::clone(&self) -> public_api::diff::PublicApiDiff
 impl core::cmp::Eq for public_api::diff::PublicApiDiff
@@ -35,6 +32,9 @@ impl core::fmt::Debug for public_api::diff::PublicApiDiff
 pub fn public_api::diff::PublicApiDiff::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralEq for public_api::diff::PublicApiDiff
 impl core::marker::StructuralPartialEq for public_api::diff::PublicApiDiff
+impl public_api::diff::PublicApiDiff
+pub fn public_api::diff::PublicApiDiff::between(old: public_api::PublicApi, new: public_api::PublicApi) -> Self
+pub fn public_api::diff::PublicApiDiff::is_empty(&self) -> bool
 impl core::marker::Send for public_api::diff::PublicApiDiff
 impl core::marker::Sync for public_api::diff::PublicApiDiff
 impl core::marker::Unpin for public_api::diff::PublicApiDiff
@@ -55,9 +55,6 @@ pub public_api::tokens::Token::Self_(alloc::string::String)
 pub public_api::tokens::Token::Symbol(alloc::string::String)
 pub public_api::tokens::Token::Type(alloc::string::String)
 pub public_api::tokens::Token::Whitespace
-impl public_api::tokens::Token
-pub fn public_api::tokens::Token::len(&self) -> usize
-pub fn public_api::tokens::Token::text(&self) -> &str
 impl core::clone::Clone for public_api::tokens::Token
 pub fn public_api::tokens::Token::clone(&self) -> public_api::tokens::Token
 impl core::cmp::Eq for public_api::tokens::Token
@@ -73,6 +70,9 @@ impl core::hash::Hash for public_api::tokens::Token
 pub fn public_api::tokens::Token::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralEq for public_api::tokens::Token
 impl core::marker::StructuralPartialEq for public_api::tokens::Token
+impl public_api::tokens::Token
+pub fn public_api::tokens::Token::len(&self) -> usize
+pub fn public_api::tokens::Token::text(&self) -> &str
 impl core::marker::Send for public_api::tokens::Token
 impl core::marker::Sync for public_api::tokens::Token
 impl core::marker::Unpin for public_api::tokens::Token
@@ -81,6 +81,8 @@ impl core::panic::unwind_safe::UnwindSafe for public_api::tokens::Token
 #[non_exhaustive] pub enum public_api::Error
 pub public_api::Error::IoError(std::io::error::Error)
 pub public_api::Error::SerdeJsonError(serde_json::error::Error)
+impl core::fmt::Debug for public_api::Error
+pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::convert::From<serde_json::error::Error> for public_api::Error
 pub fn public_api::Error::from(source: serde_json::error::Error) -> Self
 impl core::convert::From<std::io::error::Error> for public_api::Error
@@ -89,14 +91,16 @@ impl core::error::Error for public_api::Error
 pub fn public_api::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Display for public_api::Error
 pub fn public_api::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Debug for public_api::Error
-pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Send for public_api::Error
 impl core::marker::Sync for public_api::Error
 impl core::marker::Unpin for public_api::Error
 impl !core::panic::unwind_safe::RefUnwindSafe for public_api::Error
 impl !core::panic::unwind_safe::UnwindSafe for public_api::Error
 pub struct public_api::Builder
+impl core::clone::Clone for public_api::Builder
+pub fn public_api::Builder::clone(&self) -> public_api::Builder
+impl core::fmt::Debug for public_api::Builder
+pub fn public_api::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl public_api::Builder
 pub fn public_api::Builder::build(self) -> public_api::Result<public_api::PublicApi>
 pub fn public_api::Builder::debug_sorting(self, debug_sorting: bool) -> Self
@@ -105,23 +109,19 @@ pub fn public_api::Builder::omit_auto_derived_impls(self, omit_auto_derived_impl
 pub fn public_api::Builder::omit_auto_trait_impls(self, omit_auto_trait_impls: bool) -> Self
 pub fn public_api::Builder::omit_blanket_impls(self, omit_blanket_impls: bool) -> Self
 pub fn public_api::Builder::sorted(self, sorted: bool) -> Self
-impl core::clone::Clone for public_api::Builder
-pub fn public_api::Builder::clone(&self) -> public_api::Builder
-impl core::fmt::Debug for public_api::Builder
-pub fn public_api::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Send for public_api::Builder
 impl core::marker::Sync for public_api::Builder
 impl core::marker::Unpin for public_api::Builder
 impl core::panic::unwind_safe::RefUnwindSafe for public_api::Builder
 impl core::panic::unwind_safe::UnwindSafe for public_api::Builder
 #[non_exhaustive] pub struct public_api::PublicApi
+impl core::fmt::Debug for public_api::PublicApi
+pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl public_api::PublicApi
 pub fn public_api::PublicApi::into_items(self) -> impl core::iter::traits::iterator::Iterator<Item = public_api::PublicItem>
 pub fn public_api::PublicApi::items(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::PublicItem>
 pub fn public_api::PublicApi::missing_item_ids(&self) -> impl core::iter::traits::iterator::Iterator<Item = &alloc::string::String>
 impl core::fmt::Display for public_api::PublicApi
-pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Debug for public_api::PublicApi
 pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Send for public_api::PublicApi
 impl core::marker::Sync for public_api::PublicApi
@@ -129,6 +129,8 @@ impl core::marker::Unpin for public_api::PublicApi
 impl core::panic::unwind_safe::RefUnwindSafe for public_api::PublicApi
 impl core::panic::unwind_safe::UnwindSafe for public_api::PublicApi
 pub struct public_api::PublicItem
+impl core::clone::Clone for public_api::PublicItem
+pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
 impl public_api::PublicItem
 pub fn public_api::PublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
 pub fn public_api::PublicItem::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::tokens::Token>
@@ -141,8 +143,6 @@ impl core::fmt::Display for public_api::PublicItem
 pub fn public_api::PublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for public_api::PublicItem
 pub fn public_api::PublicItem::hash<H: core::hash::Hasher>(&self, state: &mut H)
-impl core::clone::Clone for public_api::PublicItem
-pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
 impl core::marker::Send for public_api::PublicItem
 impl core::marker::Sync for public_api::PublicItem
 impl core::marker::Unpin for public_api::PublicItem

--- a/cargo-public-api/tests/expected-output/subcommand_invocation_public_api_arg.txt
+++ b/cargo-public-api/tests/expected-output/subcommand_invocation_public_api_arg.txt
@@ -3,8 +3,6 @@ pub mod public_api::diff
 pub struct public_api::diff::ChangedPublicItem
 pub public_api::diff::ChangedPublicItem::new: public_api::PublicItem
 pub public_api::diff::ChangedPublicItem::old: public_api::PublicItem
-impl public_api::diff::ChangedPublicItem
-pub fn public_api::diff::ChangedPublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
 impl core::clone::Clone for public_api::diff::ChangedPublicItem
 pub fn public_api::diff::ChangedPublicItem::clone(&self) -> public_api::diff::ChangedPublicItem
 impl core::cmp::Eq for public_api::diff::ChangedPublicItem
@@ -14,13 +12,12 @@ impl core::fmt::Debug for public_api::diff::ChangedPublicItem
 pub fn public_api::diff::ChangedPublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralEq for public_api::diff::ChangedPublicItem
 impl core::marker::StructuralPartialEq for public_api::diff::ChangedPublicItem
+impl public_api::diff::ChangedPublicItem
+pub fn public_api::diff::ChangedPublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
 pub struct public_api::diff::PublicApiDiff
 pub public_api::diff::PublicApiDiff::added: alloc::vec::Vec<public_api::PublicItem>
 pub public_api::diff::PublicApiDiff::changed: alloc::vec::Vec<public_api::diff::ChangedPublicItem>
 pub public_api::diff::PublicApiDiff::removed: alloc::vec::Vec<public_api::PublicItem>
-impl public_api::diff::PublicApiDiff
-pub fn public_api::diff::PublicApiDiff::between(old: public_api::PublicApi, new: public_api::PublicApi) -> Self
-pub fn public_api::diff::PublicApiDiff::is_empty(&self) -> bool
 impl core::clone::Clone for public_api::diff::PublicApiDiff
 pub fn public_api::diff::PublicApiDiff::clone(&self) -> public_api::diff::PublicApiDiff
 impl core::cmp::Eq for public_api::diff::PublicApiDiff
@@ -30,6 +27,9 @@ impl core::fmt::Debug for public_api::diff::PublicApiDiff
 pub fn public_api::diff::PublicApiDiff::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralEq for public_api::diff::PublicApiDiff
 impl core::marker::StructuralPartialEq for public_api::diff::PublicApiDiff
+impl public_api::diff::PublicApiDiff
+pub fn public_api::diff::PublicApiDiff::between(old: public_api::PublicApi, new: public_api::PublicApi) -> Self
+pub fn public_api::diff::PublicApiDiff::is_empty(&self) -> bool
 pub mod public_api::tokens
 pub enum public_api::tokens::Token
 pub public_api::tokens::Token::Annotation(alloc::string::String)
@@ -45,9 +45,6 @@ pub public_api::tokens::Token::Self_(alloc::string::String)
 pub public_api::tokens::Token::Symbol(alloc::string::String)
 pub public_api::tokens::Token::Type(alloc::string::String)
 pub public_api::tokens::Token::Whitespace
-impl public_api::tokens::Token
-pub fn public_api::tokens::Token::len(&self) -> usize
-pub fn public_api::tokens::Token::text(&self) -> &str
 impl core::clone::Clone for public_api::tokens::Token
 pub fn public_api::tokens::Token::clone(&self) -> public_api::tokens::Token
 impl core::cmp::Eq for public_api::tokens::Token
@@ -63,9 +60,14 @@ impl core::hash::Hash for public_api::tokens::Token
 pub fn public_api::tokens::Token::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralEq for public_api::tokens::Token
 impl core::marker::StructuralPartialEq for public_api::tokens::Token
+impl public_api::tokens::Token
+pub fn public_api::tokens::Token::len(&self) -> usize
+pub fn public_api::tokens::Token::text(&self) -> &str
 #[non_exhaustive] pub enum public_api::Error
 pub public_api::Error::IoError(std::io::error::Error)
 pub public_api::Error::SerdeJsonError(serde_json::error::Error)
+impl core::fmt::Debug for public_api::Error
+pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::convert::From<serde_json::error::Error> for public_api::Error
 pub fn public_api::Error::from(source: serde_json::error::Error) -> Self
 impl core::convert::From<std::io::error::Error> for public_api::Error
@@ -74,9 +76,11 @@ impl core::error::Error for public_api::Error
 pub fn public_api::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Display for public_api::Error
 pub fn public_api::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Debug for public_api::Error
-pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct public_api::Builder
+impl core::clone::Clone for public_api::Builder
+pub fn public_api::Builder::clone(&self) -> public_api::Builder
+impl core::fmt::Debug for public_api::Builder
+pub fn public_api::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl public_api::Builder
 pub fn public_api::Builder::build(self) -> public_api::Result<public_api::PublicApi>
 pub fn public_api::Builder::debug_sorting(self, debug_sorting: bool) -> Self
@@ -85,20 +89,18 @@ pub fn public_api::Builder::omit_auto_derived_impls(self, omit_auto_derived_impl
 pub fn public_api::Builder::omit_auto_trait_impls(self, omit_auto_trait_impls: bool) -> Self
 pub fn public_api::Builder::omit_blanket_impls(self, omit_blanket_impls: bool) -> Self
 pub fn public_api::Builder::sorted(self, sorted: bool) -> Self
-impl core::clone::Clone for public_api::Builder
-pub fn public_api::Builder::clone(&self) -> public_api::Builder
-impl core::fmt::Debug for public_api::Builder
-pub fn public_api::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 #[non_exhaustive] pub struct public_api::PublicApi
+impl core::fmt::Debug for public_api::PublicApi
+pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl public_api::PublicApi
 pub fn public_api::PublicApi::into_items(self) -> impl core::iter::traits::iterator::Iterator<Item = public_api::PublicItem>
 pub fn public_api::PublicApi::items(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::PublicItem>
 pub fn public_api::PublicApi::missing_item_ids(&self) -> impl core::iter::traits::iterator::Iterator<Item = &alloc::string::String>
 impl core::fmt::Display for public_api::PublicApi
 pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Debug for public_api::PublicApi
-pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct public_api::PublicItem
+impl core::clone::Clone for public_api::PublicItem
+pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
 impl public_api::PublicItem
 pub fn public_api::PublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
 pub fn public_api::PublicItem::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::tokens::Token>
@@ -111,7 +113,5 @@ impl core::fmt::Display for public_api::PublicItem
 pub fn public_api::PublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for public_api::PublicItem
 pub fn public_api::PublicItem::hash<H: core::hash::Hasher>(&self, state: &mut H)
-impl core::clone::Clone for public_api::PublicItem
-pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
 pub const public_api::MINIMUM_NIGHTLY_RUST_VERSION: &str
 pub type public_api::Result<T> = core::result::Result<T, public_api::Error>

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -30,6 +30,7 @@ version = "0.23.0"
 anyhow = "1.0.75"
 assert_cmd = "2.0.12"
 expect-test = "1.4.1"
+pretty_assertions = "1.2.3"
 tempfile = "3.8.1"
 
 [dev-dependencies.itertools]

--- a/public-api/src/item_processor.rs
+++ b/public-api/src/item_processor.rs
@@ -349,9 +349,10 @@ pub(crate) fn sorting_prefix(item: &Item) -> u8 {
         ItemEnum::TypeAlias(_) => 19,
 
         ItemEnum::Impl(impl_) => match ImplKind::from(item, impl_) {
-            ImplKind::Inherent => 20,
+            // To not cause a diff when changing a manual impl to an
+            // auto-derived impl (or vice versa), we put them in the same group.
+            ImplKind::Inherent | ImplKind::AutoDerived => 20,
             ImplKind::Trait => 21,
-            ImplKind::AutoDerived => 22,
             ImplKind::AutoTrait => 23,
             ImplKind::Blanket => 24,
         },

--- a/public-api/tests/public-api.txt
+++ b/public-api/tests/public-api.txt
@@ -3,8 +3,6 @@ pub mod public_api::diff
 pub struct public_api::diff::ChangedPublicItem
 pub public_api::diff::ChangedPublicItem::new: public_api::PublicItem
 pub public_api::diff::ChangedPublicItem::old: public_api::PublicItem
-impl public_api::diff::ChangedPublicItem
-pub fn public_api::diff::ChangedPublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
 impl core::clone::Clone for public_api::diff::ChangedPublicItem
 pub fn public_api::diff::ChangedPublicItem::clone(&self) -> public_api::diff::ChangedPublicItem
 impl core::cmp::Eq for public_api::diff::ChangedPublicItem
@@ -14,6 +12,8 @@ impl core::fmt::Debug for public_api::diff::ChangedPublicItem
 pub fn public_api::diff::ChangedPublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralEq for public_api::diff::ChangedPublicItem
 impl core::marker::StructuralPartialEq for public_api::diff::ChangedPublicItem
+impl public_api::diff::ChangedPublicItem
+pub fn public_api::diff::ChangedPublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
 impl core::marker::Send for public_api::diff::ChangedPublicItem
 impl core::marker::Sync for public_api::diff::ChangedPublicItem
 impl core::marker::Unpin for public_api::diff::ChangedPublicItem
@@ -43,9 +43,6 @@ pub struct public_api::diff::PublicApiDiff
 pub public_api::diff::PublicApiDiff::added: alloc::vec::Vec<public_api::PublicItem>
 pub public_api::diff::PublicApiDiff::changed: alloc::vec::Vec<public_api::diff::ChangedPublicItem>
 pub public_api::diff::PublicApiDiff::removed: alloc::vec::Vec<public_api::PublicItem>
-impl public_api::diff::PublicApiDiff
-pub fn public_api::diff::PublicApiDiff::between(old: public_api::PublicApi, new: public_api::PublicApi) -> Self
-pub fn public_api::diff::PublicApiDiff::is_empty(&self) -> bool
 impl core::clone::Clone for public_api::diff::PublicApiDiff
 pub fn public_api::diff::PublicApiDiff::clone(&self) -> public_api::diff::PublicApiDiff
 impl core::cmp::Eq for public_api::diff::PublicApiDiff
@@ -55,6 +52,9 @@ impl core::fmt::Debug for public_api::diff::PublicApiDiff
 pub fn public_api::diff::PublicApiDiff::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralEq for public_api::diff::PublicApiDiff
 impl core::marker::StructuralPartialEq for public_api::diff::PublicApiDiff
+impl public_api::diff::PublicApiDiff
+pub fn public_api::diff::PublicApiDiff::between(old: public_api::PublicApi, new: public_api::PublicApi) -> Self
+pub fn public_api::diff::PublicApiDiff::is_empty(&self) -> bool
 impl core::marker::Send for public_api::diff::PublicApiDiff
 impl core::marker::Sync for public_api::diff::PublicApiDiff
 impl core::marker::Unpin for public_api::diff::PublicApiDiff
@@ -95,9 +95,6 @@ pub public_api::tokens::Token::Self_(alloc::string::String)
 pub public_api::tokens::Token::Symbol(alloc::string::String)
 pub public_api::tokens::Token::Type(alloc::string::String)
 pub public_api::tokens::Token::Whitespace
-impl public_api::tokens::Token
-pub fn public_api::tokens::Token::len(&self) -> usize
-pub fn public_api::tokens::Token::text(&self) -> &str
 impl core::clone::Clone for public_api::tokens::Token
 pub fn public_api::tokens::Token::clone(&self) -> public_api::tokens::Token
 impl core::cmp::Eq for public_api::tokens::Token
@@ -113,6 +110,9 @@ impl core::hash::Hash for public_api::tokens::Token
 pub fn public_api::tokens::Token::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralEq for public_api::tokens::Token
 impl core::marker::StructuralPartialEq for public_api::tokens::Token
+impl public_api::tokens::Token
+pub fn public_api::tokens::Token::len(&self) -> usize
+pub fn public_api::tokens::Token::text(&self) -> &str
 impl core::marker::Send for public_api::tokens::Token
 impl core::marker::Sync for public_api::tokens::Token
 impl core::marker::Unpin for public_api::tokens::Token
@@ -141,6 +141,8 @@ pub fn public_api::tokens::Token::from(t: T) -> T
 #[non_exhaustive] pub enum public_api::Error
 pub public_api::Error::IoError(std::io::error::Error)
 pub public_api::Error::SerdeJsonError(serde_json::error::Error)
+impl core::fmt::Debug for public_api::Error
+pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::convert::From<serde_json::error::Error> for public_api::Error
 pub fn public_api::Error::from(source: serde_json::error::Error) -> Self
 impl core::convert::From<std::io::error::Error> for public_api::Error
@@ -149,8 +151,6 @@ impl core::error::Error for public_api::Error
 pub fn public_api::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Display for public_api::Error
 pub fn public_api::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Debug for public_api::Error
-pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Send for public_api::Error
 impl core::marker::Sync for public_api::Error
 impl core::marker::Unpin for public_api::Error
@@ -175,6 +175,10 @@ pub fn public_api::Error::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for public_api::Error
 pub fn public_api::Error::from(t: T) -> T
 pub struct public_api::Builder
+impl core::clone::Clone for public_api::Builder
+pub fn public_api::Builder::clone(&self) -> public_api::Builder
+impl core::fmt::Debug for public_api::Builder
+pub fn public_api::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl public_api::Builder
 pub fn public_api::Builder::build(self) -> public_api::Result<public_api::PublicApi>
 pub fn public_api::Builder::debug_sorting(self, debug_sorting: bool) -> Self
@@ -183,10 +187,6 @@ pub fn public_api::Builder::omit_auto_derived_impls(self, omit_auto_derived_impl
 pub fn public_api::Builder::omit_auto_trait_impls(self, omit_auto_trait_impls: bool) -> Self
 pub fn public_api::Builder::omit_blanket_impls(self, omit_blanket_impls: bool) -> Self
 pub fn public_api::Builder::sorted(self, sorted: bool) -> Self
-impl core::clone::Clone for public_api::Builder
-pub fn public_api::Builder::clone(&self) -> public_api::Builder
-impl core::fmt::Debug for public_api::Builder
-pub fn public_api::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Send for public_api::Builder
 impl core::marker::Sync for public_api::Builder
 impl core::marker::Unpin for public_api::Builder
@@ -213,13 +213,13 @@ pub fn public_api::Builder::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for public_api::Builder
 pub fn public_api::Builder::from(t: T) -> T
 #[non_exhaustive] pub struct public_api::PublicApi
+impl core::fmt::Debug for public_api::PublicApi
+pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl public_api::PublicApi
 pub fn public_api::PublicApi::into_items(self) -> impl core::iter::traits::iterator::Iterator<Item = public_api::PublicItem>
 pub fn public_api::PublicApi::items(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::PublicItem>
 pub fn public_api::PublicApi::missing_item_ids(&self) -> impl core::iter::traits::iterator::Iterator<Item = &alloc::string::String>
 impl core::fmt::Display for public_api::PublicApi
-pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Debug for public_api::PublicApi
 pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Send for public_api::PublicApi
 impl core::marker::Sync for public_api::PublicApi
@@ -245,6 +245,8 @@ pub fn public_api::PublicApi::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for public_api::PublicApi
 pub fn public_api::PublicApi::from(t: T) -> T
 pub struct public_api::PublicItem
+impl core::clone::Clone for public_api::PublicItem
+pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
 impl public_api::PublicItem
 pub fn public_api::PublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
 pub fn public_api::PublicItem::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::tokens::Token>
@@ -257,8 +259,6 @@ impl core::fmt::Display for public_api::PublicItem
 pub fn public_api::PublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for public_api::PublicItem
 pub fn public_api::PublicItem::hash<H: core::hash::Hasher>(&self, state: &mut H)
-impl core::clone::Clone for public_api::PublicItem
-pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
 impl core::marker::Send for public_api::PublicItem
 impl core::marker::Sync for public_api::PublicItem
 impl core::marker::Unpin for public_api::PublicItem

--- a/rustdoc-json/tests/public-api.txt
+++ b/rustdoc-json/tests/public-api.txt
@@ -5,6 +5,8 @@ pub rustdoc_json::BuildError::CargoMetadataError(cargo_metadata::errors::Error)
 pub rustdoc_json::BuildError::General(alloc::string::String)
 pub rustdoc_json::BuildError::IoError(std::io::error::Error)
 pub rustdoc_json::BuildError::VirtualManifest(std::path::PathBuf)
+impl core::fmt::Debug for rustdoc_json::BuildError
+pub fn rustdoc_json::BuildError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::convert::From<cargo_manifest::error::Error> for rustdoc_json::BuildError
 pub fn rustdoc_json::BuildError::from(source: cargo_manifest::error::Error) -> Self
 impl core::convert::From<cargo_metadata::errors::Error> for rustdoc_json::BuildError
@@ -15,8 +17,6 @@ impl core::error::Error for rustdoc_json::BuildError
 pub fn rustdoc_json::BuildError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Display for rustdoc_json::BuildError
 pub fn rustdoc_json::BuildError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Debug for rustdoc_json::BuildError
-pub fn rustdoc_json::BuildError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Send for rustdoc_json::BuildError
 impl core::marker::Sync for rustdoc_json::BuildError
 impl core::marker::Unpin for rustdoc_json::BuildError
@@ -78,6 +78,10 @@ pub fn rustdoc_json::PackageTarget::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for rustdoc_json::PackageTarget
 pub fn rustdoc_json::PackageTarget::from(t: T) -> T
 pub struct rustdoc_json::Builder
+impl core::clone::Clone for rustdoc_json::Builder
+pub fn rustdoc_json::Builder::clone(&self) -> rustdoc_json::Builder
+impl core::fmt::Debug for rustdoc_json::Builder
+pub fn rustdoc_json::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl rustdoc_json::Builder
 pub const fn rustdoc_json::Builder::all_features(self, all_features: bool) -> Self
 pub fn rustdoc_json::Builder::build(self) -> core::result::Result<std::path::PathBuf, rustdoc_json::BuildError>
@@ -98,10 +102,6 @@ pub fn rustdoc_json::Builder::toolchain(self, toolchain: impl core::convert::Int
 pub const fn rustdoc_json::Builder::verbose(self, verbose: bool) -> Self
 impl core::default::Default for rustdoc_json::Builder
 pub fn rustdoc_json::Builder::default() -> Self
-impl core::clone::Clone for rustdoc_json::Builder
-pub fn rustdoc_json::Builder::clone(&self) -> rustdoc_json::Builder
-impl core::fmt::Debug for rustdoc_json::Builder
-pub fn rustdoc_json::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Send for rustdoc_json::Builder
 impl core::marker::Sync for rustdoc_json::Builder
 impl core::marker::Unpin for rustdoc_json::Builder

--- a/rustup-toolchain/tests/public-api.txt
+++ b/rustup-toolchain/tests/public-api.txt
@@ -3,14 +3,14 @@ pub mod rustup_toolchain
 pub rustup_toolchain::Error::IoError(std::io::error::Error)
 pub rustup_toolchain::Error::RustupToolchainInstallError
 pub rustup_toolchain::Error::StdSyncPoisonError
+impl core::fmt::Debug for rustup_toolchain::Error
+pub fn rustup_toolchain::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::convert::From<std::io::error::Error> for rustup_toolchain::Error
 pub fn rustup_toolchain::Error::from(source: std::io::error::Error) -> Self
 impl core::error::Error for rustup_toolchain::Error
 pub fn rustup_toolchain::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Display for rustup_toolchain::Error
 pub fn rustup_toolchain::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Debug for rustup_toolchain::Error
-pub fn rustup_toolchain::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Send for rustup_toolchain::Error
 impl core::marker::Sync for rustup_toolchain::Error
 impl core::marker::Unpin for rustup_toolchain::Error


### PR DESCRIPTION
The programmatic differ `public_api::diff::PublicApiDiff::between()` is smart enough to realize there is no diff, but when diffing the textual representations of APIs (like in the CI example we have in our README) there is an unnecessary diff. Fix this unnecessary diff. (There will still be a diff if changing from `ConcreteType` to `Self`, see https://github.com/Enselic/cargo-public-api/issues/364)

This was discovered in https://github.com/trishume/syntect/pull/500 in which CI failed because of the unwanted diff that this PR corrects.