### PR TITLE
Remove `cargo public-api --toolchain foo` arg. Use `cargo +foo public-api` instead.

### DIFF
--- a/cargo-public-api/src/published_crate.rs
+++ b/cargo-public-api/src/published_crate.rs
@@ -3,12 +3,13 @@
 //! project.
 
 use crate::vendor::crates_index;
-use crate::{Args, LATEST_VERSION_ARG};
+use crate::{Args, ArgsAndToolchain, LATEST_VERSION_ARG};
 use anyhow::{anyhow, Context, Result};
 use crates_index::{Crate, Version};
 use std::path::PathBuf;
 
-pub fn build_rustdoc_json(version: Option<&str>, args: &Args) -> Result<PathBuf> {
+pub fn build_rustdoc_json(version: Option<&str>, argst: &ArgsAndToolchain) -> Result<PathBuf> {
+    let args = &argst.args;
     let package_name = package_name_from_args(args).ok_or_else(|| anyhow!("You must specify a package with either `-p package-name` or `--manifest-path path/to/Cargo.toml`"))?;
     let crate_ = http_get_crate(&package_name, args.verbose)?;
     let crate_version = get_crate_version(&crate_, version)?;
@@ -30,7 +31,7 @@ pub fn build_rustdoc_json(version: Option<&str>, args: &Args) -> Result<PathBuf>
     // `args.target_dir` is set, both the dummy crate and the real crate will
     // write to the same JSON path since they have the same project name! That
     // won't work. So always clear the target dir before we use the builder.
-    let builder = crate::api_source::builder_from_args(args)
+    let builder = crate::api_source::builder_from_args(argst)
         .clear_target_dir()
         .all_features(false)
         .features(Vec::<&str>::new())

--- a/cargo-public-api/src/toolchain.rs
+++ b/cargo-public-api/src/toolchain.rs
@@ -3,15 +3,8 @@
 ///
 /// See <https://rust-lang.github.io/rustup/overrides.html> for some
 /// more info of how different toolchains can be activated.
-pub fn is_probably_stable(toolchain: Option<&str>) -> bool {
-    let mut cmd = toolchain.map_or_else(
-        || std::process::Command::new("cargo"),
-        |toolchain| {
-            let mut cmd = std::process::Command::new("rustup");
-            cmd.args(["run", toolchain, "cargo"]);
-            cmd
-        },
-    );
+pub fn is_probably_stable() -> bool {
+    let mut cmd = std::process::Command::new("cargo");
     cmd.arg("--version");
 
     let Ok(output) = cmd.output() else {

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -176,8 +176,7 @@ fn renamed_binary_works_as_subcommand() {
 #[test]
 fn one_day_before_minimum_nightly_rust_version() {
     test_unusable_toolchain(
-        TestCmd::new()
-            .with_toolchain(&get_toolchain_one_day_before_minimal_toolchain())
+        TestCmd::with_proxy_toolchain(&get_toolchain_one_day_before_minimal_toolchain())
             .with_separate_target_dir(),
         &format!(
             "This version of `cargo public-api` requires at least:
@@ -197,9 +196,7 @@ fn one_day_before_minimum_nightly_rust_version() {
 #[test]
 fn compilation_error_toolchain() {
     test_unusable_toolchain(
-        TestCmd::new()
-            .with_toolchain(COMPILATION_ERROR_TOOLCHAIN)
-            .with_separate_target_dir(),
+        TestCmd::with_proxy_toolchain(COMPILATION_ERROR_TOOLCHAIN).with_separate_target_dir(),
         "generic associated types are unstable",
     );
 }
@@ -1346,12 +1343,6 @@ impl TestCmd {
     /// Disable colors to make asserts on output insensitive to color codes.
     fn without_cargo_colors(mut self) -> Self {
         self.cmd.env("CARGO_TERM_COLOR", "never");
-        self
-    }
-
-    fn with_toolchain(mut self, toolchain: &str) -> Self {
-        rustup_toolchain::install(toolchain).unwrap();
-        self.cmd.arg("--toolchain").arg(toolchain);
         self
     }
 


### PR DESCRIPTION
Maintaining both variants is too much work. From now on we only support `cargo +foo public-api`.

But users will normally not specify a toolchain explicitly and simply run `cargo public-api` instead.

This will make it easier to solve https://github.com/Enselic/cargo-public-api/issues/512.