### PR TITLE
README.md: Only show last 6 months in Compatibility Matrix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,6 +1029,7 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 name = "release-helper"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "jiff",
  "pretty_assertions",
  "semver",

--- a/README.md
+++ b/README.md
@@ -159,12 +159,7 @@ cargo public-api -sss
 | 0.43.x — 0.44.x  | nightly-2025-01-25 — nightly-2025-03-13 |
 | 0.40.x — 0.42.x  | nightly-2024-10-18 — nightly-2025-01-24 |
 | 0.39.x           | nightly-2024-10-13 — nightly-2024-10-17 |
-| 0.38.x           | nightly-2024-09-10 — nightly-2024-10-12 |
-| 0.37.x           | nightly-2024-07-05 — nightly-2024-09-09 |
-| 0.35.x — 0.36.x  | nightly-2024-06-07 — nightly-2024-07-04 |
-| 0.32.x — 0.34.x  | nightly-2023-08-25 — nightly-2024-06-06 |
-| 0.30.x — 0.31.x  | nightly-2023-05-24 — nightly-2023-08-24 |
-| earlier versions | see [here](https://github.com/cargo-public-api/cargo-public-api/blob/7056d59cd279610fc61cc9669be3840b0dd8273c/README.md#compatibility-matrix) |
+| earlier versions | see [here](https://github.com/cargo-public-api/cargo-public-api/blob/main/scripts/release-helper/src/version_info.rs) |
 
 # Contributing
 

--- a/scripts/release-helper/Cargo.toml
+++ b/scripts/release-helper/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 
+[dependencies.clap]
+version = "4.5.0"
+features = ["derive", "wrap_help"]
+
 [dependencies.jiff]
 version = "0.1.15"
 default-features = false

--- a/scripts/release-helper/src/bin/update-version-info/main.rs
+++ b/scripts/release-helper/src/bin/update-version-info/main.rs
@@ -1,6 +1,18 @@
 //! See `docs/RELEASE.md` for information on how to use this.
 
+#[derive(clap::Parser, Debug)]
+#[command(author, version, about)]
+struct Args {
+    #[arg(long, default_value_t = 6)]
+    min_compatibility_matrix_rows: usize,
+
+    #[arg(long, default_value_t = 6)]
+    max_compatibility_matrix_months_back: i64,
+}
+
 fn main() {
+    let args = <Args as clap::Parser>::parse();
+
     let current_min_nightly_rust_version =
         release_helper::version_info::TABLE[0].min_nightly_rust_version;
 
@@ -12,7 +24,11 @@ fn main() {
 | Version          | Understands the rustdoc JSON output of  |
 | ---------------- | --------------------------------------- |
 ",
-        &release_helper::compatibility_matrix::render(release_helper::version_info::TABLE),
+        &release_helper::compatibility_matrix::render(
+            release_helper::version_info::TABLE,
+            Some(args.min_compatibility_matrix_rows),
+            Some(args.max_compatibility_matrix_months_back),
+        ),
         "| earlier versions | see [here]",
     );
     insert_file_contents_in_between(


### PR DESCRIPTION
I bet 90% of readers don't care about versions older than that. And if they do we still reference the full info.