### PR TITLE
Allow `stdout` and `stderr` of rustdoc JSON building to be captured with new `rustdoc_json::Builder::build_with_captured_output(self, stdout: impl Write, stderr: impl Write)` function

### DIFF
--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -243,7 +243,7 @@ fn invocation_without_rustup_in_path() {
 fn custom_toolchain_via_proxy() {
     test_unusable_toolchain(
         TestCmd::with_proxy_toolchain(COMPILATION_ERROR_TOOLCHAIN).with_separate_target_dir(),
-        "Failed to build crate",
+        "Failed to build rustdoc JSON",
     );
 }
 

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -243,7 +243,7 @@ fn invocation_without_rustup_in_path() {
 fn custom_toolchain_via_proxy() {
     test_unusable_toolchain(
         TestCmd::with_proxy_toolchain(COMPILATION_ERROR_TOOLCHAIN).with_separate_target_dir(),
-        "Failed to build rustdoc JSON",
+        "Failed to build crate",
     );
 }
 

--- a/rustdoc-json/src/lib.rs
+++ b/rustdoc-json/src/lib.rs
@@ -38,12 +38,23 @@ pub enum BuildError {
     #[error("Failed to build rustdoc JSON: {0}")]
     General(String),
 
-    /// An error originating from building the crate's documentation.
+    /// An error originating from building the rustdoc JSON for a crate.
     ///
-    /// In this case the user will see the errors on stderr, unless the `cargo rustdoc` output is
-    /// captured (by using [`Builder::build_with_captured_output()`]).
-    #[error("Failed to build crate (see stderr)")]
-    CrateBuildError,
+    /// In this case the user will see the exact errors on stderr, regardless of
+    /// if stderr was printed to the terminal or captured with
+    /// [`Builder::build_with_captured_output()`].
+    #[error("Failed to build rustdoc JSON (see stderr)")]
+    BuildRustdocJsonError,
+
+    /// Occcurs when stdout or stderr could not be captured when using
+    /// [`Builder::build_with_captured_output()`]).
+    #[error("Failed to capture output: {0}")]
+    CapturedOutputError(String),
+
+    /// Occurs when a command could not be executed, e.g. because the binary
+    /// that we tried to run did not exist.
+    #[error("Failed to execute: {0}")]
+    CommandExecutionError(String),
 
     /// An error originating from `cargo-manifest`.
     #[error(transparent)]

--- a/rustdoc-json/src/lib.rs
+++ b/rustdoc-json/src/lib.rs
@@ -23,7 +23,7 @@
 use std::path::PathBuf;
 
 mod builder;
-pub use builder::{Builder, PackageTarget};
+pub use builder::{Builder, Color, PackageTarget};
 
 /// Represents all errors that can occur when using [`Builder::build()`].
 #[derive(thiserror::Error, Debug)]
@@ -37,6 +37,13 @@ pub enum BuildError {
     /// A general error. Refer to the attached error message for more info.
     #[error("Failed to build rustdoc JSON: {0}")]
     General(String),
+
+    /// An error originating from building the crate's documentation.
+    ///
+    /// In this case the user will see the errors on stderr, unless the `cargo rustdoc` output is
+    /// captured (by using [`Builder::build_with_captured_output()`]).
+    #[error("Failed to build crate (see stderr)")]
+    CrateBuildError,
 
     /// An error originating from `cargo-manifest`.
     #[error(transparent)]

--- a/rustdoc-json/tests/public-api.txt
+++ b/rustdoc-json/tests/public-api.txt
@@ -2,6 +2,7 @@ pub mod rustdoc_json
 #[non_exhaustive] pub enum rustdoc_json::BuildError
 pub rustdoc_json::BuildError::CargoManifestError(cargo_manifest::error::Error)
 pub rustdoc_json::BuildError::CargoMetadataError(cargo_metadata::errors::Error)
+pub rustdoc_json::BuildError::CrateBuildError
 pub rustdoc_json::BuildError::General(alloc::string::String)
 pub rustdoc_json::BuildError::IoError(std::io::error::Error)
 pub rustdoc_json::BuildError::VirtualManifest(std::path::PathBuf)
@@ -43,6 +44,43 @@ impl<T> core::convert::From<T> for rustdoc_json::BuildError
 pub fn rustdoc_json::BuildError::from(t: T) -> T
 impl<T> tracing::instrument::Instrument for rustdoc_json::BuildError
 impl<T> tracing::instrument::WithSubscriber for rustdoc_json::BuildError
+pub enum rustdoc_json::Color
+pub rustdoc_json::Color::Always
+pub rustdoc_json::Color::Auto
+pub rustdoc_json::Color::Never
+impl core::clone::Clone for rustdoc_json::Color
+pub fn rustdoc_json::Color::clone(&self) -> rustdoc_json::Color
+impl core::fmt::Debug for rustdoc_json::Color
+pub fn rustdoc_json::Color::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for rustdoc_json::Color
+impl core::marker::Freeze for rustdoc_json::Color
+impl core::marker::Send for rustdoc_json::Color
+impl core::marker::Sync for rustdoc_json::Color
+impl core::marker::Unpin for rustdoc_json::Color
+impl core::panic::unwind_safe::RefUnwindSafe for rustdoc_json::Color
+impl core::panic::unwind_safe::UnwindSafe for rustdoc_json::Color
+impl<T, U> core::convert::Into<U> for rustdoc_json::Color where U: core::convert::From<T>
+pub fn rustdoc_json::Color::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for rustdoc_json::Color where U: core::convert::Into<T>
+pub type rustdoc_json::Color::Error = core::convert::Infallible
+pub fn rustdoc_json::Color::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for rustdoc_json::Color where U: core::convert::TryFrom<T>
+pub type rustdoc_json::Color::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn rustdoc_json::Color::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for rustdoc_json::Color where T: core::clone::Clone
+pub type rustdoc_json::Color::Owned = T
+pub fn rustdoc_json::Color::clone_into(&self, target: &mut T)
+pub fn rustdoc_json::Color::to_owned(&self) -> T
+impl<T> core::any::Any for rustdoc_json::Color where T: 'static + core::marker::Sized
+pub fn rustdoc_json::Color::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for rustdoc_json::Color where T: core::marker::Sized
+pub fn rustdoc_json::Color::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for rustdoc_json::Color where T: core::marker::Sized
+pub fn rustdoc_json::Color::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for rustdoc_json::Color
+pub fn rustdoc_json::Color::from(t: T) -> T
+impl<T> tracing::instrument::Instrument for rustdoc_json::Color
+impl<T> tracing::instrument::WithSubscriber for rustdoc_json::Color
 #[non_exhaustive] pub enum rustdoc_json::PackageTarget
 pub rustdoc_json::PackageTarget::Bench(alloc::string::String)
 pub rustdoc_json::PackageTarget::Bin(alloc::string::String)
@@ -87,9 +125,11 @@ pub struct rustdoc_json::Builder
 impl rustdoc_json::Builder
 pub const fn rustdoc_json::Builder::all_features(self, all_features: bool) -> Self
 pub fn rustdoc_json::Builder::build(self) -> core::result::Result<std::path::PathBuf, rustdoc_json::BuildError>
+pub fn rustdoc_json::Builder::build_with_captured_output(self, stdout: impl std::io::Write, stderr: impl std::io::Write) -> core::result::Result<std::path::PathBuf, rustdoc_json::BuildError>
 pub fn rustdoc_json::Builder::cap_lints(self, cap_lints: core::option::Option<impl core::convert::AsRef<str>>) -> Self
 pub fn rustdoc_json::Builder::clear_target_dir(self) -> Self
 pub fn rustdoc_json::Builder::clear_toolchain(self) -> Self
+pub const fn rustdoc_json::Builder::color(self, color: rustdoc_json::Color) -> Self
 pub fn rustdoc_json::Builder::document_private_items(self, document_private_items: bool) -> Self
 pub fn rustdoc_json::Builder::features<I: core::iter::traits::collect::IntoIterator<Item = S>, S: core::convert::AsRef<str>>(self, features: I) -> Self
 pub fn rustdoc_json::Builder::manifest_path(self, manifest_path: impl core::convert::AsRef<std::path::Path>) -> Self

--- a/rustdoc-json/tests/public-api.txt
+++ b/rustdoc-json/tests/public-api.txt
@@ -1,8 +1,10 @@
 pub mod rustdoc_json
 #[non_exhaustive] pub enum rustdoc_json::BuildError
+pub rustdoc_json::BuildError::BuildRustdocJsonError
+pub rustdoc_json::BuildError::CapturedOutputError(alloc::string::String)
 pub rustdoc_json::BuildError::CargoManifestError(cargo_manifest::error::Error)
 pub rustdoc_json::BuildError::CargoMetadataError(cargo_metadata::errors::Error)
-pub rustdoc_json::BuildError::CrateBuildError
+pub rustdoc_json::BuildError::CommandExecutionError(alloc::string::String)
 pub rustdoc_json::BuildError::General(alloc::string::String)
 pub rustdoc_json::BuildError::IoError(std::io::error::Error)
 pub rustdoc_json::BuildError::VirtualManifest(std::path::PathBuf)

--- a/rustdoc-json/tests/rustdoc-json-lib-tests.rs
+++ b/rustdoc-json/tests/rustdoc-json-lib-tests.rs
@@ -119,7 +119,7 @@ fn capture_output() {
 
     assert!(matches!(
         result,
-        Err(rustdoc_json::BuildError::CrateBuildError)
+        Err(rustdoc_json::BuildError::BuildRustdocJsonError)
     ));
     assert!(stdout.is_empty());
 

--- a/rustdoc-json/tests/rustdoc-json-lib-tests.rs
+++ b/rustdoc-json/tests/rustdoc-json-lib-tests.rs
@@ -102,3 +102,32 @@ fn silent_build() {
             "Found `{stderr_substring_if_not_silent}` in stderr, but stderr should be silent!"
         ));
 }
+
+#[test]
+fn capture_output() {
+    let target_dir = tempfile::tempdir().unwrap();
+    let mut stdout = vec![];
+    let mut stderr = vec![];
+
+    let result = rustdoc_json::Builder::default()
+        .toolchain("nightly")
+        .manifest_path("tests/test_crates/test_crate_error/Cargo.toml")
+        .quiet(true) // Make it less noisy to run tests
+        .color(rustdoc_json::Color::Never)
+        .target_dir(&target_dir)
+        .build_with_captured_output(&mut stdout, &mut stderr);
+
+    assert!(matches!(
+        result,
+        Err(rustdoc_json::BuildError::CrateBuildError)
+    ));
+    assert!(stdout.is_empty());
+
+    let stderr = String::from_utf8(stderr).unwrap();
+
+    assert!(
+        stderr.contains("error: this file contains an unclosed delimiter"),
+        "Got stderr: {}",
+        stderr,
+    );
+}

--- a/rustdoc-json/tests/test_crates/test_crate_error/Cargo.toml
+++ b/rustdoc-json/tests/test_crates/test_crate_error/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+description = "For testing rustdoc-json"
+name = "test_crate_error"
+version = "0.1.0"
+edition = "2021"
+
+# Exclude this package from the top level workspace by declaring our own empty
+# workspace
+[workspace]

--- a/rustdoc-json/tests/test_crates/test_crate_error/src/lib.rs
+++ b/rustdoc-json/tests/test_crates/test_crate_error/src/lib.rs
@@ -1,0 +1,2 @@
+pub fn foo() {
+


### PR DESCRIPTION
Hi @Enselic. This PR allows users to capture the std{out,err} of rustdoc, which is something I need to do in cargo-rdme.

Let me know what you think.