### PR TITLE
CI: Windows does not run any tests, so remove

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,7 +59,6 @@ jobs:
         variant:
           - { name: Ubuntu,  os: ubuntu-latest  }
           - { name: macOS,   os: macos-latest   }
-          - { name: Windows, os: windows-latest }
     name: cargo test (${{ matrix.variant.name }})
     runs-on: ${{ matrix.variant.os }}
     permissions:


### PR DESCRIPTION
Windows does not actually run any tests so CI is always green.

Let's remove the job to not make it appear like we test for Windows, until someone has interest and time to fix the Windows CI.

cc @Emilgardis who maybe want to take a look? IIRC you added the Windows job