### PR TITLE
Prepare v0.44.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `cargo-public-api` changelog
 
+## v0.44.1
+* Support precise capturing syntax in function return types: `-> impl Sized + use<'a, T>`
+
 ## v0.44.0
 * Do not render function arg names `""` (`nightly-2025-02-05` and later)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-public-api"
-version = "0.44.0"
+version = "0.44.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "public-api"
-version = "0.44.0"
+version = "0.44.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "cargo-public-api"
-version = "0.44.0"
+version = "0.44.1"
 default-run = "cargo-public-api"
 description = "List and diff the public API of Rust library crates between releases and commits. Detect breaking API changes and semver violations via CI or a CLI."
 homepage = "https://github.com/cargo-public-api/cargo-public-api"
@@ -48,7 +48,7 @@ version = "0.9.4"
 
 [dependencies.public-api]
 path = "../public-api"
-version = "0.44.0"
+version = "0.44.1"
 
 [dependencies.serde]
 version = "1.0.179"

--- a/public-api/CHANGELOG.md
+++ b/public-api/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `public-api` changelog
 
+## v0.44.1
+* Support precise capturing syntax in function return types: `-> impl Sized + use<'a, T>`
+
 ## v0.44.0
 * Do not render function arg names `""` (`nightly-2025-02-05` and later)
 

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "public-api"
-version = "0.44.0"
+version = "0.44.1"
 description = "List and diff the public API of Rust library crates. Relies on rustdoc JSON output from the nightly toolchain."
 homepage = "https://github.com/cargo-public-api/cargo-public-api/tree/main/public-api"
 documentation = "https://docs.rs/public-api"

--- a/repo-tests/Cargo.toml
+++ b/repo-tests/Cargo.toml
@@ -7,5 +7,5 @@ license = "MIT"
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.44.0"
+version = "0.44.1"
 


### PR DESCRIPTION
Note that we don't bump 0.x.0 even though we change the rendering. In this case we can do a simple 0.0.x bump since no one can depend on the old rendering since then they would have hit the `todo!()`.