### PR TITLE
Include all subcommands in top-level `--help` output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.5.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -51,9 +51,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "2.1.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -249,20 +249,19 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.0"
+version = "4.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d5f1946157a96594eb2d2c10eb7ad9a2b27518cb3000209dec700c35df9197d"
+checksum = "41fffed7514f420abec6d183b1d3acfd9099c79c3a10a06ade4f8203f1411272"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.0"
+version = "4.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78116e32a042dd73c2901f0dc30790d20ff3447f3e3472fad359e8c3d282bcd6"
+checksum = "63361bae7eef3771745f02d8d892bec2fee5f6e34af316ba556e7f97a7069ff1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -314,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.0"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9fd1a5729c4548118d7d70ff234a44868d00489a4b6597b0b020918a0e91a1a"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -326,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "colorchoice"
@@ -579,12 +578,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,17 +603,6 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -679,12 +661,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
@@ -957,20 +933,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4eb579851244c2c03e7c24f501c3432bed80b8f720af1d6e5b0e0f01555a035"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rustix"
 version = "0.38.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
@@ -978,7 +940,7 @@ dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
- "linux-raw-sys 0.4.10",
+ "linux-raw-sys",
  "windows-sys 0.48.0",
 ]
 
@@ -1139,17 +1101,17 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.4.1",
- "rustix 0.38.21",
+ "rustix",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "terminal_size"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "rustix 0.37.25",
+ "rustix",
  "windows-sys 0.48.0",
 ]
 

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -28,7 +28,7 @@ cargo_metadata = "0.18.1"
 toml = "0.8.2"
 
 [dependencies.clap]
-version = "4.4.0"
+version = "4.4.10"
 features = ["derive", "wrap_help"]
 
 [dependencies.curl]

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -352,7 +352,7 @@ fn main_task_from_diff_args(args: &Args, diff_args: &DiffArgs) -> Result<MainTas
         )
     }
 
-    let first_arg = diff_args.args.get(0);
+    let first_arg = diff_args.args.first();
     let second_arg = diff_args.args.get(1);
 
     let main_task = match (first_arg, second_arg) {

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -31,6 +31,7 @@ mod vendor;
     long_about = "List and diff the public API of Rust library crates between releases and commits. Website: https://github.com/Enselic/cargo-public-api",
     bin_name = "cargo public-api"
 )]
