### PR TITLE
CI test: Does CI fail with no-op change?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cargo-public-api
+## cargo-public-api
 
 List and diff the public API of Rust library crates between releases and commits. Detect breaking API changes and semver violations via CI or a CLI. Relies on and automatically builds [rustdoc JSON](https://github.com/rust-lang/rust/issues/76578), for which a recent version of the Rust nightly toolchain must be installed.
 


### PR DESCRIPTION
https://github.com/Enselic/cargo-public-api/pull/574 fails in strange way. Does this PR too?