### PR TITLE
Don't panic when encountering constants without a type (e.g. `TakesConstGenericArg<120>`)

### DIFF
--- a/public-api/src/render.rs
+++ b/public-api/src/render.rs
@@ -794,17 +794,26 @@ impl<'c> RenderingContext<'c> {
     fn render_constant(&self, constant: &Constant, type_: Option<&Type>) -> Vec<Token> {
         let mut output = vec![];
         if constant.is_literal {
-            output.extend(self.render_type(type_.expect("constant literals have a type")));
-            if let Some(value) = &constant.value {
-                output.extend(equals());
+            // In general we do not want to include values of e.g. public
+            // constants, since the values themselves do not typically
+            // constitute the public API surface. It is the constant identifier
+            // itself that forms the public API surface. So if we have a type,
+            // we only render the type.
+            //
+            // However, sometimes we do not have any type (e.g. for const
+            // generic args), and it that case it looks weird to not show
+            // anything. So in that case we show the value.
+            if let Some(type_) = type_ {
+                output.extend(self.render_type(type_));
+            } else if let Some(value) = &constant.value {
                 if constant.is_literal {
                     output.push(Token::primitive(value));
                 } else {
                     output.push(Token::identifier(value));
                 }
+            } else {
+                output.push(Token::identifier(&constant.expr));
             }
-        } else {
-            output.push(Token::identifier(&constant.expr));
         }
         output
     }

--- a/public-api/tests/expected-output/comprehensive_api.txt
+++ b/public-api/tests/expected-output/comprehensive_api.txt
@@ -151,6 +151,7 @@ pub mut static comprehensive_api::statics::MUT_ANSWER: i8
 pub mod comprehensive_api::structs
 pub struct comprehensive_api::structs::ConstArg<T, const N: usize>
 pub comprehensive_api::structs::ConstArg::items: [T; N]
+pub struct comprehensive_api::structs::OnlyConstArg<const N: usize>
 pub struct comprehensive_api::structs::Plain
 pub comprehensive_api::structs::Plain::x: usize
 impl comprehensive_api::structs::Plain
@@ -228,6 +229,7 @@ pub type comprehensive_api::impls::TestItemGrouping::Foo = u8
 pub fn comprehensive_api::impls::TestItemGrouping::bar() -> <Self as comprehensive_api::traits::TraitWithGenerics<T, U>>::Foo
 pub unsafe trait comprehensive_api::traits::UnsafeTrait
 pub mod comprehensive_api::typedefs
+pub type comprehensive_api::typedefs::ConstArg120 = comprehensive_api::structs::OnlyConstArg<120>
 pub type comprehensive_api::typedefs::RedefinedResult<T, E> = core::result::Result<T, E>
 pub type comprehensive_api::typedefs::TypedefPlain = comprehensive_api::structs::Plain
 pub mod comprehensive_api::unions

--- a/test-apis/comprehensive_api/src/constants.rs
+++ b/test-apis/comprehensive_api/src/constants.rs
@@ -1,1 +1,3 @@
-pub const CONST: &str = "const";
+// The value should not be part of the public API, only the `CONST` symbol
+// should be.
+pub const CONST: &str = "a-str-value-that-itself-is-not-part-of-the-public-api-surface";

--- a/test-apis/comprehensive_api/src/structs.rs
+++ b/test-apis/comprehensive_api/src/structs.rs
@@ -24,6 +24,8 @@ pub struct ConstArg<T, const N: usize> {
     pub items: [T; N],
 }
 
+pub struct OnlyConstArg<const N: usize> {}
+
 pub struct WithTraitBounds<T: Display + Debug> {
     t: T,
 }

--- a/test-apis/comprehensive_api/src/typedefs.rs
+++ b/test-apis/comprehensive_api/src/typedefs.rs
@@ -3,3 +3,5 @@ use crate::structs::Plain;
 pub type TypedefPlain = Plain;
 
 pub type RedefinedResult<T, E> = Result<T, E>;
+
+pub type ConstArg120 = crate::structs::OnlyConstArg<120>;


### PR DESCRIPTION
This also makes values appear on constants, just like in rustdoc HTML.

Closes #583