### PR TITLE
Make most CLI options global so they also work as subcommand args (e.g. `cargo public-api diff --package=...`)

### DIFF
--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -34,11 +34,11 @@ mod vendor;
 #[command(flatten_help = true)]
 pub struct Args {
     /// Path to `Cargo.toml`.
-    #[arg(long, value_name = "PATH", default_value = "Cargo.toml")]
+    #[arg(global = true, long, value_name = "PATH", default_value = "Cargo.toml")]
     manifest_path: PathBuf,
 
     /// Name of package in workspace to list or diff the public API for.
-    #[arg(long, short)]
+    #[arg(global = true, long, short)]
     package: Option<String>,
 
     /// Omit noisy items. Can be used more than once.
@@ -49,34 +49,34 @@ pub struct Args {
     /// | -ss   | --omit blanket-impls,auto-trait-impls                    |
     /// | -sss  | --omit blanket-impls,auto-trait-impls,auto-derived-impls |
     #[clap(verbatim_doc_comment)]
-    #[arg(short, long, action = clap::ArgAction::Count)]
+    #[arg(global = true, short, long, action = clap::ArgAction::Count)]
     simplified: u8,
 
     /// Omit specified items.
-    #[arg(long, value_enum, value_delimiter = ',')]
+    #[arg(global = true, long, value_enum, value_delimiter = ',')]
     omit: Option<Vec<Omit>>,
 
     /// Space or comma separated list of features to activate
-    #[arg(long, short = 'F', num_args = 1..)]
+    #[arg(global = true, long, short = 'F', num_args = 1..)]
     features: Vec<String>,
 
     /// Activate all available features
-    #[arg(long)]
+    #[arg(global = true, long)]
     all_features: bool,
 
     /// Do not activate the `default` feature
-    #[arg(long)]
+    #[arg(global = true, long)]
     no_default_features: bool,
 
     /// Build for the target triple
-    #[arg(long)]
+    #[arg(global = true, long)]
     target: Option<String>,
 
     /// When to color the output.
     ///
     /// By default, `--color=auto` is active. Using just `--color` without an
     /// arg is equivalent to `--color=always`.
-    #[arg(long, value_enum)]
+    #[arg(global = true, long, value_enum)]
     color: Option<Option<Color>>,
 
     /// List the public API based on the given rustdoc JSON file.
@@ -91,31 +91,31 @@ pub struct Args {
     ///
     ///     cargo public-api --rustdoc-json ~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/share/doc/rust/json/std.json
     ///
-    #[arg(long, value_name = "RUSTDOC_JSON_PATH", hide = true)]
+    #[arg(global = true, long, value_name = "RUSTDOC_JSON_PATH", hide = true)]
     rustdoc_json: Option<String>,
 
     /// Show detailed info about processing.
     ///
     /// For debugging purposes. The output is not stable and can change across
     /// patch versions.
-    #[arg(long, hide = true)]
+    #[arg(global = true, long, hide = true)]
     verbose: bool,
 
     /// Show the hidden "sorting prefix" that makes items nicely grouped
     ///
     /// Only intended for debugging this tool.
-    #[arg(long, hide = true)]
+    #[arg(global = true, long, hide = true)]
     debug_sorting: bool,
 
     /// Where to put rustdoc JSON build artifacts.
     ///
     /// Hidden by default because it will typically not be needed by users.
     /// Mainly useful to allow tests to run in parallel.
-    #[arg(long, value_name = "PATH", hide = true)]
+    #[arg(global = true, long, value_name = "PATH", hide = true)]
     target_dir: Option<PathBuf>,
 
     /// Forwarded to rustdoc JSON build command
-    #[arg(long, hide = true)]
+    #[arg(global = true, long, hide = true)]
     cap_lints: Option<String>,
 
     #[command(subcommand)]

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -799,6 +799,17 @@ fn diff_public_items_with_color() {
 }
 
 #[test]
+fn diff_public_items_with_color_arg_after_diff_subcommand() {
+    let mut cmd = TestCmd::new().with_test_repo();
+    cmd.arg("diff");
+    cmd.arg("v0.1.0..v0.2.0");
+    cmd.arg("--color=always");
+    cmd.assert()
+        .stdout_or_update("./expected-output/example_api_diff_v0.1.0_to_v0.2.0_colored.txt")
+        .success();
+}
+
+#[test]
 fn list_public_items_with_color() {
     list_public_items_with_color_impl("--color=always");
 }
@@ -943,6 +954,18 @@ fn diff_published_explicit_package() {
     cmd.arg("example_api");
     cmd.arg("diff");
     cmd.arg("0.1.0");
+    cmd.assert()
+        .stdout_or_update("./expected-output/diff_published.txt")
+        .success();
+}
+
+#[test]
+fn diff_published_explicit_package_after_diff_subcommand() {
+    let mut cmd = TestCmd::new().with_test_repo();
+    cmd.arg("diff");
+    cmd.arg("0.1.0");
+    cmd.arg("-p");
+    cmd.arg("example_api");
     cmd.assert()
         .stdout_or_update("./expected-output/diff_published.txt")
         .success();

--- a/docs/long-completions-help.txt
+++ b/docs/long-completions-help.txt
@@ -14,12 +14,64 @@ Example on how to generate and install the completion script for zsh:
    --debug-sorting        -- Show the hidden "sorting prefix" that makes items nicely grouped
    [...]
 
-Usage: cargo public-api completions <SHELL>
+Usage: cargo public-api completions [OPTIONS] <SHELL>
 
 Arguments:
   <SHELL>
           [possible values: bash, elvish, fig, fish, nushell, powershell, zsh]
 
 Options:
+      --manifest-path <PATH>
+          Path to `Cargo.toml`
+          
+          [default: Cargo.toml]
+
+  -p, --package <PACKAGE>
+          Name of package in workspace to list or diff the public API for
+
+  -s, --simplified...
+          Omit noisy items. Can be used more than once.
+          
+          | Usage | Corresponds to                                           |
+          |-------|----------------------------------------------------------|
+          | -s    | --omit blanket-impls                                     |
+          | -ss   | --omit blanket-impls,auto-trait-impls                    |
+          | -sss  | --omit blanket-impls,auto-trait-impls,auto-derived-impls |
+
+      --omit <OMIT>
+          Omit specified items
+
+          Possible values:
+          - blanket-impls:      Omit items that belong to Blanket Implementations such as `impl<T>
+            Any for T`, `impl<T> Borrow<T> for T`, and `impl<T, U> Into<U> for T where U: From<T>`
+          - auto-trait-impls:   Omit items that belong to Auto Trait Implementations such as `impl
+            Send for ...`, `impl Sync for ...`, and `impl Unpin for ...`
+          - auto-derived-impls: Omit items that belong to Auto Derived Implementations such as
+            `Clone`, `Debug`, and `Eq`
+
+  -F, --features <FEATURES>...
+          Space or comma separated list of features to activate
+
+      --all-features
+          Activate all available features
+
+      --no-default-features
+          Do not activate the `default` feature
+
+      --target <TARGET>
+          Build for the target triple
+
+      --color [<COLOR>]
+          When to color the output.
+          
+          By default, `--color=auto` is active. Using just `--color` without an arg is equivalent to
+          `--color=always`.
+
+          Possible values:
+          - auto:   Colors will be used if stdout is a terminal. Colors will not be used if stdout
+            is a regular file
+          - never:  Colors will never be used
+          - always: Colors will always be used
+
   -h, --help
           Print help (see a summary with '-h')

--- a/docs/long-diff-help.txt
+++ b/docs/long-diff-help.txt
@@ -96,9 +96,61 @@ Options:
           - changed: Deny changed things in API diffs
           - removed: Deny removed things in API diffs
 
+      --manifest-path <PATH>
+          Path to `Cargo.toml`
+          
+          [default: Cargo.toml]
+
       --force
           Force the diff. For example, when diffing commits, enabling this option will discard
           working tree changes during git checkouts of other commits
+
+  -p, --package <PACKAGE>
+          Name of package in workspace to list or diff the public API for
+
+  -s, --simplified...
+          Omit noisy items. Can be used more than once.
+          
+          | Usage | Corresponds to                                           |
+          |-------|----------------------------------------------------------|
+          | -s    | --omit blanket-impls                                     |
+          | -ss   | --omit blanket-impls,auto-trait-impls                    |
+          | -sss  | --omit blanket-impls,auto-trait-impls,auto-derived-impls |
+
+      --omit <OMIT>
+          Omit specified items
+
+          Possible values:
+          - blanket-impls:      Omit items that belong to Blanket Implementations such as `impl<T>
+            Any for T`, `impl<T> Borrow<T> for T`, and `impl<T, U> Into<U> for T where U: From<T>`
+          - auto-trait-impls:   Omit items that belong to Auto Trait Implementations such as `impl
+            Send for ...`, `impl Sync for ...`, and `impl Unpin for ...`
+          - auto-derived-impls: Omit items that belong to Auto Derived Implementations such as
+            `Clone`, `Debug`, and `Eq`
+
+  -F, --features <FEATURES>...
+          Space or comma separated list of features to activate
+
+      --all-features
+          Activate all available features
+
+      --no-default-features
+          Do not activate the `default` feature
+
+      --target <TARGET>
+          Build for the target triple
+
+      --color [<COLOR>]
+          When to color the output.
+          
+          By default, `--color=auto` is active. Using just `--color` without an arg is equivalent to
+          `--color=always`.
+
+          Possible values:
+          - auto:   Colors will be used if stdout is a terminal. Colors will not be used if stdout
+            is a regular file
+          - never:  Colors will never be used
+          - always: Colors will always be used
 
   -h, --help
           Print help (see a summary with '-h')

--- a/docs/long-help.txt
+++ b/docs/long-help.txt
@@ -3,7 +3,7 @@ https://github.com/Enselic/cargo-public-api
 
 Usage: cargo public-api [OPTIONS]
        cargo public-api diff [OPTIONS] [ARGS]...
-       cargo public-api completions <SHELL>
+       cargo public-api completions [OPTIONS] <SHELL>
        cargo public-api help [COMMAND]...
 
 Options:

--- a/docs/short-completions-help.txt
+++ b/docs/short-completions-help.txt
@@ -1,9 +1,19 @@
 Generate completion scripts for many different shells.
 
-Usage: cargo public-api completions <SHELL>
+Usage: cargo public-api completions [OPTIONS] <SHELL>
 
 Arguments:
   <SHELL>  [possible values: bash, elvish, fig, fish, nushell, powershell, zsh]
 
 Options:
-  -h, --help  Print help (see more with '--help')
+      --manifest-path <PATH>    Path to `Cargo.toml` [default: Cargo.toml]
+  -p, --package <PACKAGE>       Name of package in workspace to list or diff the public API for
+  -s, --simplified...           Omit noisy items. Can be used more than once.
+      --omit <OMIT>             Omit specified items [possible values: blanket-impls,
+                                auto-trait-impls, auto-derived-impls]
+  -F, --features <FEATURES>...  Space or comma separated list of features to activate
+      --all-features            Activate all available features
+      --no-default-features     Do not activate the `default` feature
+      --target <TARGET>         Build for the target triple
+      --color [<COLOR>]         When to color the output [possible values: auto, never, always]
+  -h, --help                    Print help (see more with '--help')

--- a/docs/short-diff-help.txt
+++ b/docs/short-diff-help.txt
@@ -6,8 +6,19 @@ Arguments:
   [ARGS]...  What to diff.
 
 Options:
-      --deny <DENY>  Exit with failure if the specified API diff is detected [possible values: all,
-                     added, changed, removed]
-      --force        Force the diff. For example, when diffing commits, enabling this option will
-                     discard working tree changes during git checkouts of other commits
-  -h, --help         Print help (see more with '--help')
+      --deny <DENY>             Exit with failure if the specified API diff is detected [possible
+                                values: all, added, changed, removed]
+      --manifest-path <PATH>    Path to `Cargo.toml` [default: Cargo.toml]
+      --force                   Force the diff. For example, when diffing commits, enabling this
+                                option will discard working tree changes during git checkouts of
+                                other commits
+  -p, --package <PACKAGE>       Name of package in workspace to list or diff the public API for
+  -s, --simplified...           Omit noisy items. Can be used more than once.
+      --omit <OMIT>             Omit specified items [possible values: blanket-impls,
+                                auto-trait-impls, auto-derived-impls]
+  -F, --features <FEATURES>...  Space or comma separated list of features to activate
+      --all-features            Activate all available features
+      --no-default-features     Do not activate the `default` feature
+      --target <TARGET>         Build for the target triple
+      --color [<COLOR>]         When to color the output [possible values: auto, never, always]
+  -h, --help                    Print help (see more with '--help')

--- a/docs/short-help.txt
+++ b/docs/short-help.txt
@@ -2,7 +2,7 @@ List and diff the public API of Rust library crates between releases and commits
 
 Usage: cargo public-api [OPTIONS]
        cargo public-api diff [OPTIONS] [ARGS]...
-       cargo public-api completions <SHELL>
+       cargo public-api completions [OPTIONS] <SHELL>
        cargo public-api help [COMMAND]...
 
 Options:


### PR DESCRIPTION
Before, the following would not work, because the `--package` and `--color` options were not allowed after subcommands such as `diff`

    cargo public-api diff --package foo --color always

Now that command works. The help texts becomes more noisy, but I think that is a fair price.

I added a couple of regression tests that fails without the fix, but I did not bother to be exhaustive.