### PR TITLE
Use and recommend `insta` instead of `expect-test` for public API CI test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "console"
+version = "0.15.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +509,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +640,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6513e4067e16e69ed1db5ab56048ed65db32d10ba5fc1217f5393f8f17d8b5a5"
+dependencies = [
+ "console",
+ "linked-hash-map",
+ "once_cell",
+ "similar",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,6 +704,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -762,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl-probe"
@@ -856,6 +892,7 @@ dependencies = [
  "assert_cmd",
  "expect-test",
  "hashbag",
+ "insta",
  "itertools",
  "predicates",
  "pretty_assertions",
@@ -992,7 +1029,7 @@ dependencies = [
  "assert_cmd",
  "cargo-manifest",
  "cargo_metadata",
- "expect-test",
+ "insta",
  "predicates",
  "public-api",
  "serde",
@@ -1028,7 +1065,7 @@ dependencies = [
 name = "rustup-toolchain"
 version = "0.1.8"
 dependencies = [
- "expect-test",
+ "insta",
  "public-api",
  "rustdoc-json",
  "thiserror 2.0.3",
@@ -1132,6 +1169,12 @@ name = "shell-escape"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
+
+[[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "smallvec"

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ cargo add --dev \
     rustup-toolchain \
     rustdoc-json \
     public-api \
-    expect-test
+    insta
 ```
 
 Then add the following test to your project. As the author of the below test code, I hereby associate it with [CC0](https://creativecommons.org/publicdomain/zero/1.0/) and to the extent possible under law waive all copyright and related or neighboring rights to it:
@@ -100,17 +100,32 @@ fn public_api() {
         .unwrap();
 
     // Assert that the public API looks correct
-    expect_test::expect_file!["public-api.txt"].assert_eq(&public_api.to_string());
+    insta::assert_snapshot!(public_api);
 }
 ```
 
 Before you run the test the first time you need to bless the current public API:
 
 ```sh
-UPDATE_EXPECT=1 cargo test public_api
+cargo install cargo-insta
+cargo insta test
+cargo insta review
 ```
 
-This creates a `tests/public-api.txt` file in your project that you `git add` together with your other project files. Whenever you change the public API, you need to bless it again with the above command. If you forget to bless, the test will fail, together with instructions on how to bless.
+This creates a `tests/snapshots/<module>_public_api.snap` file in your project that you `git add` together with your other project files. Then a regular
+
+```sh
+cargo test
+```
+
+will fail if your public API is accidentally or deliberately changed. Run
+
+```sh
+cargo insta test
+cargo insta review
+```
+
+again to review and accept public API changes.
 
 ## Less Noisy Output
 

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -29,6 +29,7 @@ version = "0.32.2"
 anyhow = "1.0.75"
 assert_cmd = "2.0.16"
 expect-test = "1.5.1"
+insta = "1.42.0"
 pretty_assertions = "1.4.1"
 tempfile = "3.10.1"
 

--- a/public-api/README.md
+++ b/public-api/README.md
@@ -27,7 +27,7 @@ cargo add --dev \
     rustup-toolchain \
     rustdoc-json \
     public-api \
-    expect-test
+    insta
 ```
 
 Then add the following test to your project. As the author of the below test code, I hereby associate it with [CC0](https://creativecommons.org/publicdomain/zero/1.0/) and to the extent possible under law waive all copyright and related or neighboring rights to it:
@@ -50,17 +50,32 @@ fn public_api() {
         .unwrap();
 
     // Assert that the public API looks correct
-    expect_test::expect_file!["public-api.txt"].assert_eq(&public_api.to_string());
+    insta::assert_snapshot!(public_api);
 }
 ```
 
 Before you run the test the first time you need to bless the current public API:
 
 ```sh
-UPDATE_EXPECT=1 cargo test public_api
+cargo install cargo-insta
+cargo insta test
+cargo insta review
 ```
 
-This creates a `tests/public-api.txt` file in your project that you `git add` together with your other project files. Whenever you change the public API, you need to bless it again with the above command. If you forget to bless, the test will fail, together with instructions on how to bless.
+This creates a `tests/snapshots/<module>_public_api.snap` file in your project that you `git add` together with your other project files. Then a regular
+
+```sh
+cargo test
+```
+
+will fail if your public API is accidentally or deliberately changed. Run
+
+```sh
+cargo insta test
+cargo insta review
+```
+
+again to review and accept public API changes.
 
 # Maintainers
 

--- a/public-api/tests/public-api-lib-tests.rs
+++ b/public-api/tests/public-api-lib-tests.rs
@@ -28,7 +28,7 @@ fn public_api() -> Result<(), Box<dyn std::error::Error>> {
 
     let public_api = public_api::Builder::from_rustdoc_json(rustdoc_json).build()?;
 
-    expect_test::expect_file!["public-api.txt"].assert_eq(&public_api.to_string());
+    insta::assert_snapshot!(public_api);
 
     Ok(())
 }

--- a/public-api/tests/snapshots/public_api_lib_tests__public_api.snap
+++ b/public-api/tests/snapshots/public_api_lib_tests__public_api.snap
@@ -1,3 +1,7 @@
+---
+source: public-api/tests/public-api-lib-tests.rs
+expression: public_api
+---
 pub mod public_api
 pub mod public_api::diff
 pub struct public_api::diff::ChangedPublicItem

--- a/rustdoc-json/Cargo.toml
+++ b/rustdoc-json/Cargo.toml
@@ -23,7 +23,7 @@ features = ["attributes"]
 
 [dev-dependencies]
 assert_cmd = "2.0.16"
-expect-test = "1.5.1"
+insta = "1.42.0"
 tempfile = "3.10.1"
 
 [dev-dependencies.predicates]

--- a/rustdoc-json/tests/rustdoc-json-lib-tests.rs
+++ b/rustdoc-json/tests/rustdoc-json-lib-tests.rs
@@ -8,7 +8,7 @@ fn public_api() -> Result<(), Box<dyn std::error::Error>> {
 
     let public_api = public_api::Builder::from_rustdoc_json(rustdoc_json).build()?;
 
-    expect_test::expect_file!["public-api.txt"].assert_eq(&public_api.to_string());
+    insta::assert_snapshot!(public_api);
 
     Ok(())
 }

--- a/rustdoc-json/tests/snapshots/rustdoc_json_lib_tests__public_api.snap
+++ b/rustdoc-json/tests/snapshots/rustdoc_json_lib_tests__public_api.snap
@@ -1,3 +1,7 @@
+---
+source: rustdoc-json/tests/rustdoc-json-lib-tests.rs
+expression: public_api
+---
 pub mod rustdoc_json
 #[non_exhaustive] pub enum rustdoc_json::BuildError
 pub rustdoc_json::BuildError::BuildRustdocJsonError

--- a/rustup-toolchain/Cargo.toml
+++ b/rustup-toolchain/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/cargo-public-api/cargo-public-api/tree/main/rus
 thiserror = "2.0.3"
 
 [dev-dependencies]
-expect-test = "1.5.1"
+insta = "1.42.0"
 
 [dev-dependencies.rustdoc-json]
 path = "../rustdoc-json"

--- a/rustup-toolchain/tests/rustup-toolchain-lib-tests.rs
+++ b/rustup-toolchain/tests/rustup-toolchain-lib-tests.rs
@@ -16,5 +16,5 @@ fn public_api() {
         .unwrap();
 
     // Assert that the public API looks correct
-    expect_test::expect_file!["public-api.txt"].assert_eq(&public_api.to_string());
+    insta::assert_snapshot!(public_api);
 }

--- a/rustup-toolchain/tests/snapshots/rustup_toolchain_lib_tests__public_api.snap
+++ b/rustup-toolchain/tests/snapshots/rustup_toolchain_lib_tests__public_api.snap
@@ -1,3 +1,7 @@
+---
+source: rustup-toolchain/tests/rustup-toolchain-lib-tests.rs
+expression: public_api
+---
 pub mod rustup_toolchain
 #[non_exhaustive] pub enum rustup_toolchain::Error
 pub rustup_toolchain::Error::IoError(std::io::error::Error)


### PR DESCRIPTION


`insta` provides a better diffing and reviewing/blessing experience than `expect-test`, and is quite widely used.

Eventually we should port all tests to use `insta`, but let's start small scale.