### PR TITLE
tests: Avoid unsafe (Rust Edition 2024) `std::env::set_var("PATH", path)`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -85,6 +85,6 @@ jobs:
         if: runner.os != 'Windows'
       - run: rustup install nightly --profile minimal
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --locked
+      - run: scripts/cargo-test.sh
       - run: scripts/cargo-test-without-rustup.sh
         if: runner.os == 'Linux' # Fails on macOS (strangely) and Windows (expected)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,16 +4,11 @@ Before you get started, you might want to read about the [architecture](./ARCHIT
 
 # Getting started
 
-Just clone the repo. Then you can make changes and run tests:
+Just clone the repo. Then you can make changes and simulate CI locally:
 
 ```
 git clone https://github.com/cargo-public-api/cargo-public-api.git ; cd cargo-public-api
 
-cargo test
-```
-
-This project makes heavy use of CI. To simulate the CI pipeline locally, run
-```
 ./scripts/run-ci-locally.sh
 ```
 
@@ -107,9 +102,7 @@ It is usually straigtforward.
 1. Update `scripts/release-helper/src/version_info.rs`
 1. Run `cargo run --bin update-version-info`
 1. Make `cargo build` build
-1. Make `cargo test` build
-1. Possibly bless changes to output with `./scripts/bless-expected-output-for-tests.sh`
-1. Make `./scripts/run-ci-locally.sh` pass
+1. Make `./scripts/run-ci-locally.sh` pass, possibly after `./scripts/bless-expected-output-for-tests.sh`
 
 Once all of the above commands completes successfully, the upgrade is usually complete. See [RELEASE.md](./RELEASE.md) for info about other preparations needed to make a release with the changes.
 

--- a/scripts/bless-expected-output-for-tests.sh
+++ b/scripts/bless-expected-output-for-tests.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -o nounset -o pipefail -o errexit
 
-UPDATE_EXPECT=1 cargo test
+UPDATE_EXPECT=1 ./scripts/cargo-test.sh

--- a/scripts/cargo-test.sh
+++ b/scripts/cargo-test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -o nounset -o pipefail -o errexit
+
+# Since `std::env::set_var()` is unsafe in Rust Edition 2024 we don't even
+# try to modify `PATH` inside of tests. Instead we make sure that it is set
+# appropriately from the start. Since we don't pass `--release` to the below
+# `cargo` commands we use `./target/debug` here and not `./target/release`.
+PATH="$(pwd)/target/debug:$PATH" cargo test --locked

--- a/scripts/run-ci-locally.sh
+++ b/scripts/run-ci-locally.sh
@@ -14,7 +14,7 @@ RUSTDOCFLAGS='--deny warnings' cargo doc --locked --no-deps --document-private-i
 
 scripts/cargo-clippy.sh
 
-cargo test --locked
+scripts/cargo-test.sh
 
 scripts/cargo-test-without-rustup.sh
 

--- a/scripts/run-ci-locally.sh
+++ b/scripts/run-ci-locally.sh
@@ -14,8 +14,6 @@ RUSTDOCFLAGS='--deny warnings' cargo doc --locked --no-deps --document-private-i
 
 scripts/cargo-clippy.sh
 
-cargo build --locked
-
 cargo test --locked
 
 scripts/cargo-test-without-rustup.sh


### PR DESCRIPTION
This is in preparation for the upcoming Rust Edition 2024 where `std::env::set_env()` must be done in an `unsafe` block which we want to avoid entirely.