### PR TITLE
Make releases easier; automate nightly version bumping more

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,6 +31,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: cargo fmt -- --check
+      - run: cargo run --bin update-version-info
+      - run: |
+          [ -z "$(git diff)" ] || { echo "ERROR: You forgot to 'cargo run --bin update-version-info'" ; exit 1 ; }
 
   cargo-doc:
     name: RUSTDOCFLAGS='--deny warnings' cargo doc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,6 +637,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
+name = "jiff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a45489186a6123c128fdf6016183fcfab7113e1820eb813127e036e287233fb"
+
+[[package]]
 name = "jobserver"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,6 +948,15 @@ name = "regex-syntax"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "release-helper"
+version = "0.1.0"
+dependencies = [
+ "jiff",
+ "pretty_assertions",
+ "semver",
+]
 
 [[package]]
 name = "remove_dir_all"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ members = [
     # High-level CLI for "rustdoc-json" and "public-api"
     "cargo-public-api",
 
-    # Contains various repo-wide tests
-    "repo-tests",
+    # Contains various repo-wide tests and utilities
+    "repo-tests", "scripts/release-helper",
 ]
 
 # Test APIs can't be part of the workspace because

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -104,14 +104,14 @@ RUSTDOC_JSON_OVERRIDDEN_TOOLCHAIN_HACK=custom ./scripts/run-ci-locally.sh
 It is usually straigtforward.
 
 1. Bump `[dependencies.rustdoc-types] version` in `./public-api/Cargo.toml`
-1. Bump `MINIMUM_NIGHTLY_RUST_VERSION` in `public-api/src/lib.rs`
-1. Bump the *value of* `MINIMUM_NIGHTLY_RUST_VERSION` in `README.md`
+1. Update `scripts/release-helper/src/version_info.rs`
+1. Run `cargo run --bin update-version-info`
 1. Make `cargo build` build
 1. Make `cargo test` build
 1. Possibly bless changes to output with `./scripts/bless-expected-output-for-tests.sh`
 1. Make `./scripts/run-ci-locally.sh` pass
 
-Once all of the above commands completes successfully, the upgrade is usually complete.
+Once all of the above commands completes successfully, the upgrade is usually complete. See [RELEASE.md](./RELEASE.md) for info about other preparations needed to make a release with the changes.
 
 # Automated tests
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -12,10 +12,9 @@
 
 ### Bumping `MINIMUM_NIGHTLY_RUST_VERSION`
 
