### PR TITLE
Bring back dependabot auto-merge workflow but don't use `pull_request_target`

### DIFF
--- a/.github/workflows/Auto-merge-dependabot-PRs.yml
+++ b/.github/workflows/Auto-merge-dependabot-PRs.yml
@@ -1,0 +1,31 @@
+# This workflow triggers auto-merge of any PR that dependabot creates so that
+# PRs will be merged automatically without maintainer intervention if CI passes
+name: Auto-merge dependabot PRs
+permissions:
+  contents: none # Minimal default permissions
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  auto-merge:
+    if: github.repository == 'cargo-public-api/cargo-public-api' && github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.user.id == 49699333
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # For pr merge
+      pull-requests: write # For pr review and pr merge
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
+    steps:
+      - run: |
+          gh pr review \
+            --comment \
+            --body "If CI passes, this dependabot PR will be [auto-merged](https://github.com/cargo-public-api/cargo-public-api/blob/main/.github/workflows/Auto-merge-dependabot-PRs.yml) 🚀" \
+            "$PR_URL"
+      - run: |
+          gh pr merge \
+            --auto \
+            --squash \
+            "$PR_URL"


### PR DESCRIPTION
We previously removed our `pull_request_target` based forkflow for security hardening purposes (5ee5ffdc1fafba). Turns out the official docs have an example of an auto-merge wokrflow that does not use `pull_request_target`. Let's use that instead of a GitHub App:
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enabling-automerge-on-a-pull-request