### PR TITLE
deny.toml/audit.toml: Allow yanked crates

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,2 @@
+[yanked]
+enabled = false

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -1601,8 +1601,12 @@ fn assert_cargo_public_api_not_in_cargo_home_bin() {
 
     assert!(
         std::fs::metadata(&path).is_err(),
-        "Found {path:?} which will override `./target/debug/cargo-public-api` and thus interfere with tests. \
-         Run `mv -v ~/.cargo/bin/cargo-public-api ~/.cargo/bin/$(~/.cargo/bin/cargo-public-api --version | tr ' ' '-')` to fix.");
+        "Found {path:?} which will override `./target/debug/cargo-public-api`
+and thus interfere with tests. Run
+
+    mv -v ~/.cargo/bin/cargo-public-api ~/.cargo/bin/$(~/.cargo/bin/cargo-public-api --version | tr ' ' '-')
+
+to fix.");
 }
 
 /// See where this is used for an explanation of why we have this helper.

--- a/deny.toml
+++ b/deny.toml
@@ -9,3 +9,6 @@ allow = [
 [bans]
 wildcards = "deny"
 multiple-versions = "allow"
+
+[advisories]
+yanked = "allow"


### PR DESCRIPTION
Our CI is currently failing because smol_str yanked 0.3.1. But it only
had a regular bug, not undefined behavior or a security hole:
https://github.com/rust-analyzer/smol_str/pull/89

I don't want our CI to fail because of known regular bugs, so let's
allow yanked crates. If a crate has a known security vulnerability,
other lint rules will catch it.