### PR TITLE
Fixup 'Avoid textual API diff when changing a trait impl to an auto-derived impl'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-public-api"
-version = "0.33.0"
+version = "0.33.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "public-api"
-version = "0.33.0"
+version = "0.33.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.33.0"
+version = "0.33.1"
 
 [workspace]
 resolver = "2"

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -44,7 +44,7 @@ version = "0.8.8"
 
 [dependencies.public-api]
 path = "../public-api"
-version = "0.33.0"
+version = "0.33.1"
 
 [dependencies.serde]
 version = "1.0.179"

--- a/cargo-public-api/tests/expected-output/list_public_items.txt
+++ b/cargo-public-api/tests/expected-output/list_public_items.txt
@@ -3,6 +3,8 @@ pub mod public_api::diff
 pub struct public_api::diff::ChangedPublicItem
 pub public_api::diff::ChangedPublicItem::new: public_api::PublicItem
 pub public_api::diff::ChangedPublicItem::old: public_api::PublicItem
+impl public_api::diff::ChangedPublicItem
+pub fn public_api::diff::ChangedPublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
 impl core::clone::Clone for public_api::diff::ChangedPublicItem
 pub fn public_api::diff::ChangedPublicItem::clone(&self) -> public_api::diff::ChangedPublicItem
 impl core::cmp::Eq for public_api::diff::ChangedPublicItem
@@ -12,8 +14,6 @@ impl core::fmt::Debug for public_api::diff::ChangedPublicItem
 pub fn public_api::diff::ChangedPublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralEq for public_api::diff::ChangedPublicItem
 impl core::marker::StructuralPartialEq for public_api::diff::ChangedPublicItem
-impl public_api::diff::ChangedPublicItem
-pub fn public_api::diff::ChangedPublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
 impl core::marker::Send for public_api::diff::ChangedPublicItem
 impl core::marker::Sync for public_api::diff::ChangedPublicItem
 impl core::marker::Unpin for public_api::diff::ChangedPublicItem
@@ -23,6 +23,9 @@ pub struct public_api::diff::PublicApiDiff
 pub public_api::diff::PublicApiDiff::added: alloc::vec::Vec<public_api::PublicItem>
 pub public_api::diff::PublicApiDiff::changed: alloc::vec::Vec<public_api::diff::ChangedPublicItem>
 pub public_api::diff::PublicApiDiff::removed: alloc::vec::Vec<public_api::PublicItem>
+impl public_api::diff::PublicApiDiff
+pub fn public_api::diff::PublicApiDiff::between(old: public_api::PublicApi, new: public_api::PublicApi) -> Self
+pub fn public_api::diff::PublicApiDiff::is_empty(&self) -> bool
 impl core::clone::Clone for public_api::diff::PublicApiDiff
 pub fn public_api::diff::PublicApiDiff::clone(&self) -> public_api::diff::PublicApiDiff
 impl core::cmp::Eq for public_api::diff::PublicApiDiff
@@ -32,9 +35,6 @@ impl core::fmt::Debug for public_api::diff::PublicApiDiff
 pub fn public_api::diff::PublicApiDiff::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralEq for public_api::diff::PublicApiDiff
 impl core::marker::StructuralPartialEq for public_api::diff::PublicApiDiff
-impl public_api::diff::PublicApiDiff
-pub fn public_api::diff::PublicApiDiff::between(old: public_api::PublicApi, new: public_api::PublicApi) -> Self
-pub fn public_api::diff::PublicApiDiff::is_empty(&self) -> bool
 impl core::marker::Send for public_api::diff::PublicApiDiff
 impl core::marker::Sync for public_api::diff::PublicApiDiff
 impl core::marker::Unpin for public_api::diff::PublicApiDiff
@@ -55,6 +55,9 @@ pub public_api::tokens::Token::Self_(alloc::string::String)
 pub public_api::tokens::Token::Symbol(alloc::string::String)
 pub public_api::tokens::Token::Type(alloc::string::String)
 pub public_api::tokens::Token::Whitespace
+impl public_api::tokens::Token
+pub fn public_api::tokens::Token::len(&self) -> usize
+pub fn public_api::tokens::Token::text(&self) -> &str
 impl core::clone::Clone for public_api::tokens::Token
 pub fn public_api::tokens::Token::clone(&self) -> public_api::tokens::Token
 impl core::cmp::Eq for public_api::tokens::Token
