### PR TITLE
Do not detach main repo git HEAD when Ctrl-C during cargo test

### DIFF
--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -987,7 +987,6 @@ fn diff_published_with_all_features() {
 #[test]
 fn diff_with_features_separated_by_comma() {
     let mut cmd = TestCmd::new().with_test_repo_variant(TestRepoVariant::Features);
-    cmd.current_dir("../test-apis/features");
     cmd.args(["--features", "feature_a,feature_b"]);
     cmd.args(["diff", "HEAD..HEAD"]);
     cmd.assert()


### PR DESCRIPTION
The main git repo HEAD ended up detaching for me if I did

    cargo test -p cargo-public-api --test '*'
    # Ctrl-C in the middle of the test run

which I found very mysterious, annoying, and tricky to debug. It only happened with --test-threads > 10, so clearly something racy. The key to figuring out the problem was to use

    inotifywait -m .git/HEAD

while running each test one by one. I then discovered that `fn diff_published_with_all_features()` made inotify report

    .git/HEAD DELETE_SELF

and that should not happen! Turns out that the test did .current_dir() on the main repo, and not on the temporary repo created in /tmp by

    TestCmd::new().with_test_repo_variant(TestRepoVariant::Features)

which already sets current_dir() appropriately.

So let's remove the faultly call to fix this annoying race. I can easily reproduce the problem without the fix, but I cannot reproduce it with the fix.

Other instances of .current_dir() in the test file are fine, because they are on the temporary repos