### PR TITLE
Update release process; allow independent `public-api` and `cargo-public-api` releases

### DIFF
--- a/.github/workflows/Release-cargo-public-api.yml
+++ b/.github/workflows/Release-cargo-public-api.yml
@@ -21,26 +21,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Figure out what tag to use. Do this first since we want to ensure that
-      # the same tag is used for both public-api and cargo-public-api before we
-      # start to cargo publish. Currently cargo publish does not support
-      # publishing many crates at once. See
-      # https://github.com/rust-lang/cargo/issues/1169.
+      # Figure out what tag to use
       - name: calculate version
         id: version
         run: |
-          version=$(cargo read-manifest --manifest-path public-api/Cargo.toml | jq --raw-output .version)
-          version2=$(cargo read-manifest --manifest-path cargo-public-api/Cargo.toml | jq --raw-output .version)
-          if [ "$version" != "$version2" ]; then
-            echo "Version mismatch! Keep public-api and cargo-public-api versions in sync before you release! $version != $version2"
-            exit 42
-          fi
+          version=$(cargo read-manifest --manifest-path cargo-public-api/Cargo.toml | jq --raw-output .version)
           echo "GIT_TAG=v${version}" >> $GITHUB_OUTPUT
 
-      # Try to cargo publish public-api. If this succeeds we will tag the
+      # Try to cargo publish rustdoc-json. If this succeeds we will tag the
       # release. This is because we don't want to have a situation where a
       # version exists at crates.io but not as a git tag.
-      - run: cargo publish -p public-api
+      - run: cargo publish -p cargo-public-api
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
@@ -49,12 +40,6 @@ jobs:
         run: |
           git tag ${{ steps.version.outputs.GIT_TAG }}
           git push origin ${{ steps.version.outputs.GIT_TAG }}
-
-      # Now before we also create a GitHub Release, also try to cargo publish
-      # cargo-public-api.
-      - run: cargo publish -p cargo-public-api
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   release:
     needs: publish
@@ -67,11 +52,9 @@ jobs:
       - name: calculate version
         id: version
         run: |
-          version=$(cargo read-manifest --manifest-path public-api/Cargo.toml | jq --raw-output .version)
+          version=$(cargo read-manifest --manifest-path cargo-public-api/Cargo.toml | jq --raw-output .version)
           echo "GIT_TAG=v${version}" >> $GITHUB_OUTPUT
 
-      # OK, both public-api and cargo-public-api has been published under the
-      # same version. Create a GitHub Release now.
       - uses: softprops/action-gh-release@d4e8205d7e959a9107da6396278b2f1f07af0f9b # 2022-12-09
         with:
           tag_name: ${{ steps.version.outputs.GIT_TAG }}

--- a/.github/workflows/Release-public-api.yml
+++ b/.github/workflows/Release-public-api.yml
@@ -1,4 +1,4 @@
-name: Release rustup-toolchain
+name: Release public-api
 
 on:
   workflow_dispatch:
@@ -14,7 +14,7 @@ jobs:
     needs: ci
     environment:
       name: crates.io
-      url: https://crates.io/crates/rustup-toolchain
+      url: https://crates.io/crates/public-api
     runs-on: ubuntu-latest
     permissions:
       contents: write # git push
@@ -25,13 +25,13 @@ jobs:
       - name: calculate version
         id: version
         run: |
-          version=$(cargo read-manifest --manifest-path rustup-toolchain/Cargo.toml | jq --raw-output .version)
-          echo "GIT_TAG=rustup-toolchain-v${version}" >> $GITHUB_OUTPUT
+          version=$(cargo read-manifest --manifest-path public-api/Cargo.toml | jq --raw-output .version)
+          echo "GIT_TAG=public-api-v${version}" >> $GITHUB_OUTPUT
 
-      # Try to cargo publish rustup-toolchain. If this succeeds we will tag the
+      # Try to cargo publish public-api. If this succeeds we will tag the
       # release. This is because we don't want to have a situation where a
       # version exists at crates.io but not as a git tag.
