### PR TITLE
Replace `bless-expected-output-for-tests.sh` with `cargo-test.sh --bless`

### DIFF
--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -37,7 +37,7 @@ jobs:
       - run: rustup install nightly --profile minimal
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get install -y zsh && zsh --version
-      - run: ./scripts/bless-expected-output-for-tests.sh
+      - run: ./scripts/cargo-test.sh --bless
       - id: latest-nightly
         run: echo "version=nightly-$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
       - run: |

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -3,7 +3,7 @@
 
 //! To update expected output it is in many cases sufficient to run
 //! ```bash
-//! ./scripts/bless-expected-output-for-tests.sh
+//! ./scripts/cargo-test.sh --bless
 //! ```
 
 use std::env;

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Note that you can run `./scripts/run-ci-locally.sh` from from within your IDE. T
 
 To make your changes become the expected output, run
 ```
-./scripts/bless-expected-output-for-tests.sh
+./scripts/cargo-test.sh --bless
 ```
 
 ## Expected Output
@@ -102,7 +102,7 @@ It is usually straigtforward.
 1. Update `scripts/release-helper/src/version_info.rs`
 1. Run `cargo run --bin update-version-info`
 1. Make `cargo build` build
-1. Make `./scripts/run-ci-locally.sh` pass, possibly after `./scripts/bless-expected-output-for-tests.sh`
+1. Make `./scripts/run-ci-locally.sh` pass, possibly after `./scripts/cargo-test.sh --bless`
 
 Once all of the above commands completes successfully, the upgrade is usually complete. See [RELEASE.md](./RELEASE.md) for info about other preparations needed to make a release with the changes.
 

--- a/scripts/bless-expected-output-for-tests.sh
+++ b/scripts/bless-expected-output-for-tests.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -o nounset -o pipefail -o errexit
-
-UPDATE_EXPECT=1 ./scripts/cargo-test.sh

--- a/scripts/cargo-test.sh
+++ b/scripts/cargo-test.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -o nounset -o pipefail -o errexit
 
+# Make it easy to bless changed output. Simply run this to bless:
+#
+#   ./scripts/cargo-test.sh --bless
+if [ "${1:-}" = "--bless" ]; then
+    export UPDATE_EXPECT=1
+fi
+
 # Since `std::env::set_var()` is unsafe in Rust Edition 2024 we don't even
 # try to modify `PATH` inside of tests. Instead we make sure that it is set
 # appropriately from the start. Since we don't pass `--release` to the below


### PR DESCRIPTION


Replace

    ./scripts/bless-expected-output-for-tests.sh

with

    ./scripts/cargo-test.sh --bless

which is simpler and more ergonomic.