### PR TITLE
README.md: Don't reference CHANGELOG.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,6 @@ cargo public-api -sss
 | 0.30.x — 0.31.x  | nightly-2023-05-24 — nightly-2023-08-24 |
 | earlier versions | see [here](https://github.com/cargo-public-api/cargo-public-api/blob/7056d59cd279610fc61cc9669be3840b0dd8273c/README.md#compatibility-matrix) |
 
-# Changelog
-
-See [CHANGELOG.md](./CHANGELOG.md).
-
 # Contributing
 
 See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).

--- a/public-api/README.md
+++ b/public-api/README.md
@@ -62,10 +62,6 @@ UPDATE_EXPECT=1 cargo test public_api
 
 This creates a `tests/public-api.txt` file in your project that you `git add` together with your other project files. Whenever you change the public API, you need to bless it again with the above command. If you forget to bless, the test will fail, together with instructions on how to bless.
 
-# Changelog
-
-See [CHANGELOG.md](https://github.com/cargo-public-api/cargo-public-api/blob/main/public-api/CHANGELOG.md).
-
 # Maintainers
 
 See [here](https://github.com/cargo-public-api/cargo-public-api#maintainers).

--- a/rustdoc-json/README.md
+++ b/rustdoc-json/README.md
@@ -19,10 +19,6 @@ println!("Wrote rustdoc JSON to {:?}", &json_path);
 
 There are many more build options. See the [docs](https://docs.rs/rustdoc-json/latest/rustdoc_json/struct.Builder.html) to learn about all of them.
 
-## Changelog
-
-Please refer to [CHANGELOG.md](https://github.com/cargo-public-api/cargo-public-api/blob/main/rustdoc-json/CHANGELOG.md).
-
 ## Tests
 
 This library is indirectly and heavily tested through the [`public-api`](https://crates.io/crates/public-api) and [`cargo-public-api`](https://crates.io/crates/cargo-public-api) test suites. Their tests heavily depend on this library, so if all of their tests pass, then this library works as it should. All tests are of course ensured to pass before a new release is made.

--- a/rustup-toolchain/README.md
+++ b/rustup-toolchain/README.md
@@ -4,10 +4,6 @@ A library for programmatically working with `rustup` toolchains.
 
 Please refer to the [docs](https://docs.rs/rustup-toolchain/latest) to learn more.
 
-## Changelog
-
-Please refer to [CHANGELOG.md](https://github.com/cargo-public-api/cargo-public-api/blob/main/rustup-toolchain/CHANGELOG.md).
-
 ## Tests
 
 This library is indirectly and heavily tested through the [`public-api`](https://crates.io/crates/public-api) and [`cargo-public-api`](https://crates.io/crates/cargo-public-api) test suites. Their tests heavily depend on this library, so if all of their tests pass, then this library works as it should.


### PR DESCRIPTION
I like READMEs to be as simple as possible, and see references to CHANGELOG.md as noise. If someone is looking for a changelog it is very easy to find the right one.

And let's be honest, very few people read the changelog. So it does not make sense to take up valuable space in the README for it.

(I now see it as a mistake by me to initially add the references.)