-      - run: cargo publish -p rustup-toolchain
+      - run: cargo publish -p public-api
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
@@ -41,5 +41,5 @@ jobs:
           git tag ${{ steps.version.outputs.GIT_TAG }}
           git push origin ${{ steps.version.outputs.GIT_TAG }}
 
-      # Do not create a GitHub release. That is only done for public-api and
-      # cargo-public-api. A git tag is sufficient for rustup-toolchain.
+      # Do not create a GitHub release. That is only done for cargo-public-api.
+      # A git tag is sufficient for public-api.

--- a/.github/workflows/Release-rustdoc-json.yml
+++ b/.github/workflows/Release-rustdoc-json.yml
@@ -26,7 +26,6 @@ jobs:
         id: version
         run: |
           version=$(cargo read-manifest --manifest-path rustdoc-json/Cargo.toml | jq --raw-output .version)
-          echo "VERSION=${version}" >> $GITHUB_OUTPUT
           echo "GIT_TAG=rustdoc-json-v${version}" >> $GITHUB_OUTPUT
 
       # Try to cargo publish rustdoc-json. If this succeeds we will tag the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,3 @@
-[workspace.package]
-version = "0.33.1"
-
 [workspace]
 resolver = "2"
 members = [

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "cargo-public-api"
-version.workspace = true
+version = "0.33.1"
 default-run = "cargo-public-api"
 description = "List and diff the public API of Rust library crates between releases and commits. Detect breaking API changes and semver violations via CI or a CLI."
 homepage = "https://github.com/Enselic/cargo-public-api"

--- a/docs/MAINTAINER.md
+++ b/docs/MAINTAINER.md
@@ -22,19 +22,6 @@ The release philosophy of this project is that it is perfectly fine to make more
 
 There is one external event that usually means we want to make a release as soon as possible, ideally the same day: When the rustdoc JSON format in nightly changes from one day to the next. If this happens, our Nightly CI job will detect it. If we don't make a new release, users that follows the installation instructions in README.md will see `cargo public-api` failures, because the `cargo public-api` will not know how to parse the rustdoc JSON format of latest nightly.
 
-## Versioning strategy
-
-For `public-api` and `cargo-public-api` (which always have the same version number):
-
-* **x.0.0**: We bump to 1.0.0 earliest when the rustdoc JSON format has [stabilized](https://rust-lang.zulipchat.com/#narrow/stream/266220-rustdoc/topic/Rustdoc.20JSON.3A.20Stabilization.20criteria).
-
-* **0.x.0**: We bump it when
-  * The `public-api` lib or the `cargo-public-api` CLI has had backwards incompatible changes.
-  * When the `public-api` lib changes how items are rendered. This is because we want people that use the [`cargo test`](https://github.com/Enselic/cargo-public-api#-as-a-ci-check) approach to not have CI break just because they upgrade **0.0.x** version.
-  * When the rustdoc JSON parsing code changes in a backwards incompatible way.
-
-* **0.0.x**: We bump it whenever we want to make a release but we don't have to/want to bump 0.x.0
-
 ## How to release
 
 Please see [RELEASE.md](./RELEASE.md).

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,33 +1,51 @@
+## Versioning strategy
+
+* **x.0.0**: We bump to 1.0.0 earliest when the rustdoc JSON format has [stabilized](https://rust-lang.zulipchat.com/#narrow/stream/266220-rustdoc/topic/Rustdoc.20JSON.3A.20Stabilization.20criteria).
+
+* **0.x.0**: We bump it when
+  * There has been backwards incompatible changes.
+  * When `public-api` changes how items are rendered. This is because we want people that use the [`cargo test`](https://github.com/Enselic/cargo-public-api#-as-a-ci-check) approach to not have CI break just because they upgrade **0.0.x** version.
+  * When the rustdoc JSON parsing code changes in a backwards incompatible way.
+  * `public-api` and `cargo-public-api` does not need to have the same 0.x.0 version, but see the note below on bumping `MINIMUM_NIGHTLY_RUST_VERSION`.
+
+* **0.0.x**: We bump it whenever we want to make a release but we don't have to/want to bump 0.x.0
+
+### Bumping `MINIMUM_NIGHTLY_RUST_VERSION`
+
+If `MINIMUM_NIGHTLY_RUST_VERSION` must be bumped then
+* update the [compatibility matrix](https://github.com/Enselic/cargo-public-api#compatibility-matrix)
+* by necessity both `cargo-public-api` and `public-api` must be bumped to the same version to make the [compatibility matrix](https://github.com/Enselic/cargo-public-api#compatibility-matrix) consistent.
+* bump it in `cargo-public-api` [installation instructions](https://github.com/Enselic/cargo-public-api#installation)
+* `rm cargo-public-api/MINIMUM_NIGHTLY_RUST_VERSION_FOR_TESTS`
+
 ## How to release
 
-### `public-api` and `cargo-public-api`
+### `cargo-public-api`
 
-1. First release `rustdoc-json` and `rustup-toolchain` if needed. See below.
-1. Update `public-api/CHANGELOG.md`
-1. Create a PR that targets `main` that
-    1. Bumps version with `cargo set-version -p public-api x.y.z`
-    2. If you bump 0.x.0 version, also update the [compatibility matrix](https://github.com/Enselic/cargo-public-api#compatibility-matrix).
-    1. If `MINIMUM_NIGHTLY_RUST_VERSION` must be bumped, bump it. If you bump it, also
-        *  bump it in [compatibility matrix](https://github.com/Enselic/cargo-public-api#compatibility-matrix)
-        *  bump it in `cargo-public-api` [installation instructions](https://github.com/Enselic/cargo-public-api#installation)
-        * `rm cargo-public-api/MINIMUM_NIGHTLY_RUST_VERSION_FOR_TESTS`
-
-1. Preview what the auto-generated release-notes will look like by going [here](https://github.com/cargo-public-api/cargo-public-api.github.io/blob/main/release-notes-preview.md). It is automatically updated, but you can also trigger manually [here](https://github.com/Enselic/cargo-public-api/actions/workflows/Preview-release-notes.yml)
+1. First release `rustup-toolchain`, `rustdoc-json` and `public-api` if needed, in that order. See below.
+1. Run `tag=$(git tag --sort=-creatordate | grep ^v | head -n1) ; git diff $tag` to see what is new in the release.
+1. For each PR included in the release, adjust its `[category-*]` according to [release.yml](https://github.com/Enselic/cargo-public-api/blob/main/.github/release.yml) and tweak the PR title if necessary to turn it into good release note entry.
+1. Preview the [auto-generated release notes](https://github.com/cargo-public-api/cargo-public-api.github.io/blob/main/release-notes-preview.md) which our CI [continuously](https://github.com/Enselic/cargo-public-api/actions/workflows/Preview-release-notes.yml) updates.
     * The target audience for the release notes is users of the `cargo-public-api` CLI. But we also want to credit contributors to our libraries with a mention in the release notes, so we should also include such PRs in the release notes. For libs we also want to update the corresponding `CHANGELOG.md` file though.
-1. For each PR included in the release:
-    1. Label with `[category-exclude]` if it shall not be mentioned in the release notes.
-    1. Label with `[category-enhancement]` if it shall be in the "New Features" section in the auto-generated release notes.
-    1. Label with `[category-bugfix]` if it shall be in the "Bugfixes" section in the auto-generated release notes.
-    1. Label with `[category-other]` if it shall be in the "Other Changes" section in the auto-generated release notes.
-    1. Label with `[category-public-api]`/`[category-rustdoc-json]`/`[category-rustup-toolchain]` if it shall be in the "`public-api`/`rustdoc-json`/`rustup-toolchain` library" section in the auto-generated release notes.
-    1. Tweak the PR title if necessary so it makes up a good release notes entry
-1. Wait for CR of the PR created in step 2.
-1. Once reviewed and merged, run https://github.com/Enselic/cargo-public-api/actions/workflows/Release-cargo-public-api.yml workflow from `main` ([instructions](https://github.com/Enselic/cargo-public-api/blob/main/docs/development.md#how-to-trigger-main-branch-workflow))
+1. Bump version with `cargo set-version -p cargo-public-api x.y.z`
+    * If you bump 0.x.0 version, also update the [compatibility matrix](https://github.com/Enselic/cargo-public-api#compatibility-matrix).
+    * If `MINIMUM_NIGHTLY_RUST_VERSION` must be bumped, see [notes](./RELEASE.md#bumping-minimum_nightly_rust_version).
+1. Run https://github.com/Enselic/cargo-public-api/actions/workflows/Release-cargo-public-api.yml workflow from `main` ([instructions](https://github.com/Enselic/cargo-public-api/blob/main/docs/development.md#how-to-trigger-main-branch-workflow))
+1. Done!
+
+### `public-api`
+
+1. Run `tag=$(git tag --sort=-creatordate | grep ^public-api-v | head -n1) ; git diff $tag -- public-api/` to see if a release is needed.
+1. Update `public-api/CHANGELOG.md`
+1. Bump version with `cargo set-version -p public-api x.y.z`
+    * If you bump 0.x.0 version, also update the [compatibility matrix](https://github.com/Enselic/cargo-public-api#compatibility-matrix).
+    * If `MINIMUM_NIGHTLY_RUST_VERSION` must be bumped, see [notes](./RELEASE.md#bumping-minimum_nightly_rust_version).
+1. Run https://github.com/Enselic/cargo-public-api/actions/workflows/Release-rustdoc-json.yml workflow from `main` ([instructions](https://github.com/Enselic/cargo-public-api/blob/main/docs/development.md#how-to-trigger-main-branch-workflow))
 1. Done!
 
 ### `rustdoc-json`
 
-1. Run `tag=$(git tag --sort=-creatordate | grep ^rustdoc-json-v | head -n1) ; echo "Latest release is $tag" ; git diff $tag -- rustdoc-json/` to see if a release is needed.
+1. Run `tag=$(git tag --sort=-creatordate | grep ^rustdoc-json-v | head -n1) ; git diff $tag -- rustdoc-json/` to see if a release is needed.
 1. Update `rustdoc-json/CHANGELOG.md`
 1. Bump version with `cargo set-version -p rustdoc-json x.y.z`
 1. Run https://github.com/Enselic/cargo-public-api/actions/workflows/Release-rustdoc-json.yml workflow from `main` ([instructions](https://github.com/Enselic/cargo-public-api/blob/main/docs/development.md#how-to-trigger-main-branch-workflow))
@@ -35,7 +53,7 @@
 
 ### `rustup-toolchain`
 
-1. Run `tag=$(git tag --sort=-creatordate | grep ^rustup-toolchain-v | head -n1) ; echo "Latest release is $tag" ; git diff $tag -- rustup-toolchain/` to see if a release is needed.
+1. Run `tag=$(git tag --sort=-creatordate | grep ^rustup-toolchain-v | head -n1) ; git diff $tag -- rustup-toolchain/` to see if a release is needed.
 1. Update `rustup-toolchain/CHANGELOG.md`
 1. Bump version with `cargo set-version -p rustup-toolchain x.y.z`
 1. Run https://github.com/Enselic/cargo-public-api/actions/workflows/Release-rustup-toolchain.yml workflow from `main` ([instructions](https://github.com/Enselic/cargo-public-api/blob/main/docs/development.md#how-to-trigger-main-branch-workflow))

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "public-api"
-version.workspace = true
+version = "0.33.1"
 description = "List and diff the public API of Rust library crates. Relies on rustdoc JSON output from the nightly toolchain."
 homepage = "https://github.com/Enselic/cargo-public-api/tree/main/public-api"
 documentation = "https://docs.rs/public-api"


### PR DESCRIPTION
The compatibility matrix still holds, and bumping `MINIMUM_NIGHTLY_RUST_VERSION` requires bumping both `public-api` and `cargo-public-api` to the same version (as detailed in the updated instructions), but apart from that we can release them separately.

There is currently no reason for us to release a new version of `public-api`, but I want to make a new 0.x.0 release of `cargo-public-api`. That is the background to this change.

Both projects are pretty mature by now, so while it made sense to keep them coupled together before, I think now is the time to start to release them separately.