### PR TITLE
Eliminate `Id` references

### DIFF
--- a/public-api/src/crate_wrapper.rs
+++ b/public-api/src/crate_wrapper.rs
@@ -12,7 +12,7 @@ pub struct CrateWrapper<'c> {
     /// <https://github.com/rust-lang/rust/pull/99287#issuecomment-1186586518>)
     /// We do not report it to users by default, because they can't do anything
     /// about it. Missing IDs will be printed with `--verbose` however.
-    missing_ids: Vec<&'c Id>,
+    missing_ids: Vec<Id>,
 }
 
 impl<'c> CrateWrapper<'c> {
@@ -23,8 +23,8 @@ impl<'c> CrateWrapper<'c> {
         }
     }
 
-    pub fn get_item(&mut self, id: &'c Id) -> Option<&'c Item> {
-        self.crate_.index.get(id).or_else(|| {
+    pub fn get_item(&mut self, id: Id) -> Option<&'c Item> {
+        self.crate_.index.get(&id).or_else(|| {
             self.missing_ids.push(id);
             None
         })


### PR DESCRIPTION
This PR changes several `&Id` to `Id`. The `Id` type became [copyable](https://github.com/rust-lang/rustdoc-types/commit/7fc07fafa5784777cfe98ca0c6c706bc72ce358b#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R299) with `rustdoc-types` version 0.31.0.