### PR TITLE
Stop auto-generating release notes. Grab them from CHANGELOG.md instead

### DIFF
--- a/.github/workflows/Auto-merge-dependabot-PRs.yml
+++ b/.github/workflows/Auto-merge-dependabot-PRs.yml
@@ -16,7 +16,6 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.AUTO_MERGE_GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
       - run: |
           gh pr review ${{ github.event.pull_request.number }} --comment --body "If CI passes, this dependabot PR will be [auto-merged](https://github.com/cargo-public-api/cargo-public-api/blob/main/.github/workflows/Auto-merge-dependabot-PRs.yml) 🚀"
       - run: |

--- a/.github/workflows/CHANGELOG-reminder.yml
+++ b/.github/workflows/CHANGELOG-reminder.yml
@@ -1,0 +1,13 @@
+name: CHANGELOG reminder
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  remind-of-changelog:
+    if: github.repository == 'cargo-public-api/cargo-public-api' && !startsWith(github.head_ref, 'dependabot/')
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          gh pr review ${{ github.event.pull_request.number }} --comment --body "If this change deserves mention to users, please don't forget to update [CHANGELOG.md](https://github.com/cargo-public-api/cargo-public-api/blob/main/CHANGELOG.md), [public-api/CHANGELOG.md](https://github.com/cargo-public-api/cargo-public-api/blob/main/public-api/CHANGELOG.md), [rustdoc-json/CHANGELOG.md](https://github.com/cargo-public-api/cargo-public-api/blob/main/rustdoc-json/CHANGELOG.md) and/or [rustup-toolchain/CHANGELOG.md](https://github.com/cargo-public-api/cargo-public-api/blob/main/rustup-toolchain/CHANGELOG.md). Thanks!"

--- a/.github/workflows/Release-cargo-public-api.yml
+++ b/.github/workflows/Release-cargo-public-api.yml
@@ -45,17 +45,20 @@ jobs:
     needs: publish
     runs-on: ubuntu-latest
     permissions:
-      contents: write # softprops/action-gh-release
+      contents: write # So we can create a release.
     steps:
       - uses: actions/checkout@v4
-
       - name: calculate version
         id: version
         run: |
           version=$(cargo read-manifest --manifest-path cargo-public-api/Cargo.toml | jq --raw-output .version)
+          echo "VERSION=${version}" >> $GITHUB_OUTPUT
           echo "GIT_TAG=v${version}" >> $GITHUB_OUTPUT
