### PR TITLE
Add trademark notice to READMEs with Rust or Cargo in the project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
 - [Enselic](https://github.com/Enselic)
 - [douweschulte](https://github.com/douweschulte)
 - [Emilgardis](https://github.com/Emilgardis)
+
+# Trademark Notice
+
+"Rust" and "Cargo" are trademarks of the Rust Foundation. This project is not affiliated with, endorsed by, or otherwise associated with the Rust Project or Rust Foundation.

--- a/rustdoc-json/README.md
+++ b/rustdoc-json/README.md
@@ -26,3 +26,7 @@ Please refer to [CHANGELOG.md](https://github.com/cargo-public-api/cargo-public-
 ## Tests
 
 This library is indirectly and heavily tested through the [`public-api`](https://crates.io/crates/public-api) and [`cargo-public-api`](https://crates.io/crates/cargo-public-api) test suites. Their tests heavily depend on this library, so if all of their tests pass, then this library works as it should. All tests are of course ensured to pass before a new release is made.
+
+# Trademark Notice
+
+"Rust" and "Cargo" are trademarks of the Rust Foundation. This project is not affiliated with, endorsed by, or otherwise associated with the Rust Project or Rust Foundation.

--- a/rustup-toolchain/README.md
+++ b/rustup-toolchain/README.md
@@ -13,3 +13,7 @@ Please refer to [CHANGELOG.md](https://github.com/cargo-public-api/cargo-public-
 This library is indirectly and heavily tested through the [`public-api`](https://crates.io/crates/public-api) and [`cargo-public-api`](https://crates.io/crates/cargo-public-api) test suites. Their tests heavily depend on this library, so if all of their tests pass, then this library works as it should.
 
 All tests are of course ensured to pass before a new release of this crate is made.
+
+# Trademark Notice
+
+"Rust" and "Cargo" are trademarks of the Rust Foundation. This project is not affiliated with, endorsed by, or otherwise associated with the Rust Project or Rust Foundation.


### PR DESCRIPTION
To fulfil requirements outlined in the Rust Project's trademark policy, more specifically "Updated Rust Trademark Policy Draft - November 2024". See https://drive.google.com/file/d/1hjTx11Fb-4W7RQLmp3R8BLDACc7zxIpG/view.

(I got help from ChatGPT to formulate the notice.)