### PR TITLE
Print a nice error message if `rustup` is not in `PATH`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,3 +82,5 @@ jobs:
       - run: rustup install nightly --profile minimal
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --locked
+      - run: scripts/cargo-test-without-rustup.sh
+        if: runner.os == 'Linux' # Fails on macOS (strangely) and Windows (expected)

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -12,6 +12,10 @@ categories = ["command-line-utilities", "development-tools::cargo-plugins"]
 license = "MIT"
 repository = "https://github.com/Enselic/cargo-public-api"
 
+[features]
+# Internal feature used by ./scripts/cargo-test-without-rustup.sh.
+test-without-rustup-in-path = []
+
 [dependencies]
 nu-ansi-term = "0.50.0"
 anyhow = "1.0.75"

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -201,6 +201,23 @@ fn compilation_error_toolchain() {
     );
 }
 
+/// Checks that we print a nice error message if rustup is not in PATH.
+/// `scripts/run-ci-locally.sh` runs this test for you.
+#[test]
+#[cfg_attr(
+    not(feature = "test-without-rustup-in-path"),
+    ignore = "requires absence of rustup from PATH"
+)]
+fn invocation_without_rustup_in_path() {
+    assert_cmd::Command::cargo_bin("cargo-public-api")
+        .unwrap()
+        .assert()
+        .stderr(predicates::str::contains(
+            "required program rustup not found in PATH. Is it installed?",
+        ))
+        .failure();
+}
+
 /// Test that we can specify a custom toolchain via the `+toolchain` mechanism.
 /// This also differs slightly from `compilation_error_toolchain()` by checking
 /// for a generic error message rather than a specific one.

--- a/scripts/cargo-test-without-rustup.sh
+++ b/scripts/cargo-test-without-rustup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -o nounset -o pipefail -o errexit -o xtrace
+
+RUSTUP="$(which rustup)"
+restore_rustup() {
+    mv "${RUSTUP}-disabled" "${RUSTUP}"
+}
+trap restore_rustup EXIT
+mv "${RUSTUP}" "${RUSTUP}-disabled"
+cargo test --locked --features test-without-rustup-in-path without_rustup_in_path

--- a/scripts/run-ci-locally.sh
+++ b/scripts/run-ci-locally.sh
@@ -18,6 +18,8 @@ cargo build --locked # Build with default features
 
 cargo test --locked
 
+scripts/cargo-test-without-rustup.sh
+
 if command -v cargo-audit >/dev/null; then
     scripts/cargo-audit.sh
 else


### PR DESCRIPTION
Closes https://github.com/Enselic/cargo-public-api/issues/512