### PR TITLE
Stop using EnselicCICD crates.io token for publish

### DIFF
--- a/.github/workflows/Release-all.yml
+++ b/.github/workflows/Release-all.yml
@@ -27,7 +27,7 @@ jobs:
   release-rustup-toolchain:
     if: ${{ !cancelled() && inputs.release_rustup_toolchain }}
     permissions:
-      contents: write # git push + access to secrets.CARGO_REGISTRY_TOKEN
+      contents: write # git push + access to secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC
     uses: ./.github/workflows/Release-rustup-toolchain.yml
     secrets: inherit
 
@@ -35,7 +35,7 @@ jobs:
     if: ${{ !cancelled() && inputs.release_rustdoc_json }}
     needs: [release-rustup-toolchain]
     permissions:
-      contents: write # git push + access to secrets.CARGO_REGISTRY_TOKEN
+      contents: write # git push + access to secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC
     uses: ./.github/workflows/Release-rustdoc-json.yml
     secrets: inherit
 
@@ -43,7 +43,7 @@ jobs:
     if: ${{ !cancelled() && inputs.release_public_api }}
     needs: [release-rustdoc-json]
     permissions:
-      contents: write # git push + access to secrets.CARGO_REGISTRY_TOKEN
+      contents: write # git push + access to secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC
     uses: ./.github/workflows/Release-public-api.yml
     secrets: inherit
 
@@ -51,6 +51,6 @@ jobs:
     if: ${{ !cancelled() && inputs.release_cargo_public_api }}
     needs: [release-public-api]
     permissions:
-      contents: write # git push + access to secrets.CARGO_REGISTRY_TOKEN
+      contents: write # git push + access to secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC
     uses: ./.github/workflows/Release-cargo-public-api.yml
     secrets: inherit

--- a/.github/workflows/Release-cargo-public-api.yml
+++ b/.github/workflows/Release-cargo-public-api.yml
@@ -22,7 +22,7 @@ jobs:
       url: https://crates.io/crates/cargo-public-api
     runs-on: ubuntu-latest
     permissions:
-      contents: write # git push + access to secrets.CARGO_REGISTRY_TOKEN
+      contents: write # git push + access to secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC
     steps:
       - uses: actions/checkout@v4
 
@@ -38,7 +38,7 @@ jobs:
       # version exists at crates.io but not as a git tag.
       - run: cargo publish -p cargo-public-api
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC }}
 
       # Push the tag to git.
       - name: push tag

--- a/.github/workflows/Release-public-api.yml
+++ b/.github/workflows/Release-public-api.yml
@@ -22,7 +22,7 @@ jobs:
       url: https://crates.io/crates/public-api
     runs-on: ubuntu-latest
     permissions:
-      contents: write # git push + access to secrets.CARGO_REGISTRY_TOKEN
+      contents: write # git push + access to secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC
     steps:
       - uses: actions/checkout@v4
 
@@ -38,7 +38,7 @@ jobs:
       # version exists at crates.io but not as a git tag.
       - run: cargo publish -p public-api
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC }}
 
       # Push the tag to git.
       - name: push tag

--- a/.github/workflows/Release-rustdoc-json.yml
+++ b/.github/workflows/Release-rustdoc-json.yml
@@ -22,7 +22,7 @@ jobs:
       url: https://crates.io/crates/rustdoc-json
     runs-on: ubuntu-latest
     permissions:
-      contents: write # git push + access to secrets.CARGO_REGISTRY_TOKEN
+      contents: write # git push + access to secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC
     steps:
       - uses: actions/checkout@v4
 
@@ -38,7 +38,7 @@ jobs:
       # version exists at crates.io but not as a git tag.
       - run: cargo publish -p rustdoc-json
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC }}
 
       # Push the tag to git.
       - name: push tag

--- a/.github/workflows/Release-rustup-toolchain.yml
+++ b/.github/workflows/Release-rustup-toolchain.yml
@@ -22,7 +22,7 @@ jobs:
       url: https://crates.io/crates/rustup-toolchain
     runs-on: ubuntu-latest
     permissions:
-      contents: write # git push + access to secrets.CARGO_REGISTRY_TOKEN
+      contents: write # git push + access to secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC
     steps:
       - uses: actions/checkout@v4
 
@@ -38,7 +38,7 @@ jobs:
       # version exists at crates.io but not as a git tag.
       - run: cargo publish -p rustup-toolchain
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC }}
 
       # Push the tag to git.
       - name: push tag


### PR DESCRIPTION
The reason we use EnselicCICD in a GitHub Org Team to make releases is that before https://github.com/rust-lang/crates.io/issues/5443 was implemented, that was the only way to have a crates.io token that did not allow changing owners, which is needed to avoid hostile takeovers in case of token leaks.

Now that https://github.com/rust-lang/crates.io/issues/5443 has been implemented for quite a long time, we can switch over to using `publish-update`-scoped tokens (i.e. tokens that do not have the `change-owners` scope).

For now I just added my token, but other maintainers are free to add their tokens for when they make releases. We'd need to figure out exactly how to safetly make a toggle, however.

After this transition is complete, I think we can remove EnselicCICD from our org, which would strengthen our security. Not that that account has low security, but it's just an unnecessary attack surface.