### PR TITLE
Bump rustup-toolchain to v0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "rustup-toolchain"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "expect-test",
  "public-api",

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -68,7 +68,7 @@ features = ["env-filter"]
 
 [dev-dependencies.rustup-toolchain]
 path = "../rustup-toolchain"
-version = "0.1.7"
+version = "0.1.8"
 
 [dev-dependencies.predicates]
 version = "3.1.2"

--- a/rustup-toolchain/CHANGELOG.md
+++ b/rustup-toolchain/CHANGELOG.md
@@ -1,5 +1,8 @@
 # rustup-toolchain
 
+## v0.1.8
+* Bump deps
+
 ## v0.1.7
 * Move project from https://github.com/Enselic/cargo-public-api to https://github.com/cargo-public-api/cargo-public-api
 

--- a/rustup-toolchain/Cargo.toml
+++ b/rustup-toolchain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "rustup-toolchain"
-version = "0.1.7"
+version = "0.1.8"
 description = "Utilities for working with rustup toolchains, primarily from cargo test:s."
 homepage = "https://github.com/cargo-public-api/cargo-public-api/tree/main/rustup-toolchain"
 documentation = "https://docs.rs/rustup-toolchain"


### PR DESCRIPTION
Changes to rustdoc-types required updates to repo.