### PR TITLE
Bump public-api to v0.38.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "public-api"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -48,7 +48,7 @@ version = "0.9.2"
 
 [dependencies.public-api]
 path = "../public-api"
-version = "0.37.0"
+version = "0.38.0"
 
 [dependencies.serde]
 version = "1.0.179"

--- a/public-api/CHANGELOG.md
+++ b/public-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `public-api` changelog
 
+## v0.38.0
+* Support `nightly-2024-09-10`, which brought in lots of field renaming due to https://github.com/rust-lang/rust/pull/128667.
+* Removed `OpaqueTy` since it was removed from rustdoc-types.
+
 ## v0.37.0
 * Move project from https://github.com/Enselic/cargo-public-api to https://github.com/cargo-public-api/cargo-public-api
 

--- a/public-api/CHANGELOG.md
+++ b/public-api/CHANGELOG.md
@@ -1,8 +1,7 @@
 # `public-api` changelog
 
 ## v0.38.0
-* Support `nightly-2024-09-10`, which brought in lots of field renaming due to https://github.com/rust-lang/rust/pull/128667.
-* Removed `OpaqueTy` since it was removed from rustdoc-types.
+* Support `nightly-2024-09-10` and later.
 
 ## v0.37.0
 * Move project from https://github.com/Enselic/cargo-public-api to https://github.com/cargo-public-api/cargo-public-api
@@ -14,7 +13,7 @@
 * Don't panic when encountering constants without a type (e.g. `TakesConstGenericArg<120>`)
 
 ## v0.35.0
-* Support `nightly-2024-06-07`.
+* Support `nightly-2024-06-07` and later.
 
 ## v0.33.1
 * Fixup 'Avoid textual API diff when changing a trait impl to an auto-derived impl.'

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "public-api"
-version = "0.37.0"
+version = "0.38.0"
 description = "List and diff the public API of Rust library crates. Relies on rustdoc JSON output from the nightly toolchain."
 homepage = "https://github.com/cargo-public-api/cargo-public-api/tree/main/public-api"
 documentation = "https://docs.rs/public-api"

--- a/repo-tests/Cargo.toml
+++ b/repo-tests/Cargo.toml
@@ -7,5 +7,5 @@ license = "MIT"
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.37.0"
+version = "0.38.0"
 

--- a/rustdoc-json/Cargo.toml
+++ b/rustdoc-json/Cargo.toml
@@ -32,4 +32,4 @@ default-features = false
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.37.0"
+version = "0.38.0"

--- a/rustup-toolchain/Cargo.toml
+++ b/rustup-toolchain/Cargo.toml
@@ -22,4 +22,4 @@ version = "0.9.2"
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.37.0"
+version = "0.38.0"


### PR DESCRIPTION
Changes to rustdoc-types required updates to repo.