### PR TITLE
Render `_` argument names in function declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `cargo-public-api` changelog
 
+## v0.42.0
+* Render `_` argument names in function declarations
+
 ## v0.41.0
 * Render `?` in front of `core::marker::Sized` if applicable.
 

--- a/public-api/CHANGELOG.md
+++ b/public-api/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `public-api` changelog
 
+## v0.42.0
+* Render `_` argument names in function declarations
+
 ## v0.41.0
 * Render `?` in front of `core::marker::Sized` if applicable.
 

--- a/public-api/src/render.rs
+++ b/public-api/src/render.rs
@@ -446,7 +446,7 @@ impl<'c> RenderingContext<'c> {
         output.extend(self.render_generic_param_defs(&generics.params));
 
         // Regular parameters and return type
-        output.extend(self.render_fn_decl(sig));
+        output.extend(self.render_fn_decl(sig, true));
 
         // Where predicates
         output.extend(self.render_where_predicates(&generics.where_predicates));
@@ -454,7 +454,7 @@ impl<'c> RenderingContext<'c> {
         output
     }
 
-    fn render_fn_decl(&self, sig: &FunctionSignature) -> Vec<Token> {
+    fn render_fn_decl(&self, sig: &FunctionSignature, include_underscores: bool) -> Vec<Token> {
         let mut output = vec![];
         // Main arguments
         output.extend(self.render_sequence(
@@ -465,7 +465,7 @@ impl<'c> RenderingContext<'c> {
             |(name, ty)| {
                 self.simplified_self(name, ty).unwrap_or_else(|| {
                     let mut output = vec![];
-                    if name != "_" {
+                    if name != "_" || include_underscores {
                         output.extend(vec![Token::identifier(name), Token::symbol(":"), ws!()]);
                     }
                     output.extend(self.render_type(ty));
@@ -563,7 +563,7 @@ impl<'c> RenderingContext<'c> {
     fn render_function_pointer(&self, ptr: &FunctionPointer) -> Vec<Token> {
         let mut output = self.render_higher_rank_trait_bounds(&ptr.generic_params);
         output.push(Token::kind("fn"));
-        output.extend(self.render_fn_decl(&ptr.sig));
+        output.extend(self.render_fn_decl(&ptr.sig, false));
         output
     }
 

--- a/public-api/tests/expected-output/comprehensive_api.txt
+++ b/public-api/tests/expected-output/comprehensive_api.txt
@@ -114,6 +114,7 @@ pub fn comprehensive_api::functions::somewhere<T, U>(t: T, u: U) where T: core::
 pub fn comprehensive_api::functions::struct_arg(s: comprehensive_api::structs::PrivateField)
 pub fn comprehensive_api::functions::synthetic_arg(t: impl comprehensive_api::traits::Simple) -> impl comprehensive_api::traits::Simple
 pub unsafe fn comprehensive_api::functions::unsafe_fn()
+pub fn comprehensive_api::functions::unused_argument(u32)
 pub mod comprehensive_api::higher_ranked_trait_bounds
 pub struct comprehensive_api::higher_ranked_trait_bounds::Bar<'a>
 pub comprehensive_api::higher_ranked_trait_bounds::Bar::bar: &'a (dyn for<'b> comprehensive_api::higher_ranked_trait_bounds::Trait<'b> + core::marker::Unpin)

--- a/public-api/tests/expected-output/comprehensive_api.txt
+++ b/public-api/tests/expected-output/comprehensive_api.txt
@@ -114,7 +114,7 @@ pub fn comprehensive_api::functions::somewhere<T, U>(t: T, u: U) where T: core::
 pub fn comprehensive_api::functions::struct_arg(s: comprehensive_api::structs::PrivateField)
 pub fn comprehensive_api::functions::synthetic_arg(t: impl comprehensive_api::traits::Simple) -> impl comprehensive_api::traits::Simple
 pub unsafe fn comprehensive_api::functions::unsafe_fn()
-pub fn comprehensive_api::functions::unused_argument(u32)
+pub fn comprehensive_api::functions::unused_argument(_: u32)
 pub mod comprehensive_api::higher_ranked_trait_bounds
 pub struct comprehensive_api::higher_ranked_trait_bounds::Bar<'a>
 pub comprehensive_api::higher_ranked_trait_bounds::Bar::bar: &'a (dyn for<'b> comprehensive_api::higher_ranked_trait_bounds::Trait<'b> + core::marker::Unpin)

--- a/test-apis/comprehensive_api/src/functions.rs
+++ b/test-apis/comprehensive_api/src/functions.rs
@@ -112,3 +112,5 @@ pub async fn async_fn() {}
 pub async fn async_fn_ret_bool() -> bool {
     true
 }
+
+pub fn unused_argument(_: u32) {}


### PR DESCRIPTION
This PR renders `_` argument names as discussed in #656.