### PR TITLE
Add cargo-public-api.code-workspace

### DIFF
--- a/cargo-public-api.code-workspace
+++ b/cargo-public-api.code-workspace
@@ -1,0 +1,11 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "test-apis/comprehensive_api"
+		}
+	],
+	"settings": {}
+}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -14,6 +14,8 @@ git clone https://github.com/cargo-public-api/cargo-public-api.git ; cd cargo-pu
 
 Note that you can run `./scripts/run-ci-locally.sh` from from within your IDE. Then you can simply click on errors to navigate to the proper file, line number, and column. See `.vscode/tasks.json` for an example configuration.
 
+Also note that for convenience there is a VS Code workspace you can use for out-of-the box code navigation etc, namely `cargo-public-api.code-workspace`.
+
 ## Blessing new expected output
 
 To make your changes become the expected output, run

--- a/repo-tests/tests/repo-tests.rs
+++ b/repo-tests/tests/repo-tests.rs
@@ -37,7 +37,17 @@ fn newline_at_end_of_all_files() {
     // Setup the list of file extensions to check. Produced by:
     //
     //   git ls-files | grep -v -e \.rs -e \.toml -e \.md -e \.sh -e \.txt -e \.yml -e \.json
-    let checked_extensions = ["json", "md", "rs", "sh", "toml", "txt", "yml"].map(OsStr::new);
+    let checked_extensions = [
+        "code-workspace",
+        "json",
+        "md",
+        "rs",
+        "sh",
+        "toml",
+        "txt",
+        "yml",
+    ]
+    .map(OsStr::new);
 
     // Check each file
     let mut missing_newline = vec![];

--- a/test-apis/comprehensive_api/src/exports.rs
+++ b/test-apis/comprehensive_api/src/exports.rs
@@ -20,10 +20,12 @@ pub mod recursion_2 {
 }
 
 pub mod recursion_glob_1 {
+    #[allow(unused_imports)]
     pub use super::recursion_glob_2::*;
 }
 
 pub mod recursion_glob_2 {
+    #[allow(unused_imports)]
     pub use super::recursion_glob_1::*;
 }
 


### PR DESCRIPTION
Split out from
https://github.com/cargo-public-api/cargo-public-api/pull/702 where we'll want a workspace anyway. But this is good to have even if that PR never lands.

For now I just added comprehensive_api but we might want to add more later.