### PR TITLE
Add .github/workflows/Release-all.yml

### DIFF
--- a/.github/workflows/Release-all.yml
+++ b/.github/workflows/Release-all.yml
@@ -1,0 +1,52 @@
+# .github/workflows/Release-all.yml
+name: Release All
+permissions:
+  contents: none # Minimal default permissions
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_rustup_toolchain:
+        type: boolean
+        description: "Release rustup-toolchain"
+        default: false
+      release_rustdoc_json:
+        type: boolean
+        description: "Release rustdoc-json"
+        default: false
+      release_public_api:
+        type: boolean
+        description: "Release public-api"
+        default: false
+      release_cargo_public_api:
+        type: boolean
+        description: "Release cargo-public-api"
+        default: false
+
+jobs:
+  release-rustup-toolchain:
+    if: inputs.release_rustup_toolchain
+    permissions:
+      contents: write # git push + access to secrets.CARGO_REGISTRY_TOKEN
+    uses: ./.github/workflows/Release-rustup-toolchain.yml
+
+  release-rustdoc-json:
+    if: inputs.release_rustdoc_json
+    needs: [release-rustup-toolchain]
+    permissions:
+      contents: write # git push + access to secrets.CARGO_REGISTRY_TOKEN
+    uses: ./.github/workflows/Release-rustdoc-json.yml
+
+  release-public-api:
+    if: inputs.release_public_api
+    needs: [release-rustdoc-json]
+    permissions:
+      contents: write # git push + access to secrets.CARGO_REGISTRY_TOKEN
+    uses: ./.github/workflows/Release-public-api.yml
+
+  release-cargo-public-api:
+    if: inputs.release_cargo_public_api
+    needs: [release-public-api]
+    permissions:
+      contents: write # git push + access to secrets.CARGO_REGISTRY_TOKEN
+    uses: ./.github/workflows/Release-cargo-public-api.yml

--- a/.github/workflows/Release-cargo-public-api.yml
+++ b/.github/workflows/Release-cargo-public-api.yml
@@ -3,6 +3,7 @@ permissions:
   contents: none # Minimal default permissions
 
 on:
+  workflow_call: # From .github/workflows/Release-all.yml
   workflow_dispatch:
 
 env:
@@ -19,7 +20,7 @@ jobs:
       url: https://crates.io/crates/cargo-public-api
     runs-on: ubuntu-latest
     permissions:
-      contents: write # git push
+      contents: write # git push + access to secrets.CARGO_REGISTRY_TOKEN
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/Release-public-api.yml
+++ b/.github/workflows/Release-public-api.yml
@@ -3,6 +3,7 @@ permissions:
   contents: none # Minimal default permissions
 
 on:
+  workflow_call: # From .github/workflows/Release-all.yml
   workflow_dispatch:
 
 env:
@@ -19,7 +20,7 @@ jobs:
       url: https://crates.io/crates/public-api
     runs-on: ubuntu-latest
     permissions:
-      contents: write # git push
+      contents: write # git push + access to secrets.CARGO_REGISTRY_TOKEN
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/Release-rustdoc-json.yml
+++ b/.github/workflows/Release-rustdoc-json.yml
@@ -3,6 +3,7 @@ permissions:
   contents: none # Minimal default permissions
 
 on:
+  workflow_call: # From .github/workflows/Release-all.yml
   workflow_dispatch:
 
 env:
@@ -19,7 +20,7 @@ jobs:
       url: https://crates.io/crates/rustdoc-json
     runs-on: ubuntu-latest
     permissions:
-      contents: write # git push
+      contents: write # git push + access to secrets.CARGO_REGISTRY_TOKEN
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/Release-rustup-toolchain.yml
+++ b/.github/workflows/Release-rustup-toolchain.yml
@@ -3,6 +3,7 @@ permissions:
   contents: none # Minimal default permissions
 
 on:
+  workflow_call: # From .github/workflows/Release-all.yml
   workflow_dispatch:
 
 env:
@@ -19,7 +20,7 @@ jobs:
       url: https://crates.io/crates/rustup-toolchain
     runs-on: ubuntu-latest
     permissions:
-      contents: write # git push
+      contents: write # git push + access to secrets.CARGO_REGISTRY_TOKEN
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
To allow maintainers to trigger a single job to
make all needed releases instead of baby-sitting
each individual release job.

I'm a bit unsure if this will actually work. Let's try.