@@ -70,9 +73,6 @@ impl core::hash::Hash for public_api::tokens::Token
 pub fn public_api::tokens::Token::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralEq for public_api::tokens::Token
 impl core::marker::StructuralPartialEq for public_api::tokens::Token
-impl public_api::tokens::Token
-pub fn public_api::tokens::Token::len(&self) -> usize
-pub fn public_api::tokens::Token::text(&self) -> &str
 impl core::marker::Send for public_api::tokens::Token
 impl core::marker::Sync for public_api::tokens::Token
 impl core::marker::Unpin for public_api::tokens::Token
@@ -81,14 +81,14 @@ impl core::panic::unwind_safe::UnwindSafe for public_api::tokens::Token
 #[non_exhaustive] pub enum public_api::Error
 pub public_api::Error::IoError(std::io::error::Error)
 pub public_api::Error::SerdeJsonError(serde_json::error::Error)
-impl core::fmt::Debug for public_api::Error
-pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::convert::From<serde_json::error::Error> for public_api::Error
 pub fn public_api::Error::from(source: serde_json::error::Error) -> Self
 impl core::convert::From<std::io::error::Error> for public_api::Error
 pub fn public_api::Error::from(source: std::io::error::Error) -> Self
 impl core::error::Error for public_api::Error
 pub fn public_api::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for public_api::Error
+pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::Error
 pub fn public_api::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Send for public_api::Error
@@ -97,10 +97,6 @@ impl core::marker::Unpin for public_api::Error
 impl !core::panic::unwind_safe::RefUnwindSafe for public_api::Error
 impl !core::panic::unwind_safe::UnwindSafe for public_api::Error
 pub struct public_api::Builder
-impl core::clone::Clone for public_api::Builder
-pub fn public_api::Builder::clone(&self) -> public_api::Builder
-impl core::fmt::Debug for public_api::Builder
-pub fn public_api::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl public_api::Builder
 pub fn public_api::Builder::build(self) -> public_api::Result<public_api::PublicApi>
 pub fn public_api::Builder::debug_sorting(self, debug_sorting: bool) -> Self