-If `MINIMUM_NIGHTLY_RUST_VERSION` must be bumped then
-* update the [compatibility matrix](https://github.com/cargo-public-api/cargo-public-api#compatibility-matrix)
-* by necessity both `cargo-public-api` and `public-api` must be bumped to the same version to make the [compatibility matrix](https://github.com/cargo-public-api/cargo-public-api#compatibility-matrix) consistent.
-* bump it in `cargo-public-api` [installation instructions](https://github.com/cargo-public-api/cargo-public-api#installation)
+If `MINIMUM_NIGHTLY_RUST_VERSION` must be bumped then by necessity both `cargo-public-api` and `public-api` must be bumped to the same version to make the [compatibility matrix](https://github.com/cargo-public-api/cargo-public-api#compatibility-matrix) consistent. With this in mind, do this:
+* Add a new version info entry at [version_info.rs](https://github.com/cargo-public-api/cargo-public-api/blob/main/scripts/release-helper/lib/version_info.rs)
+* Run `cargo run --bin update-version-info`
 * ```
   rm cargo-public-api/MINIMUM_NIGHTLY_RUST_VERSION_FOR_TESTS
   ```
@@ -38,7 +37,6 @@ If `MINIMUM_NIGHTLY_RUST_VERSION` must be bumped then
    ```
    cargo set-version -p cargo-public-api x.y.z
    ```
-    * If you bump 0.x.0 version, also update the [compatibility matrix](https://github.com/cargo-public-api/cargo-public-api#compatibility-matrix).
     * If `MINIMUM_NIGHTLY_RUST_VERSION` must be bumped, see [notes](./RELEASE.md#bumping-minimum_nightly_rust_version).
 1. Push branch
 
@@ -60,7 +58,6 @@ MAINTAINER:
    ```
    cargo set-version -p public-api x.y.z
    ```
-    * If you bump 0.x.0 version, also update the [compatibility matrix](https://github.com/cargo-public-api/cargo-public-api#compatibility-matrix).
     * If `MINIMUM_NIGHTLY_RUST_VERSION` must be bumped, see [notes](./RELEASE.md#bumping-minimum_nightly_rust_version).
 1. Push branch
 

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -63,6 +63,7 @@ pub use public_item::PublicItem;
 /// this library to support the latest format. If you use this version of
 /// nightly or later, you should be fine.
 pub const MINIMUM_NIGHTLY_RUST_VERSION: &str = "nightly-2024-10-18";
+// End-marker for scripts/release-helper/src/bin/update-version-info/main.rs
 
 /// See [`Builder`] method docs for what each field means.
 #[derive(Copy, Clone, Debug)]

--- a/scripts/release-helper/Cargo.toml
+++ b/scripts/release-helper/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "release-helper"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies.jiff]
+version = "0.1.13"
+default-features = false
+features = ["alloc"]
+
+[dependencies]
+semver = "1.0.18"
+
+[dev-dependencies]
+pretty_assertions = "1.4.1"

--- a/scripts/release-helper/src/bin/update-version-info/main.rs
+++ b/scripts/release-helper/src/bin/update-version-info/main.rs
@@ -1,0 +1,51 @@
+//! See `docs/RELEASE.md` for information on how to use this.
+
+fn main() {
+    insert_file_contents_in_between(
+        "README.md",
+        "# Compatibility Matrix
+
+| Version          | Understands the rustdoc JSON output of  |
+| ---------------- | --------------------------------------- |
+",
+        &release_helper::compatibility_matrix::render(release_helper::version_info::TABLE),
+        "| earlier versions | see [here]",
+    );
+
+    insert_file_contents_in_between(
+        "README.md",
+        "```sh
+cargo +stable install cargo-public-api --locked
+```
+
+Ensure **",
+        release_helper::version_info::TABLE[0].min_nightly_rust_version,
+        "** or later is installed (does not need to be the active toolchain)",
+    );
+
+    insert_file_contents_in_between(
+        "public-api/src/lib.rs",
+        "pub const MINIMUM_NIGHTLY_RUST_VERSION: &str = \"",
+        release_helper::version_info::TABLE[0].min_nightly_rust_version,
+        "\";
+// End-marker for scripts/release-helper/src/bin/update-version-info/main.rs",
+    );
+}
+
+fn insert_file_contents_in_between(
+    source_file_path: &str,
+    existing_start_text: &str,
+    new_text_in_middle: &str,
+    existing_end_text: &str,
+) {
+    let contents = std::fs::read_to_string(source_file_path).unwrap();
+
+    let start_index = contents.find(existing_start_text).unwrap();
+    let end_index = contents.find(existing_end_text).unwrap();
+
+    let start = contents[..start_index + existing_start_text.len()].to_string();
+    let end = contents[end_index..].to_string();
+
+    let new_contents = format!("{}{}{}", start, new_text_in_middle, end);
+    std::fs::write(source_file_path, new_contents.clone()).unwrap();
+}

--- a/scripts/release-helper/src/compatibility_matrix.rs
+++ b/scripts/release-helper/src/compatibility_matrix.rs
@@ -1,0 +1,278 @@
+use jiff::{civil::Date, ToSpan};
+
+use crate::version_info::CargoPublicApiVersionInfo;
+
+pub fn render(version_infos: &[CargoPublicApiVersionInfo]) -> String {
+    /// Same as ['CargoPublicApiVersionInfo'] but easier to maniuplate
+    /// programatically.
+    struct InternalCargoPublicApiVersionInfo {
+        cargo_public_api_minor_version: u32,
+        min_nightly_rust_version: Date,
+    }
+
+    /// Represents `0.39.x — 0.40.x` or just `0.39.x` if start and end is the
+    /// same.
+    #[derive(Clone)]
+    struct CargoPublicApiMinorVersionRange {
+        start: u32,
+        end: u32,
+    }
+
+    #[derive(Clone)]
+    struct NightlyVersionRange {
+        start: Date,
+        end: Option<Date>,
+    }
+
+    #[derive(Clone)]
+    struct CompatibilityMatrixRow {
+        cargo_public_api_version_range: CargoPublicApiMinorVersionRange,
+        nightly_rust_version_range: NightlyVersionRange,
+    }
+
+    let version_infos: Vec<_> = version_infos
+        .iter()
+        .map(|version_info| InternalCargoPublicApiVersionInfo {
+            // Turn `0.39.x` into `39`
+            cargo_public_api_minor_version: version_info
+                .cargo_public_api_version
+                .split('.')
+                .nth(1)
+                .unwrap()
+                .parse()
+                .unwrap(),
+            // Turn `nightly-2024-10-13` into `2024-10-13`
+            min_nightly_rust_version: version_info
+                .min_nightly_rust_version
+                .strip_prefix("nightly-")
+                .unwrap()
+                .parse()
+                .unwrap(),
+        })
+        .collect();
+
+    let mut rows = Vec::new();
+    let mut current_row: Option<CompatibilityMatrixRow> = None;
+    for version_info in version_infos.iter().rev() {
+        if let Some(mut row) = current_row.take() {
+            if row.nightly_rust_version_range.start == version_info.min_nightly_rust_version {
+                row.cargo_public_api_version_range.end =
+                    version_info.cargo_public_api_minor_version;
+                current_row = Some(row);
+            } else {
+                row.nightly_rust_version_range.end = Some(
+                    version_info
+                        .min_nightly_rust_version
+                        .checked_sub(1.days())
+                        .unwrap(),
+                );
+                rows.push(row);
+                current_row = None;
+            }
+        }
+        if current_row.is_none() {
+            current_row = Some(CompatibilityMatrixRow {
+                cargo_public_api_version_range: CargoPublicApiMinorVersionRange {
+                    start: version_info.cargo_public_api_minor_version,
+                    end: version_info.cargo_public_api_minor_version,
+                },
+                nightly_rust_version_range: NightlyVersionRange {
+                    start: version_info.min_nightly_rust_version,
+                    end: None,
+                },
+            });
+        }
+    }
+    rows.push(current_row.unwrap());
+
+    let mut output = String::new();
+    for row in rows.iter().rev() {
+        let cargo_public_api_version_str = if row.cargo_public_api_version_range.start
+            == row.cargo_public_api_version_range.end
+        {
+            format!("0.{}.x         ", row.cargo_public_api_version_range.start)
+        } else {
+            format!(
+                "0.{}.x — 0.{}.x",
+                row.cargo_public_api_version_range.start, row.cargo_public_api_version_range.end
+            )
+        };
+        let nightly_version_range_str = format!(
+            "{} — {}",
+            jiff::fmt::strtime::format("nightly-%Y-%m-%d", row.nightly_rust_version_range.start)
+                .unwrap(),
+            row.nightly_rust_version_range
+                .end
+                .map(|t| jiff::fmt::strtime::format("nightly-%Y-%m-%d", t).unwrap())
+                .unwrap_or_else(|| "                  ".to_string())
+        );
+        output.push_str(&format!(
+            "| {cargo_public_api_version_str}  | {nightly_version_range_str} |\n",
+        ));
+    }
+
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_render_compatibility_matrix_one_version() {
+        assert_render(
+            &[CargoPublicApiVersionInfo {
+                cargo_public_api_version: "0.39.x",
+                min_nightly_rust_version: "nightly-2024-10-13",
+            }],
+            "| 0.39.x           | nightly-2024-10-13 —                    |\n\
+            ",
+        );
+    }
+
+    #[test]
+    fn test_render_compatibility_matrix_two_versions() {
+        assert_render(
+            &[
+                CargoPublicApiVersionInfo {
+                    cargo_public_api_version: "0.39.x",
+                    min_nightly_rust_version: "nightly-2024-10-13",
+                },
+                CargoPublicApiVersionInfo {
+                    cargo_public_api_version: "0.38.x",
+                    min_nightly_rust_version: "nightly-2024-09-10",
+                },
+            ],
+            "| 0.39.x           | nightly-2024-10-13 —                    |\n\
+             | 0.38.x           | nightly-2024-09-10 — nightly-2024-10-12 |\n\
+            ",
+        );
+    }
+
+    #[test]
+    fn test_render_compatibility_matrix_two_versions_same_nightly() {
+        assert_render(
+            &[
+                CargoPublicApiVersionInfo {
+                    cargo_public_api_version: "0.39.x",
+                    min_nightly_rust_version: "nightly-2024-09-10",
+                },
+                CargoPublicApiVersionInfo {
+                    cargo_public_api_version: "0.38.x",
+                    min_nightly_rust_version: "nightly-2024-09-10",
+                },
+            ],
+            "| 0.38.x — 0.39.x  | nightly-2024-09-10 —                    |\n\
+            ",
+        );
+    }
+
+    #[test]
+    fn test_render_compatibility_matrix_three_versions() {
+        assert_render(
+            &[
+                CargoPublicApiVersionInfo {
+                    cargo_public_api_version: "0.39.x",
+                    min_nightly_rust_version: "nightly-2024-10-13",
+                },
+                CargoPublicApiVersionInfo {
+                    cargo_public_api_version: "0.38.x",
+                    min_nightly_rust_version: "nightly-2024-09-10",
+                },
+                CargoPublicApiVersionInfo {
+                    cargo_public_api_version: "0.37.x",
+                    min_nightly_rust_version: "nightly-2024-07-05",
+                },
+            ],
+            "\
+             | 0.39.x           | nightly-2024-10-13 —                    |\n\
+             | 0.38.x           | nightly-2024-09-10 — nightly-2024-10-12 |\n\
+             | 0.37.x           | nightly-2024-07-05 — nightly-2024-09-09 |\n\
+            ",
+        );
+    }
+
+    #[test]
+    fn test_render_compatibility_matrix_three_versions_last_same_nightly() {
+        assert_render(
+            &[
+                CargoPublicApiVersionInfo {
+                    cargo_public_api_version: "0.39.x",
+                    min_nightly_rust_version: "nightly-2024-09-10",
+                },
+                CargoPublicApiVersionInfo {
+                    cargo_public_api_version: "0.38.x",
+                    min_nightly_rust_version: "nightly-2024-09-10",
+                },
+                CargoPublicApiVersionInfo {
+                    cargo_public_api_version: "0.37.x",
+                    min_nightly_rust_version: "nightly-2024-07-05",
+                },
+            ],
+            "\
+             | 0.38.x — 0.39.x  | nightly-2024-09-10 —                    |\n\
+             | 0.37.x           | nightly-2024-07-05 — nightly-2024-09-09 |\n\
+            ",
+        );
+    }
+
+    #[test]
+    fn test_render_compatibility_matrix_three_versions_first_same_nightly() {
+        assert_render(
+            &[
+                CargoPublicApiVersionInfo {
+                    cargo_public_api_version: "0.39.x",
+                    min_nightly_rust_version: "nightly-2024-10-13",
+                },
+                CargoPublicApiVersionInfo {
+                    cargo_public_api_version: "0.38.x",
+                    min_nightly_rust_version: "nightly-2024-07-05",
+                },
+                CargoPublicApiVersionInfo {
+                    cargo_public_api_version: "0.37.x",
+                    min_nightly_rust_version: "nightly-2024-07-05",
+                },
+            ],
+            "\
+             | 0.39.x           | nightly-2024-10-13 —                    |\n\
+             | 0.37.x — 0.38.x  | nightly-2024-07-05 — nightly-2024-10-12 |\n\
+            ",
+        );
+    }
+
+    #[test]
+    fn test_render_compatibility_matrix_four_versions_middle_same_nightly() {
+        assert_render(
+            &[
+                CargoPublicApiVersionInfo {
+                    cargo_public_api_version: "0.39.x",
+                    min_nightly_rust_version: "nightly-2024-10-13",
+                },
+                CargoPublicApiVersionInfo {
+                    cargo_public_api_version: "0.38.x",
+                    min_nightly_rust_version: "nightly-2024-09-10",
+                },
+                CargoPublicApiVersionInfo {
+                    cargo_public_api_version: "0.37.x",
+                    min_nightly_rust_version: "nightly-2024-09-10",
+                },
+                CargoPublicApiVersionInfo {
+                    cargo_public_api_version: "0.36.x",
+                    min_nightly_rust_version: "nightly-2024-06-07",
+                },
+            ],
+            "\
+             | 0.39.x           | nightly-2024-10-13 —                    |\n\
+             | 0.37.x — 0.38.x  | nightly-2024-09-10 — nightly-2024-10-12 |\n\
+             | 0.36.x           | nightly-2024-06-07 — nightly-2024-09-09 |\n\
+            ",
+        );
+    }
+
+    fn assert_render(version_infos: &[CargoPublicApiVersionInfo], expected_output: &str) {
+        let output = render(version_infos);
+        assert_eq!(output, expected_output);
+    }
+}

--- a/scripts/release-helper/src/lib.rs
+++ b/scripts/release-helper/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod compatibility_matrix;
+pub mod version_info;

--- a/scripts/release-helper/src/version_info.rs
+++ b/scripts/release-helper/src/version_info.rs
@@ -1,0 +1,53 @@
+//! See `docs/RELEASE.md` for information on how to use this.
+
+pub struct CargoPublicApiVersionInfo {
+    pub cargo_public_api_version: &'static str,
+    pub min_nightly_rust_version: &'static str,
+}
+
+pub static TABLE: &[CargoPublicApiVersionInfo] = &[
+    CargoPublicApiVersionInfo {
+        cargo_public_api_version: "0.40.x",
+        min_nightly_rust_version: "nightly-2024-10-18",
+    },
+    CargoPublicApiVersionInfo {
+        cargo_public_api_version: "0.39.x",
+        min_nightly_rust_version: "nightly-2024-10-13",
+    },
+    CargoPublicApiVersionInfo {
+        cargo_public_api_version: "0.38.x",
+        min_nightly_rust_version: "nightly-2024-09-10",
+    },
+    CargoPublicApiVersionInfo {
+        cargo_public_api_version: "0.37.x",
+        min_nightly_rust_version: "nightly-2024-07-05",
+    },
+    CargoPublicApiVersionInfo {
+        cargo_public_api_version: "0.36.x",
+        min_nightly_rust_version: "nightly-2024-06-07",
+    },
+    CargoPublicApiVersionInfo {
+        cargo_public_api_version: "0.35.x",
+        min_nightly_rust_version: "nightly-2024-06-07",
+    },
+    CargoPublicApiVersionInfo {
+        cargo_public_api_version: "0.34.x",
+        min_nightly_rust_version: "nightly-2023-08-25",
+    },
+    CargoPublicApiVersionInfo {
+        cargo_public_api_version: "0.33.x",
+        min_nightly_rust_version: "nightly-2023-08-25",
+    },
+    CargoPublicApiVersionInfo {
+        cargo_public_api_version: "0.32.x",
+        min_nightly_rust_version: "nightly-2023-08-25",
+    },
+    CargoPublicApiVersionInfo {
+        cargo_public_api_version: "0.31.x",
+        min_nightly_rust_version: "nightly-2023-05-24",
+    },
+    CargoPublicApiVersionInfo {
+        cargo_public_api_version: "0.30.x",
+        min_nightly_rust_version: "nightly-2023-05-24",
+    },
+];


### PR DESCRIPTION
To make it easier for others to help make releases, remove some manual
steps. Namely the ones related to updating minimum nightly Rust version
info in various places.