### PR TITLE
Replace peter-evans/create-pull-request with custom script

### DIFF
--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -51,19 +51,19 @@ jobs:
       contents: write # Give access to secrets.ENSELICCICD_GITHUB_TOKEN
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.ENSELICCICD_GITHUB_TOKEN }} # for git push
       - run: rustup install nightly --profile minimal
       - run: sudo apt-get install -y zsh && zsh --version
       - run: ./scripts/cargo-test.sh --bless
-      - id: latest-nightly
-        run: echo "version=nightly-$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-      - run: |
-          [ -z "$(git status --porcelain)" ] || echo "${{ steps.latest-nightly.outputs.version }}" > cargo-public-api/MINIMUM_NIGHTLY_RUST_VERSION_FOR_TESTS
-      - uses: peter-evans/create-pull-request@v4
-        with:
-          title: Bless `${{ steps.latest-nightly.outputs.version }}` output
-          commit-message: Bless `${{ steps.latest-nightly.outputs.version }}` output
-          author: EnselicCICD <junta-pixlar0l@icloud.com>
-          body: Automatically created by ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs/${{ github.job }}
-          token: ${{ secrets.ENSELICCICD_GITHUB_TOKEN }}
-          push-to-fork: EnselicCICD/cargo-public-api
-          branch: create-pull-request/${{ steps.latest-nightly.outputs.version }}
+      - name: Check for changes
+        id: check-for-changes
+        run: |
+          echo "changes-detected=$([ -n "$(git status --porcelain)" ] && echo yes || echo no)" >> $GITHUB_OUTPUT
+      - name: Create PR
+        if: steps.check-for-changes.outputs.changes-detected == 'yes'
+        env:
+          GH_TOKEN: ${{ secrets.ENSELICCICD_GITHUB_TOKEN }} # for gh pr create
+          CURRENT_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs/${{ github.job }}
+        run: |
+          ./scripts/create-auto-bless-pr.sh

--- a/scripts/create-auto-bless-pr.sh
+++ b/scripts/create-auto-bless-pr.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -o nounset -o errexit -o pipefail
+
+# When this script is run there are already local git repo changes with new
+# blessed output using latest nightly toolchain. Create a branch to work with.
+nightly_version="nightly-$(date +'%Y-%m-%d')"
+branch_name="auto-bless/$nightly_version"
+git checkout \
+    -b "$branch_name"
+
+# Update MINIMUM_NIGHTLY_RUST_VERSION_FOR_TESTS and then commit all changes.
+echo $nightly_version >cargo-public-api/MINIMUM_NIGHTLY_RUST_VERSION_FOR_TESTS
+git add .
+git commit \
+    --author "Martin Nordholts CI/CD <104096785+EnselicCICD@users.noreply.github.com>" \
+    --message "Bless \`$nightly_version\` output
+
+Automatically created by $CURRENT_JOB_URL
+"
+
+# Create the PR
+git push https://EnselicCICD@github.com/EnselicCICD/cargo-public-api "$branch_name"
+gh config set prompt disabled
+gh pr create \
+    --repo cargo-public-api/cargo-public-api \
+    --base main \
+    --head EnselicCICD:"$branch_name" \
+    --fill


### PR DESCRIPTION
To reduce security risk since the job in question
has access to the token of the `EnselicCICD` user.

~~Todo~~ Done:
- [x] Verify, which will require me to spam PRs for a while, sorry about that.