### PR TITLE
[Experiment] Auto-merge dependabot PRs with a GitHub App instead of a workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -70,4 +70,4 @@ jobs:
         if: runner.os != 'Windows'
       - run: rustup install nightly --profile minimal
       - run: cargo version --verbose # Make it easier to debug version-specific issues
-      - run: scripts/cargo-test.sh
+      - run: false # Never merge


### PR DESCRIPTION
We currently only have one `pull_request_target`-triggered workflow, namely `.github/workflows/Auto-merge-dependabot-PRs.yml`. That kind of workflow is more prone to pwn requests than other workflows.

I'd like to follow the guideline at
https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#considering-cross-repository-access and replace that workflow with a GitHub App.

This PR will be used to test the new GitHub App I am creating.