### PR TITLE
CI: Don't create issue about nightly failing if we auto-blessed

### DIFF
--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -50,6 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # Give access to secrets.ENSELICCICD_GITHUB_TOKEN
+    outputs:
+      changes-detected: ${{ steps.check-for-changes.outputs.changes-detected }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Looks like I forgot to declare the output of the job, which is why this was not working before.

Closes https://github.com/cargo-public-api/cargo-public-api/issues/771