### PR TITLE
deny.toml: Migrate to licenses version = 2

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,13 +1,10 @@
 [licenses]
+version = 2
 allow = [
     "Apache-2.0",
     "MIT",
     "Unicode-DFS-2016",
 ]
-
-unlicensed = "deny"
-copyleft = "deny"
-default = "deny"
 
 [bans]
 wildcards = "deny"


### PR DESCRIPTION
See https://github.com/EmbarkStudios/cargo-deny/pull/611

By default unlicensed and copyleft is "deny", and exceptions has to be explicitly ignored.
