### PR TITLE
Remove `#[allow(clippy::needless_borrow)]` for fixed false positive

### DIFF
--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -160,11 +160,6 @@ fn renamed_binary_works_as_subcommand() {
     // Now copy the file (but make sure to clean up after the test)
     let regular_bin = bin_dir.join(format!("cargo-public-api{EXE_SUFFIX}"));
     let renamed_bin = RmOnDrop(bin_dir.join(format!("cargo-public-api-v0.13.0{EXE_SUFFIX}")));
-    #[allow(
-        unknown_lints,
-        clippy::needless_borrow,
-        clippy::needless_borrows_for_generic_args
-    )] // False positive :(
     std::fs::copy(regular_bin, &renamed_bin.0).unwrap();
 
     // Now the command should succeed

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -54,7 +54,7 @@ pub fn bat::PrettyPrinter::input_files<I, P>(&mut self, paths: I) -> &mut Self w
 
 ## Minimum required stable Rust version
 
-This project is guaranteed to build with the latest stable Rust toolchain. More specifically, the toolchain that is installed by default on GitHub's `ubuntu-latest` runner. You can see [here](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md#rust-tools) what version that currently is.
+This project is guaranteed to build with the latest stable Rust toolchain. More specifically, the toolchain that is installed by default on GitHub's `ubuntu-latest` runner. You can see [here](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#rust-tools) what version that currently is.
 
 Note that the toolchain required to build this project is distinct from the toolchain required to build the rustdoc JSON that this project relies on. See below for more info.
 


### PR DESCRIPTION
My [fix](https://github.com/rust-lang/rust-clippy/pull/11900) for the false positive has reached Rust 1.76 stable, so let's remove the annoying `allow`.