### PR TITLE
Render `pub const` types in more cases, such as for arrays and tuples

### DIFF
--- a/public-api/src/render.rs
+++ b/public-api/src/render.rs
@@ -793,27 +793,25 @@ impl<'c> RenderingContext<'c> {
 
     fn render_constant(&self, constant: &Constant, type_: Option<&Type>) -> Vec<Token> {
         let mut output = vec![];
-        if constant.is_literal {
-            // In general we do not want to include values of e.g. public
-            // constants, since the values themselves do not typically
-            // constitute the public API surface. It is the constant identifier
-            // itself that forms the public API surface. So if we have a type,
-            // we only render the type.
-            //
-            // However, sometimes we do not have any type (e.g. for const
-            // generic args), and it that case it looks weird to not show
-            // anything. So in that case we show the value.
-            if let Some(type_) = type_ {
-                output.extend(self.render_type(type_));
-            } else if let Some(value) = &constant.value {
-                if constant.is_literal {
-                    output.push(Token::primitive(value));
-                } else {
-                    output.push(Token::identifier(value));
-                }
+        // In general we do not want to include values of e.g. public
+        // constants, since the values themselves do not typically
+        // constitute the public API surface. It is the constant identifier
+        // itself that forms the public API surface. So if we have a type,
+        // we only render the type.
+        //
+        // However, sometimes we do not have any type (e.g. for const
+        // generic args), and it that case it looks weird to not show
+        // anything. So in that case we show the value.
+        if let Some(type_) = type_ {
+            output.extend(self.render_type(type_));
+        } else if let Some(value) = &constant.value {
+            if constant.is_literal {
+                output.push(Token::primitive(value));
             } else {
-                output.push(Token::identifier(&constant.expr));
+                output.push(Token::identifier(value));
             }
+        } else {
+            output.push(Token::identifier(&constant.expr));
         }
         output
     }

--- a/public-api/tests/expected-output/comprehensive_api.txt
+++ b/public-api/tests/expected-output/comprehensive_api.txt
@@ -15,11 +15,11 @@ pub fn comprehensive_api::attributes::must_use() -> usize
 pub mod comprehensive_api::constants
 pub const comprehensive_api::constants::CONST_BOOL: bool
 pub const comprehensive_api::constants::CONST_F64: f64
-pub const comprehensive_api::constants::CONST_FN: 
-pub const comprehensive_api::constants::CONST_I32_ARRAY: 
-pub const comprehensive_api::constants::CONST_I32_F64_TUPLE: 
-pub const comprehensive_api::constants::CONST_OPTION_I32: 
-pub const comprehensive_api::constants::CONST_PLAIN_STRUCT: 
+pub const comprehensive_api::constants::CONST_FN: fn(usize)
+pub const comprehensive_api::constants::CONST_I32_ARRAY: [i32; 3]
+pub const comprehensive_api::constants::CONST_I32_F64_TUPLE: (i32, f64)
+pub const comprehensive_api::constants::CONST_OPTION_I32: core::option::Option<i32>
+pub const comprehensive_api::constants::CONST_PLAIN_STRUCT: comprehensive_api::structs::Plain
 pub const comprehensive_api::constants::CONST_STR: &str
 pub const comprehensive_api::constants::CONST_USIZE: usize
 pub mod comprehensive_api::enums

--- a/public-api/tests/expected-output/comprehensive_api.txt
+++ b/public-api/tests/expected-output/comprehensive_api.txt
@@ -13,7 +13,15 @@ pub comprehensive_api::attributes::C::b: bool
 #[export_name = "something_arbitrary"] pub fn comprehensive_api::attributes::export_name()
 pub fn comprehensive_api::attributes::must_use() -> usize
 pub mod comprehensive_api::constants
-pub const comprehensive_api::constants::CONST: &str
+pub const comprehensive_api::constants::CONST_BOOL: bool
+pub const comprehensive_api::constants::CONST_F64: f64
+pub const comprehensive_api::constants::CONST_FN: 
+pub const comprehensive_api::constants::CONST_I32_ARRAY: 
+pub const comprehensive_api::constants::CONST_I32_F64_TUPLE: 
+pub const comprehensive_api::constants::CONST_OPTION_I32: 
+pub const comprehensive_api::constants::CONST_PLAIN_STRUCT: 
+pub const comprehensive_api::constants::CONST_STR: &str
+pub const comprehensive_api::constants::CONST_USIZE: usize
 pub mod comprehensive_api::enums
 pub enum comprehensive_api::enums::DiverseVariants
 pub comprehensive_api::enums::DiverseVariants::Recursive

--- a/test-apis/comprehensive_api/src/constants.rs
+++ b/test-apis/comprehensive_api/src/constants.rs
@@ -1,3 +1,19 @@
-// The value should not be part of the public API, only the `CONST` symbol
-// should be.
-pub const CONST: &str = "a-str-value-that-itself-is-not-part-of-the-public-api-surface";
+//! The values should not be part of the public API, only the symbols should be.
+
+pub const CONST_STR: &str = "a-str-value-that-itself-is-not-part-of-the-public-api-surface";
+
+pub const CONST_USIZE: usize = 42;
+
+pub const CONST_BOOL: bool = true;
+
+pub const CONST_F64: f64 = 3.1415926535;
+
+pub const CONST_I32_ARRAY: [i32; 3] = [1, 2, 3];
+
+pub const CONST_I32_F64_TUPLE: (i32, f64) = (42, 3.14);
+
+pub const CONST_OPTION_I32: Option<i32> = Some(10);
+
+pub const CONST_PLAIN_STRUCT: crate::structs::Plain = crate::structs::Plain { x: 42 };
+
+pub const CONST_FN: fn(usize) = crate::functions::one_arg;


### PR DESCRIPTION
In general, Rust semver is about backwards compatibility on the source code level. And changing a value of a constant does not break source code compatibility. Dependent crates will still build. So we should not include values as part of the API surface.

We did have the wrong logic with regards to rendering types though. Fix that.

See discussion starting at https://github.com/Enselic/cargo-public-api/pull/584#issuecomment-2182652259.

Since we change the way items are rendered, this requires a 0.x.0 release.