### PR TITLE
Prepare for releases of all crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustdoc-json"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "assert_cmd",
  "cargo-manifest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-public-api"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "public-api"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "rustup-toolchain"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "expect-test",
  "public-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.32.0"
+version = "0.33.0"
 
 [workspace]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ cargo public-api -sss
 
 | cargo-public-api | Understands the rustdoc JSON output of  |
 | ---------------- | --------------------------------------- |
-| 0.32.x           | nightly-2023-08-25 —                    |
+| 0.32.x — 0.33.x  | nightly-2023-08-25 —                    |
 | 0.30.x — 0.31.x  | nightly-2023-05-24 — nightly-2023-08-24 |
 | 0.26.x — 0.29.x  | nightly-2023-01-04 — nightly-2023-05-23 |
 | 0.20.x — 0.25.x  | nightly-2022-09-28 — nightly-2023-01-03 |

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -40,7 +40,7 @@ features = ["serde"]
 
 [dependencies.rustdoc-json]
 path = "../rustdoc-json"
-version = "0.8.7"
+version = "0.8.8"
 
 [dependencies.public-api]
 path = "../public-api"

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -44,7 +44,7 @@ version = "0.8.8"
 
 [dependencies.public-api]
 path = "../public-api"
-version = "0.32.0"
+version = "0.33.0"
 
 [dependencies.serde]
 version = "1.0.179"

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -60,7 +60,7 @@ features = ["serde"]
 
 [dev-dependencies.rustup-toolchain]
 path = "../rustup-toolchain"
-version = "0.1.5"
+version = "0.1.6"
 
 [dev-dependencies.predicates]
 version = "3.0.4"

--- a/public-api/CHANGELOG.md
+++ b/public-api/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `public-api` changelog
 
+## v0.33.0
+* Avoid textual API diff when changing an inherent impl to an auto-derived impl.
+
 ## v0.32.0
 * Support `nightly-2023-08-25` and later
 * Remove all deprecated API

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -39,7 +39,7 @@ default-features = false
 
 [dev-dependencies.rustdoc-json]
 path = "../rustdoc-json"
-version = "0.8.7"
+version = "0.8.8"
 
 [dev-dependencies.predicates]
 version = "3.0.4"

--- a/repo-tests/Cargo.toml
+++ b/repo-tests/Cargo.toml
@@ -7,5 +7,5 @@ license = "MIT"
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.32.0"
+version = "0.33.0"
 

--- a/rustdoc-json/Cargo.toml
+++ b/rustdoc-json/Cargo.toml
@@ -28,4 +28,4 @@ default-features = false
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.32.0"
+version = "0.33.0"

--- a/rustdoc-json/Cargo.toml
+++ b/rustdoc-json/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "rustdoc-json"
-version = "0.8.7"
+version = "0.8.8"
 description = "Utilities for working with rustdoc JSON."
 homepage = "https://github.com/Enselic/cargo-public-api/tree/main/rustdoc-json"
 documentation = "https://docs.rs/rustdoc-json"

--- a/rustup-toolchain/CHANGELOG.md
+++ b/rustup-toolchain/CHANGELOG.md
@@ -1,5 +1,8 @@
 # rustup-toolchain
 
+## v0.1.6
+* Add `package.keywords` to `Cargo.toml`.
+
 ## v0.1.5
 * Remove deprecation of `is_installed()` since there are legitimate use cases for it.
 

--- a/rustup-toolchain/Cargo.toml
+++ b/rustup-toolchain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "rustup-toolchain"
-version = "0.1.5"
+version = "0.1.6"
 description = "Utilities for working with rustup toolchains."
 homepage = "https://github.com/Enselic/cargo-public-api/tree/main/rustup-toolchain"
 documentation = "https://docs.rs/rustup-toolchain"

--- a/rustup-toolchain/Cargo.toml
+++ b/rustup-toolchain/Cargo.toml
@@ -22,4 +22,4 @@ version = "0.8.8"
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.32.0"
+version = "0.33.0"

--- a/rustup-toolchain/Cargo.toml
+++ b/rustup-toolchain/Cargo.toml
@@ -18,7 +18,7 @@ expect-test = "1.4.1"
 
 [dev-dependencies.rustdoc-json]
 path = "../rustdoc-json"
-version = "0.8.7"
+version = "0.8.8"
 
 [dev-dependencies.public-api]
 path = "../public-api"


### PR DESCRIPTION
We need to bump 0.x.0 of public-api since we changed the order of rendered items in https://github.com/Enselic/cargo-public-api/pull/516, and we don't want other's CI pipeline to fail from a 0.0.x upgrade.