### PR TITLE
Add an option to disable toolchain checks

### DIFF
--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -573,7 +573,10 @@ fn subcommand_name(bin: OsString) -> Option<OsString> {
 fn resolve_toolchain(args: Args) -> ArgsAndToolchain {
     // This option allows the use of a custom version of rustup that is pre-configured to run nightly
     if std::env::var_os("CARGO_PUBLIC_API_IGNORE_TOOLCHAIN").is_some() {
-        return ArgsAndToolchain { args, toolchain: None };
+        return ArgsAndToolchain {
+            args,
+            toolchain: None,
+        };
     }
 
     let toolchain = if toolchain::is_probably_stable() {

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -571,6 +571,11 @@ fn subcommand_name(bin: OsString) -> Option<OsString> {
 
 /// Check if using a stable compiler, and use nightly if it is.
 fn resolve_toolchain(args: Args) -> ArgsAndToolchain {
+    // This option allows to use a custom version of rustup that is already set up to run nightly
+    if std::env::var_os("CARGO_PUBLIC_API_IGNORE_TOOLCHAIN").is_some() {
+        return ArgsAndToolchain { args, toolchain: None };
+    }
+
     let toolchain = if toolchain::is_probably_stable() {
         if let Some(toolchain) = toolchain::from_rustup() {
             eprintln!("Warning: using the `{toolchain}` toolchain for gathering the public api is not possible, switching to `nightly`");

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -571,7 +571,7 @@ fn subcommand_name(bin: OsString) -> Option<OsString> {
 
 /// Check if using a stable compiler, and use nightly if it is.
 fn resolve_toolchain(args: Args) -> ArgsAndToolchain {
-    // This option allows to use a custom version of rustup that is already set up to run nightly
+    // This option allows the use of a custom version of rustup that is pre-configured to run nightly
     if std::env::var_os("CARGO_PUBLIC_API_IGNORE_TOOLCHAIN").is_some() {
         return ArgsAndToolchain { args, toolchain: None };
     }


### PR DESCRIPTION
We aim to integrate this tool into our company’s CI pipeline for automated checks. However, we face an issue due to our custom `rustup`, which has a different name and command set compared to the official one. All of that doesn’t give a chance for `cargo-public-api` to run.

Fortunately, the toolset supports nightly features and functions correctly when running cargo directly without specifying a toolset.

This PR introduces an environment variable, CARGO_PUBLIC_API_IGNORE_TOOLCHAIN, to disable toolset checks, allowing cargo-public-api to run seamlessly with our custom setup.