@@ -109,18 +105,22 @@ pub fn public_api::Builder::omit_auto_derived_impls(self, omit_auto_derived_impl
 pub fn public_api::Builder::omit_auto_trait_impls(self, omit_auto_trait_impls: bool) -> Self
 pub fn public_api::Builder::omit_blanket_impls(self, omit_blanket_impls: bool) -> Self
 pub fn public_api::Builder::sorted(self, sorted: bool) -> Self
+impl core::clone::Clone for public_api::Builder
+pub fn public_api::Builder::clone(&self) -> public_api::Builder
+impl core::fmt::Debug for public_api::Builder
+pub fn public_api::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Send for public_api::Builder
 impl core::marker::Sync for public_api::Builder
 impl core::marker::Unpin for public_api::Builder
 impl core::panic::unwind_safe::RefUnwindSafe for public_api::Builder
 impl core::panic::unwind_safe::UnwindSafe for public_api::Builder
 #[non_exhaustive] pub struct public_api::PublicApi
-impl core::fmt::Debug for public_api::PublicApi
-pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl public_api::PublicApi
 pub fn public_api::PublicApi::into_items(self) -> impl core::iter::traits::iterator::Iterator<Item = public_api::PublicItem>
 pub fn public_api::PublicApi::items(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::PublicItem>
 pub fn public_api::PublicApi::missing_item_ids(&self) -> impl core::iter::traits::iterator::Iterator<Item = &alloc::string::String>
+impl core::fmt::Debug for public_api::PublicApi
+pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::PublicApi
 pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Send for public_api::PublicApi
@@ -129,11 +129,11 @@ impl core::marker::Unpin for public_api::PublicApi
 impl core::panic::unwind_safe::RefUnwindSafe for public_api::PublicApi
 impl core::panic::unwind_safe::UnwindSafe for public_api::PublicApi
 pub struct public_api::PublicItem
-impl core::clone::Clone for public_api::PublicItem
-pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
 impl public_api::PublicItem
 pub fn public_api::PublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
 pub fn public_api::PublicItem::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::tokens::Token>
+impl core::clone::Clone for public_api::PublicItem
+pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
 impl core::cmp::Eq for public_api::PublicItem
 impl core::cmp::PartialEq for public_api::PublicItem
 pub fn public_api::PublicItem::eq(&self, other: &Self) -> bool

--- a/cargo-public-api/tests/expected-output/subcommand_invocation_public_api_arg.txt
+++ b/cargo-public-api/tests/expected-output/subcommand_invocation_public_api_arg.txt
@@ -3,6 +3,8 @@ pub mod public_api::diff
 pub struct public_api::diff::ChangedPublicItem
 pub public_api::diff::ChangedPublicItem::new: public_api::PublicItem
 pub public_api::diff::ChangedPublicItem::old: public_api::PublicItem
+impl public_api::diff::ChangedPublicItem
+pub fn public_api::diff::ChangedPublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
 impl core::clone::Clone for public_api::diff::ChangedPublicItem
 pub fn public_api::diff::ChangedPublicItem::clone(&self) -> public_api::diff::ChangedPublicItem
 impl core::cmp::Eq for public_api::diff::ChangedPublicItem
@@ -12,12 +14,13 @@ impl core::fmt::Debug for public_api::diff::ChangedPublicItem
 pub fn public_api::diff::ChangedPublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralEq for public_api::diff::ChangedPublicItem
 impl core::marker::StructuralPartialEq for public_api::diff::ChangedPublicItem
-impl public_api::diff::ChangedPublicItem
-pub fn public_api::diff::ChangedPublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
 pub struct public_api::diff::PublicApiDiff
 pub public_api::diff::PublicApiDiff::added: alloc::vec::Vec<public_api::PublicItem>
 pub public_api::diff::PublicApiDiff::changed: alloc::vec::Vec<public_api::diff::ChangedPublicItem>
 pub public_api::diff::PublicApiDiff::removed: alloc::vec::Vec<public_api::PublicItem>
+impl public_api::diff::PublicApiDiff
+pub fn public_api::diff::PublicApiDiff::between(old: public_api::PublicApi, new: public_api::PublicApi) -> Self
+pub fn public_api::diff::PublicApiDiff::is_empty(&self) -> bool
 impl core::clone::Clone for public_api::diff::PublicApiDiff
 pub fn public_api::diff::PublicApiDiff::clone(&self) -> public_api::diff::PublicApiDiff
 impl core::cmp::Eq for public_api::diff::PublicApiDiff
@@ -27,9 +30,6 @@ impl core::fmt::Debug for public_api::diff::PublicApiDiff
 pub fn public_api::diff::PublicApiDiff::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralEq for public_api::diff::PublicApiDiff
 impl core::marker::StructuralPartialEq for public_api::diff::PublicApiDiff
-impl public_api::diff::PublicApiDiff
-pub fn public_api::diff::PublicApiDiff::between(old: public_api::PublicApi, new: public_api::PublicApi) -> Self
-pub fn public_api::diff::PublicApiDiff::is_empty(&self) -> bool
 pub mod public_api::tokens
 pub enum public_api::tokens::Token
 pub public_api::tokens::Token::Annotation(alloc::string::String)
@@ -45,6 +45,9 @@ pub public_api::tokens::Token::Self_(alloc::string::String)
 pub public_api::tokens::Token::Symbol(alloc::string::String)
 pub public_api::tokens::Token::Type(alloc::string::String)
 pub public_api::tokens::Token::Whitespace
+impl public_api::tokens::Token
+pub fn public_api::tokens::Token::len(&self) -> usize
+pub fn public_api::tokens::Token::text(&self) -> &str
 impl core::clone::Clone for public_api::tokens::Token
 pub fn public_api::tokens::Token::clone(&self) -> public_api::tokens::Token
 impl core::cmp::Eq for public_api::tokens::Token
@@ -60,27 +63,20 @@ impl core::hash::Hash for public_api::tokens::Token
 pub fn public_api::tokens::Token::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralEq for public_api::tokens::Token
 impl core::marker::StructuralPartialEq for public_api::tokens::Token
-impl public_api::tokens::Token
-pub fn public_api::tokens::Token::len(&self) -> usize
-pub fn public_api::tokens::Token::text(&self) -> &str
 #[non_exhaustive] pub enum public_api::Error
 pub public_api::Error::IoError(std::io::error::Error)
 pub public_api::Error::SerdeJsonError(serde_json::error::Error)
-impl core::fmt::Debug for public_api::Error
-pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::convert::From<serde_json::error::Error> for public_api::Error
 pub fn public_api::Error::from(source: serde_json::error::Error) -> Self
 impl core::convert::From<std::io::error::Error> for public_api::Error
 pub fn public_api::Error::from(source: std::io::error::Error) -> Self
 impl core::error::Error for public_api::Error
 pub fn public_api::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for public_api::Error
+pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::Error
 pub fn public_api::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct public_api::Builder
-impl core::clone::Clone for public_api::Builder
-pub fn public_api::Builder::clone(&self) -> public_api::Builder
-impl core::fmt::Debug for public_api::Builder
-pub fn public_api::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl public_api::Builder
 pub fn public_api::Builder::build(self) -> public_api::Result<public_api::PublicApi>
 pub fn public_api::Builder::debug_sorting(self, debug_sorting: bool) -> Self
@@ -89,21 +85,25 @@ pub fn public_api::Builder::omit_auto_derived_impls(self, omit_auto_derived_impl
 pub fn public_api::Builder::omit_auto_trait_impls(self, omit_auto_trait_impls: bool) -> Self
 pub fn public_api::Builder::omit_blanket_impls(self, omit_blanket_impls: bool) -> Self
 pub fn public_api::Builder::sorted(self, sorted: bool) -> Self
+impl core::clone::Clone for public_api::Builder
+pub fn public_api::Builder::clone(&self) -> public_api::Builder
+impl core::fmt::Debug for public_api::Builder
+pub fn public_api::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 #[non_exhaustive] pub struct public_api::PublicApi
-impl core::fmt::Debug for public_api::PublicApi
-pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl public_api::PublicApi
 pub fn public_api::PublicApi::into_items(self) -> impl core::iter::traits::iterator::Iterator<Item = public_api::PublicItem>
 pub fn public_api::PublicApi::items(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::PublicItem>
 pub fn public_api::PublicApi::missing_item_ids(&self) -> impl core::iter::traits::iterator::Iterator<Item = &alloc::string::String>
+impl core::fmt::Debug for public_api::PublicApi
+pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::PublicApi
 pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct public_api::PublicItem
-impl core::clone::Clone for public_api::PublicItem
-pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
 impl public_api::PublicItem
 pub fn public_api::PublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
 pub fn public_api::PublicItem::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::tokens::Token>
+impl core::clone::Clone for public_api::PublicItem
+pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
 impl core::cmp::Eq for public_api::PublicItem
 impl core::cmp::PartialEq for public_api::PublicItem
 pub fn public_api::PublicItem::eq(&self, other: &Self) -> bool

--- a/public-api/CHANGELOG.md
+++ b/public-api/CHANGELOG.md
@@ -1,7 +1,10 @@
 # `public-api` changelog
 
+## v0.33.1
+* Fixup 'Avoid textual API diff when changing a trait impl to an auto-derived impl.'
+
 ## v0.33.0
-* Avoid textual API diff when changing an inherent impl to an auto-derived impl.
+* Avoid textual API diff when changing a trait impl to an auto-derived impl.
 
 ## v0.32.0
 * Support `nightly-2023-08-25` and later

--- a/public-api/src/item_processor.rs
+++ b/public-api/src/item_processor.rs
@@ -351,8 +351,8 @@ pub(crate) fn sorting_prefix(item: &Item) -> u8 {
         ItemEnum::Impl(impl_) => match ImplKind::from(item, impl_) {
             // To not cause a diff when changing a manual impl to an
             // auto-derived impl (or vice versa), we put them in the same group.
-            ImplKind::Inherent | ImplKind::AutoDerived => 20,
-            ImplKind::Trait => 21,
+            ImplKind::Inherent => 20,
+            ImplKind::Trait | ImplKind::AutoDerived => 21,
             ImplKind::AutoTrait => 23,
             ImplKind::Blanket => 24,
         },

--- a/public-api/tests/public-api.txt
+++ b/public-api/tests/public-api.txt
@@ -3,6 +3,8 @@ pub mod public_api::diff
 pub struct public_api::diff::ChangedPublicItem
 pub public_api::diff::ChangedPublicItem::new: public_api::PublicItem
 pub public_api::diff::ChangedPublicItem::old: public_api::PublicItem
+impl public_api::diff::ChangedPublicItem
+pub fn public_api::diff::ChangedPublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
 impl core::clone::Clone for public_api::diff::ChangedPublicItem
 pub fn public_api::diff::ChangedPublicItem::clone(&self) -> public_api::diff::ChangedPublicItem
 impl core::cmp::Eq for public_api::diff::ChangedPublicItem
@@ -12,8 +14,6 @@ impl core::fmt::Debug for public_api::diff::ChangedPublicItem
 pub fn public_api::diff::ChangedPublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralEq for public_api::diff::ChangedPublicItem
 impl core::marker::StructuralPartialEq for public_api::diff::ChangedPublicItem
-impl public_api::diff::ChangedPublicItem
-pub fn public_api::diff::ChangedPublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
 impl core::marker::Send for public_api::diff::ChangedPublicItem
 impl core::marker::Sync for public_api::diff::ChangedPublicItem
 impl core::marker::Unpin for public_api::diff::ChangedPublicItem
@@ -43,6 +43,9 @@ pub struct public_api::diff::PublicApiDiff
 pub public_api::diff::PublicApiDiff::added: alloc::vec::Vec<public_api::PublicItem>
 pub public_api::diff::PublicApiDiff::changed: alloc::vec::Vec<public_api::diff::ChangedPublicItem>
 pub public_api::diff::PublicApiDiff::removed: alloc::vec::Vec<public_api::PublicItem>
+impl public_api::diff::PublicApiDiff
+pub fn public_api::diff::PublicApiDiff::between(old: public_api::PublicApi, new: public_api::PublicApi) -> Self
+pub fn public_api::diff::PublicApiDiff::is_empty(&self) -> bool
 impl core::clone::Clone for public_api::diff::PublicApiDiff
 pub fn public_api::diff::PublicApiDiff::clone(&self) -> public_api::diff::PublicApiDiff
 impl core::cmp::Eq for public_api::diff::PublicApiDiff
@@ -52,9 +55,6 @@ impl core::fmt::Debug for public_api::diff::PublicApiDiff
 pub fn public_api::diff::PublicApiDiff::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralEq for public_api::diff::PublicApiDiff
 impl core::marker::StructuralPartialEq for public_api::diff::PublicApiDiff
-impl public_api::diff::PublicApiDiff
-pub fn public_api::diff::PublicApiDiff::between(old: public_api::PublicApi, new: public_api::PublicApi) -> Self
-pub fn public_api::diff::PublicApiDiff::is_empty(&self) -> bool
 impl core::marker::Send for public_api::diff::PublicApiDiff
 impl core::marker::Sync for public_api::diff::PublicApiDiff
 impl core::marker::Unpin for public_api::diff::PublicApiDiff
@@ -95,6 +95,9 @@ pub public_api::tokens::Token::Self_(alloc::string::String)
 pub public_api::tokens::Token::Symbol(alloc::string::String)
 pub public_api::tokens::Token::Type(alloc::string::String)
 pub public_api::tokens::Token::Whitespace
+impl public_api::tokens::Token
+pub fn public_api::tokens::Token::len(&self) -> usize
+pub fn public_api::tokens::Token::text(&self) -> &str
 impl core::clone::Clone for public_api::tokens::Token
 pub fn public_api::tokens::Token::clone(&self) -> public_api::tokens::Token
 impl core::cmp::Eq for public_api::tokens::Token
@@ -110,9 +113,6 @@ impl core::hash::Hash for public_api::tokens::Token
 pub fn public_api::tokens::Token::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralEq for public_api::tokens::Token
 impl core::marker::StructuralPartialEq for public_api::tokens::Token
-impl public_api::tokens::Token
-pub fn public_api::tokens::Token::len(&self) -> usize
-pub fn public_api::tokens::Token::text(&self) -> &str
 impl core::marker::Send for public_api::tokens::Token
 impl core::marker::Sync for public_api::tokens::Token
 impl core::marker::Unpin for public_api::tokens::Token
@@ -141,14 +141,14 @@ pub fn public_api::tokens::Token::from(t: T) -> T
 #[non_exhaustive] pub enum public_api::Error
 pub public_api::Error::IoError(std::io::error::Error)
 pub public_api::Error::SerdeJsonError(serde_json::error::Error)
-impl core::fmt::Debug for public_api::Error
-pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::convert::From<serde_json::error::Error> for public_api::Error
 pub fn public_api::Error::from(source: serde_json::error::Error) -> Self
 impl core::convert::From<std::io::error::Error> for public_api::Error
 pub fn public_api::Error::from(source: std::io::error::Error) -> Self
 impl core::error::Error for public_api::Error
 pub fn public_api::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for public_api::Error
+pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::Error
 pub fn public_api::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Send for public_api::Error
@@ -175,10 +175,6 @@ pub fn public_api::Error::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for public_api::Error
 pub fn public_api::Error::from(t: T) -> T
 pub struct public_api::Builder
-impl core::clone::Clone for public_api::Builder
-pub fn public_api::Builder::clone(&self) -> public_api::Builder
-impl core::fmt::Debug for public_api::Builder
-pub fn public_api::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl public_api::Builder
 pub fn public_api::Builder::build(self) -> public_api::Result<public_api::PublicApi>
 pub fn public_api::Builder::debug_sorting(self, debug_sorting: bool) -> Self
@@ -187,6 +183,10 @@ pub fn public_api::Builder::omit_auto_derived_impls(self, omit_auto_derived_impl
 pub fn public_api::Builder::omit_auto_trait_impls(self, omit_auto_trait_impls: bool) -> Self
 pub fn public_api::Builder::omit_blanket_impls(self, omit_blanket_impls: bool) -> Self
 pub fn public_api::Builder::sorted(self, sorted: bool) -> Self
+impl core::clone::Clone for public_api::Builder
+pub fn public_api::Builder::clone(&self) -> public_api::Builder
+impl core::fmt::Debug for public_api::Builder
+pub fn public_api::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Send for public_api::Builder
 impl core::marker::Sync for public_api::Builder
 impl core::marker::Unpin for public_api::Builder
@@ -213,12 +213,12 @@ pub fn public_api::Builder::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for public_api::Builder
 pub fn public_api::Builder::from(t: T) -> T
 #[non_exhaustive] pub struct public_api::PublicApi
-impl core::fmt::Debug for public_api::PublicApi
-pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl public_api::PublicApi
 pub fn public_api::PublicApi::into_items(self) -> impl core::iter::traits::iterator::Iterator<Item = public_api::PublicItem>
 pub fn public_api::PublicApi::items(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::PublicItem>
 pub fn public_api::PublicApi::missing_item_ids(&self) -> impl core::iter::traits::iterator::Iterator<Item = &alloc::string::String>
+impl core::fmt::Debug for public_api::PublicApi
+pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::PublicApi
 pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Send for public_api::PublicApi
@@ -245,11 +245,11 @@ pub fn public_api::PublicApi::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for public_api::PublicApi
 pub fn public_api::PublicApi::from(t: T) -> T
 pub struct public_api::PublicItem
-impl core::clone::Clone for public_api::PublicItem
-pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
 impl public_api::PublicItem
 pub fn public_api::PublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
 pub fn public_api::PublicItem::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::tokens::Token>
+impl core::clone::Clone for public_api::PublicItem
+pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
 impl core::cmp::Eq for public_api::PublicItem
 impl core::cmp::PartialEq for public_api::PublicItem
 pub fn public_api::PublicItem::eq(&self, other: &Self) -> bool

--- a/repo-tests/Cargo.toml
+++ b/repo-tests/Cargo.toml
@@ -7,5 +7,5 @@ license = "MIT"
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.33.0"
+version = "0.33.1"
 

--- a/rustdoc-json/Cargo.toml
+++ b/rustdoc-json/Cargo.toml
@@ -28,4 +28,4 @@ default-features = false
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.33.0"
+version = "0.33.1"

--- a/rustdoc-json/tests/public-api.txt
+++ b/rustdoc-json/tests/public-api.txt
@@ -5,8 +5,6 @@ pub rustdoc_json::BuildError::CargoMetadataError(cargo_metadata::errors::Error)
 pub rustdoc_json::BuildError::General(alloc::string::String)
 pub rustdoc_json::BuildError::IoError(std::io::error::Error)
 pub rustdoc_json::BuildError::VirtualManifest(std::path::PathBuf)
-impl core::fmt::Debug for rustdoc_json::BuildError
-pub fn rustdoc_json::BuildError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::convert::From<cargo_manifest::error::Error> for rustdoc_json::BuildError
 pub fn rustdoc_json::BuildError::from(source: cargo_manifest::error::Error) -> Self
 impl core::convert::From<cargo_metadata::errors::Error> for rustdoc_json::BuildError
@@ -15,6 +13,8 @@ impl core::convert::From<std::io::error::Error> for rustdoc_json::BuildError
 pub fn rustdoc_json::BuildError::from(source: std::io::error::Error) -> Self
 impl core::error::Error for rustdoc_json::BuildError
 pub fn rustdoc_json::BuildError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for rustdoc_json::BuildError
+pub fn rustdoc_json::BuildError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for rustdoc_json::BuildError
 pub fn rustdoc_json::BuildError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Send for rustdoc_json::BuildError
@@ -78,10 +78,6 @@ pub fn rustdoc_json::PackageTarget::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for rustdoc_json::PackageTarget
 pub fn rustdoc_json::PackageTarget::from(t: T) -> T
 pub struct rustdoc_json::Builder
-impl core::clone::Clone for rustdoc_json::Builder
-pub fn rustdoc_json::Builder::clone(&self) -> rustdoc_json::Builder
-impl core::fmt::Debug for rustdoc_json::Builder
-pub fn rustdoc_json::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl rustdoc_json::Builder
 pub const fn rustdoc_json::Builder::all_features(self, all_features: bool) -> Self
 pub fn rustdoc_json::Builder::build(self) -> core::result::Result<std::path::PathBuf, rustdoc_json::BuildError>
@@ -100,8 +96,12 @@ pub fn rustdoc_json::Builder::target(self, target: alloc::string::String) -> Sel
 pub fn rustdoc_json::Builder::target_dir(self, target_dir: impl core::convert::AsRef<std::path::Path>) -> Self
 pub fn rustdoc_json::Builder::toolchain(self, toolchain: impl core::convert::Into<alloc::string::String>) -> Self
 pub const fn rustdoc_json::Builder::verbose(self, verbose: bool) -> Self
+impl core::clone::Clone for rustdoc_json::Builder
+pub fn rustdoc_json::Builder::clone(&self) -> rustdoc_json::Builder
 impl core::default::Default for rustdoc_json::Builder
 pub fn rustdoc_json::Builder::default() -> Self
+impl core::fmt::Debug for rustdoc_json::Builder
+pub fn rustdoc_json::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Send for rustdoc_json::Builder
 impl core::marker::Sync for rustdoc_json::Builder
 impl core::marker::Unpin for rustdoc_json::Builder

--- a/rustup-toolchain/Cargo.toml
+++ b/rustup-toolchain/Cargo.toml
@@ -22,4 +22,4 @@ version = "0.8.8"
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.33.0"
+version = "0.33.1"

--- a/rustup-toolchain/tests/public-api.txt
+++ b/rustup-toolchain/tests/public-api.txt
@@ -3,12 +3,12 @@ pub mod rustup_toolchain
 pub rustup_toolchain::Error::IoError(std::io::error::Error)
 pub rustup_toolchain::Error::RustupToolchainInstallError
 pub rustup_toolchain::Error::StdSyncPoisonError
-impl core::fmt::Debug for rustup_toolchain::Error
-pub fn rustup_toolchain::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::convert::From<std::io::error::Error> for rustup_toolchain::Error
 pub fn rustup_toolchain::Error::from(source: std::io::error::Error) -> Self
 impl core::error::Error for rustup_toolchain::Error
 pub fn rustup_toolchain::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for rustup_toolchain::Error
+pub fn rustup_toolchain::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for rustup_toolchain::Error
 pub fn rustup_toolchain::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Send for rustup_toolchain::Error


### PR DESCRIPTION
An inherent impl can't be changed to an auto-derived impl. It is _trait_ impls that can be changed to auto-derived impls.

The regression test I added in
https://github.com/Enselic/cargo-public-api/pull/516 failed without the (wrong) fix in https://github.com/Enselic/cargo-public-api/pull/516 and passed with the (wrong) fix, but that was just an accident.

This is a fix of the fix. Honestly I'm too lazy to come up with a regression test for the regression test. Clearly the fix was logically wrong in the first place, so I will re-use the regression test I already added also for this fix. I have confirmed that the regression test fails without the correct and wrong fix, but passes with the correct fix.