### PR TITLE
Bring back `scripts/cargo-test.sh --bless`

### DIFF
--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -48,6 +48,9 @@ jobs:
       - run: rustup install nightly --profile minimal
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get install -y zsh && zsh --version
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-insta
       - run: ./scripts/cargo-test.sh --bless
       - id: latest-nightly
         run: echo "version=nightly-$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -3,6 +3,7 @@
 
 //! To update expected output it is in many cases sufficient to run
 //! ```bash
+//! cargo install cargo-insta
 //! ./scripts/cargo-test.sh --bless
 //! ```
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -20,6 +20,7 @@ Also note that for convenience there is a VS Code workspace you can use for out-
 
 To make your changes become the expected output, run
 ```
+cargo install cargo-insta
 ./scripts/cargo-test.sh --bless
 ```
 

--- a/scripts/cargo-test.sh
+++ b/scripts/cargo-test.sh
@@ -2,10 +2,21 @@
 set -o nounset -o pipefail -o errexit
 
 # Put `cargo-public-api` in $PATH so `cargo` finds it and `cargo public-api`
-# works.
+# works, which some tests depend on.
 #
 # Since `std::env::set_var()` is unsafe in Rust Edition 2024 we don't even
 # try to modify `PATH` inside of tests. Instead we make sure that it is set
 # appropriately from the start. Since we don't pass `--release` to the below
 # `cargo` commands we use `./target/debug` here and not `./target/release`.
-PATH="$(pwd)/target/debug:$PATH" cargo test --locked
+export PATH="$(pwd)/target/debug:$PATH"
+
+if [ "${1:-}" = "--bless" ]; then
+    if ! command -v cargo-insta >/dev/null; then
+        echo "ERROR: \`cargo-insta\` not found. Run \`cargo install cargo-insta\` first."
+        exit 1
+    fi
+    cargo insta test || true # avoid errexit if output changed
+    cargo insta review
+else
+    cargo test --locked
+fi


### PR DESCRIPTION
I removed it too hastily in 106201b9cc1 because I
forgot that we reference --bless in several places in workflows and docs.

So bring it back and make it work with insta.