### PR TITLE
Make Rust 1.74 (and earlier) clippy pass

### DIFF
--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -160,7 +160,11 @@ fn renamed_binary_works_as_subcommand() {
     // Now copy the file (but make sure to clean up after the test)
     let regular_bin = bin_dir.join(format!("cargo-public-api{EXE_SUFFIX}"));
     let renamed_bin = RmOnDrop(bin_dir.join(format!("cargo-public-api-v0.13.0{EXE_SUFFIX}")));
-    #[allow(clippy::needless_borrow)] // False positive :(
+    #[allow(
+        unknown_lints,
+        clippy::needless_borrow,
+        clippy::needless_borrows_for_generic_args
+    )] // False positive :(
     std::fs::copy(regular_bin, &renamed_bin.0).unwrap();
 
     // Now the command should succeed


### PR DESCRIPTION
This will fix nightly: https://github.com/Enselic/cargo-public-api/actions/runs/7041688522

I'll try to fox this false positive upstream because it is quite annoying, especially now that it uses a different name in 1.73 and 1.74.

Edit: Upstream fix: https://github.com/rust-lang/rust-clippy/pull/11900 