### PR TITLE
Support `nightly-2024-10-18` and later

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-public-api"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "public-api"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -989,9 +989,9 @@ dependencies = [
 
 [[package]]
 name = "rustdoc-types"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d368a6e25f5445187e8f67a7ec1cdf38f6d361fb26f9476b8b5f0bd91d88fd60"
+checksum = "0958527c2f4e8ff8b64e067bda402306946efc96f9b69f9f691b146f4b17f930"
 dependencies = [
  "serde",
 ]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install the `cargo public-api` subcommand with a recent regular **stable** Rust 
 cargo +stable install cargo-public-api --locked
 ```
 
-Ensure **nightly-2024-10-13** or later is installed (does not need to be the active toolchain) so `cargo public-api` can build rustdoc JSON for you:
+Ensure **nightly-2024-10-18** or later is installed (does not need to be the active toolchain) so `cargo public-api` can build rustdoc JSON for you:
 
 ```sh
 rustup install nightly --profile minimal
@@ -142,7 +142,8 @@ cargo public-api -sss
 
 | Version          | Understands the rustdoc JSON output of  |
 | ---------------- | --------------------------------------- |
-| 0.39.x           | nightly-2024-10-13 —                    |
+| 0.40.x           | nightly-2024-10-18 —                    |
+| 0.39.x           | nightly-2024-10-13 — nightly-2024-10-17 |
 | 0.38.x           | nightly-2024-09-10 — nightly-2024-10-12 |
 | 0.37.x           | nightly-2024-07-05 — nightly-2024-09-09 |
 | 0.35.x — 0.36.x  | nightly-2024-06-07 — nightly-2024-07-04 |

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "cargo-public-api"
-version = "0.39.0"
+version = "0.40.0"
 default-run = "cargo-public-api"
 description = "List and diff the public API of Rust library crates between releases and commits. Detect breaking API changes and semver violations via CI or a CLI."
 homepage = "https://github.com/cargo-public-api/cargo-public-api"
@@ -48,7 +48,7 @@ version = "0.9.2"
 
 [dependencies.public-api]
 path = "../public-api"
-version = "0.39.0"
+version = "0.40.0"
 
 [dependencies.serde]
 version = "1.0.179"

--- a/cargo-public-api/tests/create_test_git_repo/mod.rs
+++ b/cargo-public-api/tests/create_test_git_repo/mod.rs
@@ -60,7 +60,7 @@ pub fn create_test_git_repo(dest_dir: impl AsRef<Path>, dirs_and_tags: &[(&str, 
         run(git()
             .args(["-c", "commit.gpgsign=false", "commit", "--quiet", "-m"])
             .arg(tag_name));
-        run(git().arg("tag").arg(tag_name));
+        run(git().arg("tag").arg(tag_name).arg("--no-sign"));
     }
 }
 

--- a/cargo-public-api/tests/create_test_git_repo/mod.rs
+++ b/cargo-public-api/tests/create_test_git_repo/mod.rs
@@ -37,10 +37,7 @@ pub fn create_test_git_repo(dest_dir: impl AsRef<Path>, dirs_and_tags: &[(&str, 
     run(git().args(["config", "user.name", "Cargo Public"]));
 
     // Now go through all directories and create git commits and tags from them
-    for dir_and_tag in dirs_and_tags {
-        let dir_name = dir_and_tag.0;
-        let tag_name = dir_and_tag.1;
-
+    for (dir_name, tag_name) in dirs_and_tags {
         let copy_to_dest = |name| {
             let mut from = PathBuf::from("../test-apis");
             from.push(dir_name);

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -104,6 +104,8 @@ RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=custom ./scripts/run-ci-locally.sh
 It is usually straigtforward.
 
 1. Bump `[dependencies.rustdoc-types] version` in `./public-api/Cargo.toml`
+1. Bump `MINIMUM_NIGHTLY_RUST_VERSION` in `public-api/src/lib.rs`
+1. Bump the *value of* `MINIMUM_NIGHTLY_RUST_VERSION` in `README.md`
 1. Make `cargo build` build
 1. Make `cargo test` build
 1. Possibly bless changes to output with `./scripts/bless-expected-output-for-tests.sh`

--- a/public-api/CHANGELOG.md
+++ b/public-api/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `public-api` changelog
 
+## v0.40.0
+* Support `nightly-2024-10-18` and later.
+
 ## v0.39.0
 * Support `nightly-2024-10-13` and later.
 

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "public-api"
-version = "0.39.0"
+version = "0.40.0"
 description = "List and diff the public API of Rust library crates. Relies on rustdoc JSON output from the nightly toolchain."
 homepage = "https://github.com/cargo-public-api/cargo-public-api/tree/main/public-api"
 documentation = "https://docs.rs/public-api"
@@ -23,7 +23,7 @@ version = "1.0.104"
 features = ["unbounded_depth"]
 
 [dependencies.rustdoc-types]
-version = "0.31.0"
+version = "0.32.0"
 
 [dev-dependencies]
 anyhow = "1.0.75"

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -62,7 +62,7 @@ pub use public_item::PublicItem;
 /// The rustdoc JSON format is still changing, so every now and then we update
 /// this library to support the latest format. If you use this version of
 /// nightly or later, you should be fine.
-pub const MINIMUM_NIGHTLY_RUST_VERSION: &str = "nightly-2024-10-13";
+pub const MINIMUM_NIGHTLY_RUST_VERSION: &str = "nightly-2024-10-18";
 
 /// See [`Builder`] method docs for what each field means.
 #[derive(Copy, Clone, Debug)]

--- a/public-api/src/nameable_item.rs
+++ b/public-api/src/nameable_item.rs
@@ -19,7 +19,7 @@ pub struct NameableItem<'c> {
     pub sorting_prefix: u8,
 }
 
-impl<'c> NameableItem<'c> {
+impl NameableItem<'_> {
     /// The regular name of the item. Shown to users.
     pub fn name(&self) -> Option<&str> {
         self.overridden_name

--- a/repo-tests/Cargo.toml
+++ b/repo-tests/Cargo.toml
@@ -7,5 +7,5 @@ license = "MIT"
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.39.0"
+version = "0.40.0"
 

--- a/rustdoc-json/Cargo.toml
+++ b/rustdoc-json/Cargo.toml
@@ -32,4 +32,4 @@ default-features = false
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.39.0"
+version = "0.40.0"

--- a/rustup-toolchain/Cargo.toml
+++ b/rustup-toolchain/Cargo.toml
@@ -22,4 +22,4 @@ version = "0.9.2"
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.39.0"
+version = "0.40.0"


### PR DESCRIPTION
See individual commits.

Updates #636 (needs release).