### PR TITLE
Do not render function args named ""  (`nightly-2025-02-05` and later)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `cargo-public-api` changelog
 
+## v0.44.0
+* Do not render function arg names `""` (`nightly-2025-02-05` and later)
+
 ## v0.43.0
 * Support `nightly-2025-01-25` and later.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-public-api"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "public-api"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ cargo public-api -sss
 
 | Version          | Understands the rustdoc JSON output of  |
 | ---------------- | --------------------------------------- |
-| 0.43.x           | nightly-2025-01-25 —                    |
+| 0.43.x — 0.44.x  | nightly-2025-01-25 —                    |
 | 0.40.x — 0.42.x  | nightly-2024-10-18 — nightly-2025-01-24 |
 | 0.39.x           | nightly-2024-10-13 — nightly-2024-10-17 |
 | 0.38.x           | nightly-2024-09-10 — nightly-2024-10-12 |

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "cargo-public-api"
-version = "0.43.0"
+version = "0.44.0"
 default-run = "cargo-public-api"
 description = "List and diff the public API of Rust library crates between releases and commits. Detect breaking API changes and semver violations via CI or a CLI."
 homepage = "https://github.com/cargo-public-api/cargo-public-api"
@@ -48,7 +48,7 @@ version = "0.9.4"
 
 [dependencies.public-api]
 path = "../public-api"
-version = "0.43.0"
+version = "0.44.0"
 
 [dependencies.serde]
 version = "1.0.179"

--- a/public-api/CHANGELOG.md
+++ b/public-api/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `public-api` changelog
 
+## v0.44.0
+* Do not render function arg names `""` (`nightly-2025-02-05` and later)
+
 ## v0.43.0
 * Support `nightly-2025-01-25` and later.
 

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "public-api"
-version = "0.43.0"
+version = "0.44.0"
 description = "List and diff the public API of Rust library crates. Relies on rustdoc JSON output from the nightly toolchain."
 homepage = "https://github.com/cargo-public-api/cargo-public-api/tree/main/public-api"
 documentation = "https://docs.rs/public-api"

--- a/public-api/src/render.rs
+++ b/public-api/src/render.rs
@@ -465,7 +465,8 @@ impl<'c> RenderingContext<'c> {
             |(name, ty)| {
                 self.simplified_self(name, ty).unwrap_or_else(|| {
                     let mut output = vec![];
-                    if name != "_" || include_underscores {
+                    let ignore_name = name.is_empty() || (name == "_" && !include_underscores);
+                    if !ignore_name {
                         output.extend(vec![Token::identifier(name), Token::symbol(":"), ws!()]);
                     }
                     output.extend(self.render_type(ty));

--- a/repo-tests/Cargo.toml
+++ b/repo-tests/Cargo.toml
@@ -7,5 +7,5 @@ license = "MIT"
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.43.0"
+version = "0.44.0"
 

--- a/rustdoc-json/Cargo.toml
+++ b/rustdoc-json/Cargo.toml
@@ -32,4 +32,4 @@ default-features = false
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.43.0"
+version = "0.44.0"

--- a/rustup-toolchain/Cargo.toml
+++ b/rustup-toolchain/Cargo.toml
@@ -22,4 +22,4 @@ version = "0.9.4"
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.43.0"
+version = "0.44.0"

--- a/scripts/release-helper/src/version_info.rs
+++ b/scripts/release-helper/src/version_info.rs
@@ -7,6 +7,10 @@ pub struct CargoPublicApiVersionInfo {
 
 pub static TABLE: &[CargoPublicApiVersionInfo] = &[
     CargoPublicApiVersionInfo {
+        cargo_public_api_version: "0.44.x",
+        min_nightly_rust_version: "nightly-2025-01-25",
+    },
+    CargoPublicApiVersionInfo {
         cargo_public_api_version: "0.43.x",
         min_nightly_rust_version: "nightly-2025-01-25",
     },


### PR DESCRIPTION
With `nightly-2025-02-05` the rustdoc JSON can apparently have the arg names be `""` (see https://github.com/cargo-public-api/cargo-public-api/actions/runs/13149774732). Skip rendering such args to keep our regression tests happy.

Note that the rustdoc JSON format itself has not changed, so we don't need to bump miminum required nightly toolchain version.