### PR TITLE
Prepare for trusted publishing to crates.io

### DIFF
--- a/.github/workflows/Release-all.yml
+++ b/.github/workflows/Release-all.yml
@@ -27,30 +27,30 @@ jobs:
   release-rustup-toolchain:
     if: ${{ !cancelled() && inputs.release_rustup_toolchain }}
     permissions:
-      contents: write # git push + access to secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC
+      contents: write # git push
+      id-token: write # https://crates.io/docs/trusted-publishing
     uses: ./.github/workflows/Release-rustup-toolchain.yml
-    secrets: inherit
 
   release-rustdoc-json:
     if: ${{ !cancelled() && inputs.release_rustdoc_json }}
     needs: [release-rustup-toolchain]
     permissions:
-      contents: write # git push + access to secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC
+      contents: write # git push
+      id-token: write # https://crates.io/docs/trusted-publishing
     uses: ./.github/workflows/Release-rustdoc-json.yml
-    secrets: inherit
 
   release-public-api:
     if: ${{ !cancelled() && inputs.release_public_api }}
     needs: [release-rustdoc-json]
     permissions:
-      contents: write # git push + access to secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC
+      contents: write # git push
+      id-token: write # https://crates.io/docs/trusted-publishing
     uses: ./.github/workflows/Release-public-api.yml
-    secrets: inherit
 
   release-cargo-public-api:
     if: ${{ !cancelled() && inputs.release_cargo_public_api }}
     needs: [release-public-api]
     permissions:
-      contents: write # git push + access to secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC
+      contents: write # git push
+      id-token: write # https://crates.io/docs/trusted-publishing
     uses: ./.github/workflows/Release-cargo-public-api.yml
-    secrets: inherit

--- a/.github/workflows/Release-cargo-public-api.yml
+++ b/.github/workflows/Release-cargo-public-api.yml
@@ -22,9 +22,12 @@ jobs:
       url: https://crates.io/crates/cargo-public-api
     runs-on: ubuntu-latest
     permissions:
-      contents: write # git push + access to secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC
+      contents: write # git push
+      id-token: write # https://crates.io/docs/trusted-publishing
     steps:
       - uses: actions/checkout@v4
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
 
       # Figure out what tag to use
       - name: calculate version
@@ -38,7 +41,7 @@ jobs:
       # version exists at crates.io but not as a git tag.
       - run: cargo publish -p cargo-public-api
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
       # Push the tag to git.
       - name: push tag

--- a/.github/workflows/Release-public-api.yml
+++ b/.github/workflows/Release-public-api.yml
@@ -22,9 +22,12 @@ jobs:
       url: https://crates.io/crates/public-api
     runs-on: ubuntu-latest
     permissions:
-      contents: write # git push + access to secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC
+      contents: write # git push
+      id-token: write # https://crates.io/docs/trusted-publishing
     steps:
       - uses: actions/checkout@v4
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
 
       # Figure out what tag to use
       - name: calculate version
@@ -38,7 +41,7 @@ jobs:
       # version exists at crates.io but not as a git tag.
       - run: cargo publish -p public-api
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
       # Push the tag to git.
       - name: push tag

--- a/.github/workflows/Release-rustdoc-json.yml
+++ b/.github/workflows/Release-rustdoc-json.yml
@@ -22,9 +22,12 @@ jobs:
       url: https://crates.io/crates/rustdoc-json
     runs-on: ubuntu-latest
     permissions:
-      contents: write # git push + access to secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC
+      contents: write # git push
+      id-token: write # https://crates.io/docs/trusted-publishing
     steps:
       - uses: actions/checkout@v4
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
 
       # Figure out what tag to use
       - name: calculate version
@@ -38,7 +41,7 @@ jobs:
       # version exists at crates.io but not as a git tag.
       - run: cargo publish -p rustdoc-json
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
       # Push the tag to git.
       - name: push tag

--- a/.github/workflows/Release-rustup-toolchain.yml
+++ b/.github/workflows/Release-rustup-toolchain.yml
@@ -22,9 +22,12 @@ jobs:
       url: https://crates.io/crates/rustup-toolchain
     runs-on: ubuntu-latest
     permissions:
-      contents: write # git push + access to secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC
+      contents: write # git push
+      id-token: write # https://crates.io/docs/trusted-publishing
     steps:
       - uses: actions/checkout@v4
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
 
       # Figure out what tag to use
       - name: calculate version
@@ -38,7 +41,7 @@ jobs:
       # version exists at crates.io but not as a git tag.
       - run: cargo publish -p rustup-toolchain
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_PUBLISH_UPDATE_TOKEN_ENSELIC }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
       # Push the tag to git.
       - name: push tag


### PR DESCRIPTION
See https://crates.io/docs/trusted-publishing.

That way we don't need to store a long-lived token in our repository settings. The only secret someone needs to store the JWT private key of GitHub. I think it is safe to assume that their security engineers are going to do a better job at keeping secrets than us.

TODO:
- [x] Wait for a need to make a release
- [x] Configure Trusted Publishing on crates.io
- [x] Verify this PR by making the release(s) through Trusted Publishing
- [ ] Remove the token from our repo secrets once we have confirmed this works