### PR TITLE
Make `./scripts/run-ci-locally.sh` pass with `rustup default nightly`

### DIFF
--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -606,7 +606,7 @@ fn resolve_simplified(args: &mut Args) {
 }
 
 fn is_json_file(file_name: impl AsRef<str>) -> bool {
-    Path::extension(Path::new(file_name.as_ref())).map_or(false, |a| a.eq_ignore_ascii_case("json"))
+    Path::extension(Path::new(file_name.as_ref())).is_some_and(|a| a.eq_ignore_ascii_case("json"))
 }
 
 /// Helper to reduce code duplication. We can't add [`Args`] to

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -232,6 +232,13 @@ fn compilation_error_toolchain() {
 fn invocation_without_rustup_in_path() {
     assert_cmd::Command::cargo_bin("cargo-public-api")
         .unwrap()
+        // Make sure to not run with a nightly toolchain. Otherwise there will
+        // be no attempt to use `rustup` to switch to a nightly toolchain to
+        // build rustdoc JSON and the test will fail.
+        .env("RUSTUP_TOOLCHAIN", "stable")
+        // Avoid distracting "no library targets found in package" errors. Point
+        // to a package that we know contains a library.
+        .arg("--manifest-path=../rustdoc-json/Cargo.toml")
         .assert()
         .stderr(predicates::str::contains(
             "required program rustup not found in PATH. Is it installed?",


### PR DESCRIPTION
This makes it easier to prepare for features such as the 2024 edition which is currently only works with a nightly toolchain unless you activate that feature explicitly.

I considered testing this case in our CI but I think it will make CI much slower without a big gain. I think it's better to just fix any regression after the fact.