### PR TITLE
Make update-version-info handle MINIMUM_NIGHTLY_RUST_VERSION_FOR_TESTS

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -15,9 +15,6 @@
 If `MINIMUM_NIGHTLY_RUST_VERSION` must be bumped then by necessity both `cargo-public-api` and `public-api` must be bumped to the same version to make the [compatibility matrix](https://github.com/cargo-public-api/cargo-public-api#compatibility-matrix) consistent. With this in mind, do this:
 * Add a new version info entry at [version_info.rs](https://github.com/cargo-public-api/cargo-public-api/blob/main/scripts/release-helper/lib/version_info.rs)
 * Run `cargo run --bin update-version-info`
-* ```
-  rm cargo-public-api/MINIMUM_NIGHTLY_RUST_VERSION_FOR_TESTS
-  ```
 
 ### When not to release
 

--- a/scripts/release-helper/src/bin/update-version-info/main.rs
+++ b/scripts/release-helper/src/bin/update-version-info/main.rs
@@ -1,6 +1,10 @@
 //! See `docs/RELEASE.md` for information on how to use this.
 
 fn main() {
+    let current_min_nightly_rust_version =
+        release_helper::version_info::TABLE[0].min_nightly_rust_version;
+
+    // Update README.md
     insert_file_contents_in_between(
         "README.md",
         "# Compatibility Matrix
@@ -11,7 +15,6 @@ fn main() {
         &release_helper::compatibility_matrix::render(release_helper::version_info::TABLE),
         "| earlier versions | see [here]",
     );
-
     insert_file_contents_in_between(
         "README.md",
         "```sh
@@ -19,17 +22,35 @@ cargo +stable install cargo-public-api --locked
 ```
 
 Ensure **",
-        release_helper::version_info::TABLE[0].min_nightly_rust_version,
+        current_min_nightly_rust_version,
         "** or later is installed (does not need to be the active toolchain)",
     );
 
+    // Update public-api/src/lib.rs
     insert_file_contents_in_between(
         "public-api/src/lib.rs",
         "pub const MINIMUM_NIGHTLY_RUST_VERSION: &str = \"",
-        release_helper::version_info::TABLE[0].min_nightly_rust_version,
+        current_min_nightly_rust_version,
         "\";
 // End-marker for scripts/release-helper/src/bin/update-version-info/main.rs",
     );
+
+    // Handle MINIMUM_NIGHTLY_RUST_VERSION_FOR_TESTS
+    let min_for_tests_path = "cargo-public-api/MINIMUM_NIGHTLY_RUST_VERSION_FOR_TESTS";
+    if let Ok(min_for_tests) =
+        std::fs::read_to_string(min_for_tests_path).map(|s| s.trim().to_string())
+    {
+        println!("The file `{min_for_tests_path}` contains {min_for_tests} and `public_apiMINIMUM_NIGHTLY_RUST_VERSION` is {current_min_nightly_rust_version}:");
+        if min_for_tests.as_str() < current_min_nightly_rust_version {
+            println!("Removing the file");
+            std::fs::remove_file(min_for_tests_path).unwrap();
+        } else {
+            println!("Keeping the file");
+        }
+    } else {
+        println!("The file `{min_for_tests_path}` does not exist:");
+        println!("No action taken.");
+    }
 }
 
 fn insert_file_contents_in_between(
@@ -38,6 +59,10 @@ fn insert_file_contents_in_between(
     new_text_in_middle: &str,
     existing_end_text: &str,
 ) {
+    println!(
+        "Updating {} by inserting:\n{}\n",
+        source_file_path, new_text_in_middle
+    );
     let contents = std::fs::read_to_string(source_file_path).unwrap();
 
     let start_index = contents.find(existing_start_text).unwrap();


### PR DESCRIPTION
To simplify the release process.