### PR TITLE
rustup-toolchain: Port to Rust Edition 2024

### DIFF
--- a/rustup-toolchain/Cargo.toml
+++ b/rustup-toolchain/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "rustup-toolchain"
 version = "0.1.10"
 description = "Utilities for working with rustup toolchains, primarily from cargo test:s."

--- a/rustup-toolchain/src/lib.rs
+++ b/rustup-toolchain/src/lib.rs
@@ -17,7 +17,9 @@ pub enum Error {
     IoError(#[from] std::io::Error),
 
     /// The lock used to work around <https://github.com/rust-lang/rustup/issues/988> has been poisoned
-    #[error("The lock used to work around https://github.com/rust-lang/rustup/issues/988 has been poisoned")]
+    #[error(
+        "The lock used to work around https://github.com/rust-lang/rustup/issues/988 has been poisoned"
+    )]
     StdSyncPoisonError,
 
     /// `rustup toolchain install ...` failed for some reason

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -o nounset -o errexit -o pipefail
+set -o nounset -o errexit -o pipefail -o xtrace
 
 cargo fmt -- --check
 


### PR DESCRIPTION
Also add xtrace to lint.sh so it's easy to see what command that fails.