### PR TITLE
Auto-merge-dependabot-PRs.yml: Do not evaulate context expressions in shell context

### DIFF
--- a/.github/workflows/Auto-merge-dependabot-PRs.yml
+++ b/.github/workflows/Auto-merge-dependabot-PRs.yml
@@ -15,16 +15,19 @@ jobs:
       url: https://github.com/cargo-public-api/cargo-public-api/blob/main/.github/workflows/Auto-merge-dependabot-PRs.yml
     env:
       GITHUB_TOKEN: ${{ secrets.AUTO_MERGE_GITHUB_TOKEN }}
+      PR: ${{ github.event.pull_request.number }}
     steps:
       - run: |
-          gh pr review ${{ github.event.pull_request.number }} \
+          gh pr review \
             --repo cargo-public-api/cargo-public-api \
             --comment \
-            --body "If CI passes, this dependabot PR will be [auto-merged](https://github.com/cargo-public-api/cargo-public-api/blob/main/.github/workflows/Auto-merge-dependabot-PRs.yml) 🚀"
+            --body "If CI passes, this dependabot PR will be [auto-merged](https://github.com/cargo-public-api/cargo-public-api/blob/main/.github/workflows/Auto-merge-dependabot-PRs.yml) 🚀" \
+            "$PR"
       - run: |
           gh pr merge \
             --repo cargo-public-api/cargo-public-api \
             --auto \
-            --squash ${{ github.event.pull_request.number }}
+            --squash \
+            "$PR"
       - run: |
           echo Temporary step just to see name of dependabot: ${{ toJson(github.event.pull_request.actor) }}


### PR DESCRIPTION
Auto-merge-dependabot-PRs.yml is our only `pull_request_target` triggered workflow and that type is extra risky.

From
https://securitylab.github.com/resources/github-actions-untrusted-input/ we can read:

> The best practice to avoid code and command
> injection vulnerabilities in GitHub workflows is
> to set the untrusted input value of the
> expression to an intermediate environment
> variable

And even though `${{ github.event.pull_request.number }}` is not free-text user controlled, there might be a bug in GitHub itself that allows free text in that field today or in the future. So protect us from pwn requests even in that unlikely scenario by putting the PR number in an env var.