### PR TITLE
Support `use<..>` bound

### DIFF
--- a/cargo-public-api/tests/snapshots/cargo_public_api_bin_tests__comprehensive_api.snap
+++ b/cargo-public-api/tests/snapshots/cargo_public_api_bin_tests__comprehensive_api.snap
@@ -117,6 +117,8 @@ pub fn comprehensive_api::functions::return_tuple() -> (bool, comprehensive_api:
 pub fn comprehensive_api::functions::somewhere<T, U>(t: T, u: U) where T: core::fmt::Display, U: core::fmt::Debug
 pub fn comprehensive_api::functions::struct_arg(s: comprehensive_api::structs::PrivateField)
 pub fn comprehensive_api::functions::synthetic_arg(t: impl comprehensive_api::traits::Simple) -> impl comprehensive_api::traits::Simple
+pub fn comprehensive_api::functions::synthetic_use_capture<'a, 'b, T>(x: &'a (), y: T) -> impl core::marker::Sized + use<'a, T>
+pub fn comprehensive_api::functions::synthetic_use_no_capture<'a>(x: &'a usize) -> impl core::marker::Sized + use<>
 pub unsafe fn comprehensive_api::functions::unsafe_fn()
 pub fn comprehensive_api::functions::unused_argument(_: u32)
 pub mod comprehensive_api::higher_ranked_trait_bounds

--- a/public-api/src/render.rs
+++ b/public-api/src/render.rs
@@ -941,7 +941,7 @@ impl<'c> RenderingContext<'c> {
                 let mut output = vec![];
                 output.extend(self.render_higher_rank_trait_bounds(generic_params));
                 match modifier {
-                    TraitBoundModifier::None | TraitBoundModifier::MaybeConst=> {}
+                    TraitBoundModifier::None | TraitBoundModifier::MaybeConst => {}
                     TraitBoundModifier::Maybe => {
                         output.push(Token::symbol("?"));
                     }

--- a/public-api/src/render.rs
+++ b/public-api/src/render.rs
@@ -950,7 +950,30 @@ impl<'c> RenderingContext<'c> {
                 output
             }
             GenericBound::Outlives(id) => vec![Token::lifetime(id)],
-            GenericBound::Use(_) => todo!("Can this code path be triggered with just stable Rust? If you hit this todo with just stable Rust, please file an issue with a minimal reproducer. Thanks!"),
+            GenericBound::Use(params) => {
+                let mut output = vec![Token::keyword("use"), Token::symbol("<")];
+
+                for i in 0..params.len() {
+                    let param = &params[i];
+
+                    // Rustdoc doesn't tell us if the parameter is a lifetime or a generic, so we
+                    // check if the string starts with `'` to see if it is a lifetime.
+                    if param.starts_with('\'') {
+                        output.push(Token::lifetime(param));
+                    } else {
+                        output.push(Token::generic(param));
+                    }
+
+                    // Insert a ", " in between parameters, but not after the final one.
+                    if i < params.len() - 1 {
+                        output.extend_from_slice(&[Token::symbol(","), Token::Whitespace]);
+                    }
+                }
+
+                output.push(Token::symbol(">"));
+
+                output
+            }
         })
     }
 

--- a/public-api/tests/snapshots/public_api_lib_tests__comprehensive_api.snap
+++ b/public-api/tests/snapshots/public_api_lib_tests__comprehensive_api.snap
@@ -117,6 +117,8 @@ pub fn comprehensive_api::functions::return_tuple() -> (bool, comprehensive_api:
 pub fn comprehensive_api::functions::somewhere<T, U>(t: T, u: U) where T: core::fmt::Display, U: core::fmt::Debug
 pub fn comprehensive_api::functions::struct_arg(s: comprehensive_api::structs::PrivateField)
 pub fn comprehensive_api::functions::synthetic_arg(t: impl comprehensive_api::traits::Simple) -> impl comprehensive_api::traits::Simple
+pub fn comprehensive_api::functions::synthetic_use_capture<'a, 'b, T>(x: &'a (), y: T) -> impl core::marker::Sized + use<'a, T>
+pub fn comprehensive_api::functions::synthetic_use_no_capture<'a>(x: &'a usize) -> impl core::marker::Sized + use<>
 pub unsafe fn comprehensive_api::functions::unsafe_fn()
 pub fn comprehensive_api::functions::unused_argument(_: u32)
 pub mod comprehensive_api::higher_ranked_trait_bounds

--- a/test-apis/comprehensive_api/src/functions.rs
+++ b/test-apis/comprehensive_api/src/functions.rs
@@ -81,6 +81,14 @@ pub fn impl_multiple<T>(t: impl Simple + AsRef<T>) -> impl Simple {
     Unit
 }
 
+pub fn synthetic_use_capture<'a, 'b, T>(x: &'a (), y: T) -> impl Sized + use<'a, T> {
+    (x, y)
+}
+
+pub fn synthetic_use_no_capture<'a>(x: &'a usize) -> impl Sized + use<> {
+    *x
+}
+
 pub fn somewhere<T, U>(t: T, u: U)
 where
     T: Display,

--- a/test-apis/comprehensive_api/src/traits.rs
+++ b/test-apis/comprehensive_api/src/traits.rs
@@ -48,8 +48,12 @@ mod private_mod {
 }
 
 pub trait GenericAssociatedTypes {
-    type WhereSelfSized where Self: Sized;
-    type WhereSimple<T> where T: Simple;
+    type WhereSelfSized
+    where
+        Self: Sized;
+    type WhereSimple<T>
+    where
+        T: Simple;
     type SimpleBound: Simple;
     type WithLifetime<'a>;
 }


### PR DESCRIPTION
Fixes #714, please see it for more information!

With this PR, the following code is now processed without crashing:

```rust
pub fn capture<'a, 'b, T>(x: &'a (), y: T) -> impl Sized + use<'a, T> {
    //                                        ~~~~~~~~~~~~~~~~~~~~~~~
    //                                       Captures `'a` and `T` only.
    (x, y)
}
```

This is my first time contributing! Where can I add tests for my changes? Is there anything else I need to do?

Thanks! :)