### PR TITLE
Auto-merge-dependabot-PRs.yml: Use --repo instead of checkout

### DIFF
--- a/.github/workflows/Auto-merge-dependabot-PRs.yml
+++ b/.github/workflows/Auto-merge-dependabot-PRs.yml
@@ -16,8 +16,13 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.AUTO_MERGE_GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4 # So the gh command knows what repo to work with
       - run: |
-          gh pr review ${{ github.event.pull_request.number }} --comment --body "If CI passes, this dependabot PR will be [auto-merged](https://github.com/cargo-public-api/cargo-public-api/blob/main/.github/workflows/Auto-merge-dependabot-PRs.yml) 🚀"
+          gh pr review ${{ github.event.pull_request.number }} \
+            --repo cargo-public-api/cargo-public-api \
+            --comment \
+            --body "If CI passes, this dependabot PR will be [auto-merged](https://github.com/cargo-public-api/cargo-public-api/blob/main/.github/workflows/Auto-merge-dependabot-PRs.yml) 🚀"
       - run: |
-          gh pr merge --auto --squash ${{ github.event.pull_request.number }}
+          gh pr merge \
+            --repo cargo-public-api/cargo-public-api \
+            --auto \
+            --squash ${{ github.event.pull_request.number }}


### PR DESCRIPTION
`pull_request_target` is the most sensitive kind
of trigger because it is the most prevalent target of own requests (see e.g.
https://blog.yossarian.net/2024/12/06/zizmor-ultralytics-injection)

So harden our only `pull_request_target` job a bit by removing `actions/checkout`. That means we
don't have to worry about the
`persist-credentials` option (which is `true` by
default).