-
-      - uses: softprops/action-gh-release@d4e8205d7e959a9107da6396278b2f1f07af0f9b # 2022-12-09, audited by me personally
-        with:
-          tag_name: ${{ steps.version.outputs.GIT_TAG }}
-          generate_release_notes: true
+      - run: cargo install parse-changelog@0.6.4 --locked
+      - name: create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          notes="$(parse-changelog CHANGELOG.md ${{ steps.version.outputs.VERSION }})"
+          title="${{ steps.version.outputs.GIT_TAG }}"
+          gh release create --title "$title" --notes "$notes" ${{ steps.version.outputs.GIT_TAG }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,133 @@
-# Changelog
+# `cargo-public-api` changelog
 
-Please see the [Releases](https://github.com/cargo-public-api/cargo-public-api/releases) page for a list of all releases and what they contain.
+## v0.40.0
+* Support `nightly-2024-10-18` and later
 
-Let me know if you would really like to have that list inside this file, and why so. A dynamically constructed and always up to date list seems like a better approach.
+## v0.39.0
+* Support `nightly-2024-10-13` and later
+
+## v0.38.0
+* Support `nightly-2024-09-10` and later
+
+## v0.37.0
+* Support `nightly-2024-07-05`
+* Properly render lifetime bounds
+* Move project from https://github.com/Enselic/cargo-public-api to https://github.com/cargo-public-api/cargo-public-api
+
+## v0.36.0
+* Render `pub const` types in more cases, such as for arrays and tuples
+
+## v0.35.1
+* Don't panic when encountering constants without a type
+
+## v0.35.0
+* Support `nightly-2024-06-07` and later
+
+## v0.34.2
+* Allow `stdout` and `stderr` of rustdoc JSON building to be captured with new `rustdoc_json::Builder::build_with_captured_output(self, stdout: impl Write, stderr: impl Write)` function
+* Make most CLI options global so they also work as subcommand args--package=...`
+* Match `cargo`'s handling of spaces with `--features`
+
+## v0.34.1
+* Make diffing against published crate work when its `[package] name` is not the same as its `[lib] name`
+* Bump cargo-manifest from v0.13.0 to v0.14.0
+* Use the `tracing` crate for debug logging and e.g. `RUST_LOG=debug` to activate
+
+## v0.34.0
+* Remove `cargo public-api --toolchain foo` arg. Use `cargo +foo public-api` instead.
+* Include all subcommands in top-level `--help` output
+* Print a nice error message if `rustup` is not in `PATH`
+* Update `cargo-manifest` from `0.12.0` to `0.13.0`
+
+## v0.33.1
+* Fixup 'Avoid textual API diff when changing a trait impl to an auto-derived impl'
+
+## v0.33.0
+* Avoid textual API diff when changing inherent impl to auto-derived impl
+* Add relevant `package.keywords` to our manifests
+
+## v0.32.0
+* Remove $ from README commands to ease copy-paste
+* Support for `nightly-2023-08-25` and later
+
+## v0.31.3
+* Handle when `[package]` `name` differs from `[lib]` `name`
+
+## v0.31.2
+* Support sparse crates.io registry index
+
+## v0.31.1
+* Print more informative error when we encounter a sparse crates.io index
+
+## v0.31.0
+* Change rendering of `impl` items to include generic args of the implementor
+* Ignore `!` when sorting `impl`s to make `Send` and `Sync` order stable
+* Rustdoc-JSON: Replace `-` with `_` for binary package target
+
+## v0.30.0
+* Support `nightly-2023-05-24` and later
+
+## v0.29.1
+* Prevent infinite RAM usage
+
+## v0.29.0
+* Interpret `cargo public-api diff` as `cargo public-api diff latest`
+* Remove the `public-api` bincargo-public-api/pull/386
+
+## v0.28.0
+* Enable `,` as `--omit` value delimiter
+* Change `-s` / `--simplified` to be usable up to 3 times
+* Introduce `public_api::Builder`, deprecate `PublicApi::from_rustdoc_json()` and `Options`
+* public-api: Rename `MINIMUM_NIGHTLY_VERSION` to `MINIMUM_NIGHTLY_RUST_VERSION`
+* rustup-toolchain: Rename `ensure_installed()` to `install()` and deprecate `is_installed()`
+
+## v0.27.3
+* Support installing the `cargo-public-api` bin with a different name
+* Add explicit variants of `--simplified` called `--omit blanket-impls | auto-trait-impls | auto-derived-impls`
+* Add `cargo public-api completions <SHELL>` to generate shell completion scripts
+
+## v0.27.2
+* Support for selecting features with `cargo public-api diff x.y.z`
+
+## v0.27.1
+* Fix RUSTSEC-2023-0003 / CVE-2023-22742 "git2 does not verify SSH keys
+* Make `diff latest` diff highest semver version, not most recently published
+* When diffing, build rustdoc JSON with `--cap-lints allow`
+* Deprecate `PublicApi::from_rustdoc_json_str()`
+
+## v0.27.0
+* Group `impl`s better, make sorting more lexicographic
+* Properly group multiple inherent `impl`s
+### Other Changes
+* README: Fix typo in compatibility matrix
+
+## v0.26.0
+* If `--simplifed` is passed twice, omit auto derived `impl`shttps://github.com/Enselic/cargo-public-api/pull/262
+* Support `cargo public-api diff latest` to diff against the latest published version
+* Fix rendering of bounds for Generic Associated Typescargo-public-api/pull/265
+* Remove deprecated `--diff` CLI
+* Remove `diff crate-name@0.1.0` support, use `-p crate-name diff 0.1.0` instead
+* Put auto derived `impl`scom/Enselic/cargo-public-api/pull/261
+* Bump minimum nightly version to `nightly-2023-01-04`
+
+## v0.25.0
+* Group impl blocks together with their respective functions
+* Get rid of `enum variant` and `struct field` prefixes
+* Upgrade all deps
+* Add `rustdoc_json::Builder::package_target()` to build for bin, test, bench, etc
+* Correctly determine JSON path for `Builder::package("foo@1.0.0")`
+
+## v0.24.2
+* Interpret `--color` as `--color=always`
+* Deprecate legacy `--diff` CLI and point to new `diff` subcommand instead
+* Support `--document-private-items`
+* Derive `Clone` for `rustdoc_json::Builder`
+
+## v0.24.1
+* Add new CLI for diffing: a `diff` subcommand
+
+## v0.24.0
+* Include Blanket and Auto Trait `impl`s
+* Allow omitting package name when diffing against crates.io
+
+For older releases, see https://github.com/cargo-public-api/cargo-public-api/releases/tag/v0.23.0 and earlier.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -30,9 +30,7 @@ If `MINIMUM_NIGHTLY_RUST_VERSION` must be bumped then by necessity both `cargo-p
    tag=$(git tag --sort=-creatordate | grep ^v | head -n1) ; git diff $tag
    ```
    to see what is new in the release.
-1. For each PR included in the release, adjust its `[category-*]` according to [release.yml](https://github.com/cargo-public-api/cargo-public-api/blob/main/.github/release.yml) and tweak the PR title if necessary to turn it into good release note entry.
-1. Preview the [auto-generated release notes](https://github.com/cargo-public-api/cargo-public-api.github.io/blob/main/release-notes-preview.md) which our CI [continuously](https://github.com/cargo-public-api/cargo-public-api/actions/workflows/Preview-release-notes.yml) updates.
-    * The target audience for the release notes is users of the `cargo-public-api` CLI. But we also want to credit contributors to our libraries with a mention in the release notes, so we should also include such PRs in the release notes. For libs we also want to update the corresponding `CHANGELOG.md` file though.
+1. Update `CHANGELOG.md`
 1. Bump version with
    ```
    cargo set-version -p cargo-public-api x.y.z


### PR DESCRIPTION
The preview of auto-generated release notes seems buggy now and I don't feel like fixing it.

So instead, let's begin using CHANGELOG.md. GitHub Release notes will be picked from that file. I chose to simplify the CHANGELOG.md compared to old GitHub Release notes, because I like things to be simple. Especially things that has to be written manualy.

Once this lands we can remove stuff related to the old workflow, such as the entire https://github.com/cargo-public-api/cargo-public-api.github.io repo and labels such as 'category-bugfix' etc.