### PR TITLE
CI: Print cargo version for easier debugging

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -86,6 +86,7 @@ jobs:
         if: runner.os != 'Windows'
       - run: rustup install nightly --profile minimal
       - uses: Swatinem/rust-cache@v2
+      - run: cargo version --verbose # Make it easier to debug version-specific issues
       - run: scripts/cargo-test.sh
       - run: scripts/cargo-test-without-rustup.sh
         if: runner.os == 'Linux' # Fails on macOS (strangely) and Windows (expected)


### PR DESCRIPTION
Since we use whatever stable version the GitHub runners have, let's make it convenient to see what version we currently run.