### PR TITLE
Make diffing against published crate work when its `[package] name` is not the same as its `[lib] name`

### DIFF
--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -857,6 +857,18 @@ fn diff_against_published_version() {
         .success();
 }
 
+#[test]
+fn diff_against_published_version_with_lib_name_different_from_package_name() {
+    let mut cmd = TestCmd::new();
+    cmd.arg("--manifest-path");
+    cmd.arg("../test-apis/other-lib-name/Cargo.toml");
+    cmd.arg("diff");
+    cmd.arg("0.1.0");
+    cmd.assert()
+        .stdout_or_update("./expected-output/other-lib-name-diff.txt")
+        .success();
+}
+
 /// Tests that we can diff between two published versions of an arbitrary crate
 /// that does not need to be in the current workspace.
 #[test]

--- a/cargo-public-api/tests/expected-output/other-lib-name-diff.txt
+++ b/cargo-public-api/tests/expected-output/other-lib-name-diff.txt
@@ -1,0 +1,12 @@
+Removed items from the public API
+=================================
+(none)
+
+Changed items in the public API
+===============================
+(none)
+
+Added items to the public API
+=============================
+(none)
+


### PR DESCRIPTION
By correcting how the path to the built rustdoc JSON is determined.

Closes https://github.com/Enselic/cargo-public-api/issues/561

I have confirmed that the added regression test fails without the fix.