### PR TITLE
workflows: Stop using Swatinem/rust-cache

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,7 +41,6 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-deny,cargo-audit,shfmt
-      - uses: Swatinem/rust-cache@v2
       - run: cargo version --verbose # Make it easier to debug version-specific issues
       - run: ./scripts/lint.sh
 
@@ -63,7 +62,6 @@ jobs:
       - run: zsh --version || (sudo apt-get install -y zsh && zsh --version)
         if: runner.os != 'Windows'
       - run: rustup install nightly --profile minimal
-      - uses: Swatinem/rust-cache@v2
       - run: cargo version --verbose # Make it easier to debug version-specific issues
       - run: scripts/cargo-test.sh
       - run: scripts/cargo-test-without-rustup.sh

--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -46,7 +46,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup install nightly --profile minimal
-      - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get install -y zsh && zsh --version
       - run: ./scripts/cargo-test.sh --bless
       - id: latest-nightly


### PR DESCRIPTION
To reduce risk of cache poisoning pwn requests.
See e.g.
https://securitylab.github.com/resources/github-actions-new-patterns-and-mitigations/

This will lead to slower CI but I prefer that over being paranoid about potential cache poisoning and other exploits.

If we end up hating the slower CI we can look into alternatives, but let's at least try.