+#[command(flatten_help = true)]
 pub struct Args {
     /// Path to `Cargo.toml`.
     #[arg(long, value_name = "PATH", default_value = "Cargo.toml")]
@@ -145,8 +146,25 @@ struct DiffArgs {
     #[arg(long)]
     force: bool,
 
-    /// What to diff. See `cargo public-api diff --help` for examples and more
-    /// info.
+    #[clap(verbatim_doc_comment)]
+    /// What to diff.
+    ///
+    /// EXAMPLES
+    /// ========
+    ///
+    /// Diff current working tree version of `specific-crate` against published version 1.2.3:
+    ///
+    ///     cargo public-api -p specific-crate diff 1.2.3
+    ///
+    /// Diff between commits:
+    ///
+    ///     cargo public-api diff v0.2.0..v0.3.0
+    ///
+    /// See
+    ///
+    ///     cargo public-api diff --help
+    ///
+    /// for more examples and more info.
     args: Vec<String>,
 }
 
@@ -169,27 +187,27 @@ enum Subcommand {
     /// EXAMPLES:
     /// =========
     ///
-    /// Diffing a published version of a crate against the current working tree:
+    /// Diff a published version of a crate against the current working tree:
     ///
     ///     cargo public-api diff 1.2.3
     ///
-    /// Diffing the latest version of a crate against the current working tree:
+    /// Diff the latest version of a crate against the current working tree:
     ///
     ///     cargo public-api diff latest
     ///
-    /// Diffing between two published versions of any crate:
+    /// Diff between two published versions of any crate:
     ///
     ///     cargo public-api -p example_api diff 0.1.0 0.2.0
     ///
-    /// Diffing working tree against a published version of a specific crate in the workspace:
+    /// Diff current working tree version of `specific-crate` against published version 1.2.3:
     ///
     ///     cargo public-api -p specific-crate diff 1.2.3
     ///
-    /// Diffing between commits:
+    /// Diff between commits:
     ///
     ///     cargo public-api diff v0.2.0..v0.3.0
     ///
-    /// Diffing between rustdoc JSON files:
+    /// Diff between rustdoc JSON files:
     ///
     ///     cargo public-api diff first.json second.json
     ///

--- a/docs/long-diff-help.txt
+++ b/docs/long-diff-help.txt
@@ -15,27 +15,27 @@ If the diffing
 EXAMPLES:
 =========
 
-Diffing a published version of a crate against the current working tree:
+Diff a published version of a crate against the current working tree:
 
     cargo public-api diff 1.2.3
 
-Diffing the latest version of a crate against the current working tree:
+Diff the latest version of a crate against the current working tree:
 
     cargo public-api diff latest
 
-Diffing between two published versions of any crate:
+Diff between two published versions of any crate:
 
     cargo public-api -p example_api diff 0.1.0 0.2.0
 
-Diffing working tree against a published version of a specific crate in the workspace:
+Diff current working tree version of `specific-crate` against published version 1.2.3:
 
     cargo public-api -p specific-crate diff 1.2.3
 
-Diffing between commits:
+Diff between commits:
 
     cargo public-api diff v0.2.0..v0.3.0
 
-Diffing between rustdoc JSON files:
+Diff between rustdoc JSON files:
 
     cargo public-api diff first.json second.json
 
@@ -64,7 +64,24 @@ Usage: cargo public-api diff [OPTIONS] [ARGS]...
 
 Arguments:
   [ARGS]...
-          What to diff. See `cargo public-api diff --help` for examples and more info
+          What to diff.
+          
+          EXAMPLES
+          ========
+          
+          Diff current working tree version of `specific-crate` against published version 1.2.3:
+          
+              cargo public-api -p specific-crate diff 1.2.3
+          
+          Diff between commits:
+          
+              cargo public-api diff v0.2.0..v0.3.0
+          
+          See
+          
+              cargo public-api diff --help
+          
+          for more examples and more info.
 
 Options:
       --deny <DENY>

--- a/docs/long-help.txt
+++ b/docs/long-help.txt
@@ -1,12 +1,10 @@
 List and diff the public API of Rust library crates between releases and commits. Website:
 https://github.com/Enselic/cargo-public-api
 
-Usage: cargo public-api [OPTIONS] [COMMAND]
-
-Commands:
-  diff         Diff the public API against a published version of the crate, or between commits.
-  completions  Generate completion scripts for many different shells.
-  help         Print this message or the help of the given subcommand(s)
+Usage: cargo public-api [OPTIONS]
+       cargo public-api diff [OPTIONS] [ARGS]...
+       cargo public-api completions <SHELL>
+       cargo public-api help [COMMAND]...
 
 Options:
       --manifest-path <PATH>
@@ -66,3 +64,57 @@ Options:
 
   -V, --version
           Print version
+
+cargo public-api diff:
+Diff the public API against a published version of the crate, or between commits.
+      --deny <DENY>
+          Exit with failure if the specified API diff is detected.
+          
+          Can be combined. For example, to only allow additions to the API, use `--deny=added
+          --deny=changed`.
+
+          Possible values:
+          - all:     All forms of API diffs are denied: additions, changes, deletions
+          - added:   Deny added things in API diffs
+          - changed: Deny changed things in API diffs
+          - removed: Deny removed things in API diffs
+
+      --force
+          Force the diff. For example, when diffing commits, enabling this option will discard
+          working tree changes during git checkouts of other commits
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  [ARGS]...
+          What to diff.
+          
+          EXAMPLES
+          ========
+          
+          Diff current working tree version of `specific-crate` against published version 1.2.3:
+          
+              cargo public-api -p specific-crate diff 1.2.3
+          
+          Diff between commits:
+          
+              cargo public-api diff v0.2.0..v0.3.0
+          
+          See
+          
+              cargo public-api diff --help
+          
+          for more examples and more info.
+
+cargo public-api completions:
+Generate completion scripts for many different shells.
+  -h, --help
+          Print help (see a summary with '-h')
+
+  <SHELL>
+          [possible values: bash, elvish, fig, fish, nushell, powershell, zsh]
+
+cargo public-api help:
+Print this message or the help of the given subcommand(s)
+  [COMMAND]...
+          Print help for the subcommand(s)

--- a/docs/short-diff-help.txt
+++ b/docs/short-diff-help.txt
@@ -3,7 +3,7 @@ Diff the public API against a published version of the crate, or between commits
 Usage: cargo public-api diff [OPTIONS] [ARGS]...
 
 Arguments:
-  [ARGS]...  What to diff. See `cargo public-api diff --help` for examples and more info
+  [ARGS]...  What to diff.
 
 Options:
       --deny <DENY>  Exit with failure if the specified API diff is detected [possible values: all,

--- a/docs/short-help.txt
+++ b/docs/short-help.txt
@@ -1,11 +1,9 @@
 List and diff the public API of Rust library crates between releases and commits.
 
-Usage: cargo public-api [OPTIONS] [COMMAND]
-
-Commands:
-  diff         Diff the public API against a published version of the crate, or between commits.
-  completions  Generate completion scripts for many different shells.
-  help         Print this message or the help of the given subcommand(s)
+Usage: cargo public-api [OPTIONS]
+       cargo public-api diff [OPTIONS] [ARGS]...
+       cargo public-api completions <SHELL>
+       cargo public-api help [COMMAND]...
 
 Options:
       --manifest-path <PATH>    Path to `Cargo.toml` [default: Cargo.toml]
@@ -20,3 +18,21 @@ Options:
       --color [<COLOR>]         When to color the output [possible values: auto, never, always]
   -h, --help                    Print help (see more with '--help')
   -V, --version                 Print version
+
+cargo public-api diff:
+Diff the public API against a published version of the crate, or between commits.
+      --deny <DENY>  Exit with failure if the specified API diff is detected [possible values: all,
+                     added, changed, removed]
+      --force        Force the diff. For example, when diffing commits, enabling this option will
+                     discard working tree changes during git checkouts of other commits
+  -h, --help         Print help (see more with '--help')
+  [ARGS]...      What to diff.
+
+cargo public-api completions:
+Generate completion scripts for many different shells.
+  -h, --help   Print help (see more with '--help')
+  <SHELL>  [possible values: bash, elvish, fig, fish, nushell, powershell, zsh]
+
+cargo public-api help:
+Print this message or the help of the given subcommand(s)
+  [COMMAND]...  Print help for the subcommand(s)


### PR DESCRIPTION
So that users only have to issue one command to see how all subcommands are supposed to be used.

Closes #238