### PR TITLE
Configure support for GitHub Merge Queues

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,7 @@ on:
   workflow_call: # From .github/workflows/Release-*.yml, .github/workflows/Nightly.yml
   workflow_dispatch:
   pull_request:
+  merge_group:
   push:
     branches: [main]
 


### PR DESCRIPTION
I tried GitHub Merge Queue a while back, but then it was quite buggy. I want to try again because it would be nice if it works now. Then we will never see the "your branch is not up to date" warning on any PR any longer.