### PR TITLE
CI: Stop testing with CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,14 +49,11 @@ jobs:
       fail-fast: false
       matrix:
         variant:
-          - { name: Ubuntu,  os: ubuntu-latest,  protocol: git    }
-          - { name: Ubuntu,  os: ubuntu-latest,  protocol: sparse }
-          - { name: macOS,   os: macos-latest,   protocol: sparse }
-          - { name: Windows, os: windows-latest, protocol: sparse }
-    name: cargo test (${{ matrix.variant.name }} ${{ matrix.variant.protocol }})
+          - { name: Ubuntu,  os: ubuntu-latest  }
+          - { name: macOS,   os: macos-latest   }
+          - { name: Windows, os: windows-latest }
+    name: cargo test (${{ matrix.variant.name }})
     runs-on: ${{ matrix.variant.os }}
-    env:
-      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: ${{ matrix.variant.protocol }}
     steps:
       - uses: actions/checkout@v4
       - run: zsh --version || (sudo apt-get install -y zsh && zsh --version)


### PR DESCRIPTION
Ubuntu with

    CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git

takes 6 minutes and slows down CI. With

    CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse

it just takes 2 minutes.

sparse became the default more than 1,5 years ago
and I doubt anyone is still using it that is also
using cargo-public-api:
https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html#sparse-by-default-for-cratesio

But keep the code that makes it work around still, since that doesn't really hurt us. But if we start to get problems with it, like regressions, we remove that code instead of fix it...