### PR TITLE
Support `nightly-2025-08-02` and later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `cargo-public-api` changelog
 
+## v0.50.0
+* Support `nightly-2025-08-02` and later.
+
 ## v0.49.0
 * Support `nightly-2025-07-17` and later.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-public-api"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1289,9 +1289,9 @@ dependencies = [
 
 [[package]]
 name = "rustdoc-types"
-version = "0.54.0"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "814bc4dddadb32bef41ec20b836b35aa7aaf88356c721a0dd9cda41331394b8b"
+checksum = "61f25a84ea78419de928cd82c3b2f76709a696a64a880486c567b4c4da8f2dda"
 dependencies = [
  "serde",
  "serde_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,7 +1274,7 @@ checksum = "2febf9acc5ee5e99d1ad0afcdbccc02d87aa3f857a1f01f825b80eacf8edfcd1"
 
 [[package]]
 name = "rustdoc-json"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "assert_cmd",
  "cargo-manifest",

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install the `cargo public-api` subcommand with a recent regular **stable** Rust 
 cargo +stable install cargo-public-api --locked
 ```
 
-Ensure **nightly-2025-07-17** or later is installed (does not need to be the active toolchain) so `cargo public-api` can build rustdoc JSON for you:
+Ensure **nightly-2025-08-02** or later is installed (does not need to be the active toolchain) so `cargo public-api` can build rustdoc JSON for you:
 
 ```sh
 rustup install nightly --profile minimal
@@ -155,12 +155,12 @@ cargo public-api -sss
 
 | Version          | Understands the rustdoc JSON output of  |
 | ---------------- | --------------------------------------- |
-| 0.49.x           | nightly-2025-07-17 —                    |
+| 0.50.x           | nightly-2025-08-02 —                    |
+| 0.49.x           | nightly-2025-07-17 — nightly-2025-08-01 |
 | 0.48.x           | nightly-2025-06-22 — nightly-2025-07-16 |
 | 0.47.x           | nightly-2025-03-24 — nightly-2025-06-21 |
 | 0.46.x           | nightly-2025-03-16 — nightly-2025-03-23 |
 | 0.45.x           | nightly-2025-03-14 — nightly-2025-03-15 |
-| 0.43.x — 0.44.x  | nightly-2025-01-25 — nightly-2025-03-13 |
 | earlier versions | see [here](https://github.com/cargo-public-api/cargo-public-api/blob/main/scripts/release-helper/src/version_info.rs) |
 
 # Contributing

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "cargo-public-api"
-version = "0.49.0"
+version = "0.50.0"
 default-run = "cargo-public-api"
 description = "List and diff the public API of Rust library crates between releases and commits. Detect breaking API changes and semver violations via CI or a CLI."
 homepage = "https://github.com/cargo-public-api/cargo-public-api"

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -40,7 +40,7 @@ features = ["serde"]
 
 [dependencies.rustdoc-json]
 path = "../rustdoc-json"
-version = "0.9.6"
+version = "0.9.7"
 
 [dependencies.public-api]
 path = "../public-api"

--- a/public-api/CHANGELOG.md
+++ b/public-api/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `public-api` changelog
 
+## v0.50.0
+* Support `nightly-2025-08-02` and later.
+
 ## v0.49.0
 * Support `nightly-2025-07-17` and later.
 

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -38,7 +38,7 @@ default-features = false
 
 [dev-dependencies.rustdoc-json]
 path = "../rustdoc-json"
-version = "0.9.6"
+version = "0.9.7"
 
 [dev-dependencies.predicates]
 version = "3.1.3"

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -23,7 +23,7 @@ version = "1.0.104"
 features = ["unbounded_depth"]
 
 [dependencies.rustdoc-types]
-version = "0.54.0"
+version = "0.55.0"
 
 [dev-dependencies]
 anyhow = "1.0.75"

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -62,7 +62,7 @@ pub use public_item::PublicItem;
 /// The rustdoc JSON format is still changing, so every now and then we update
 /// this library to support the latest format. If you use this version of
 /// nightly or later, you should be fine.
-pub const MINIMUM_NIGHTLY_RUST_VERSION: &str = "nightly-2025-07-17";
+pub const MINIMUM_NIGHTLY_RUST_VERSION: &str = "nightly-2025-08-02";
 // End-marker for scripts/release-helper/src/bin/update-version-info/main.rs
 
 /// See [`Builder`] method docs for what each field means.

--- a/rustdoc-json/CHANGELOG.md
+++ b/rustdoc-json/CHANGELOG.md
@@ -1,5 +1,8 @@
 # rustdoc-json
 
+## v0.9.7
+* Bump `cargo_metadata` from `0.19.2` to `0.21.0`.
+
 ## v0.9.6
 * Don't panic on `resolver = 3` in `Cargo.toml`.
 

--- a/rustdoc-json/Cargo.toml
+++ b/rustdoc-json/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "rustdoc-json"
-version = "0.9.6"
+version = "0.9.7"
 description = "Utilities for working with rustdoc JSON."
 homepage = "https://github.com/cargo-public-api/cargo-public-api/tree/main/rustdoc-json"
 documentation = "https://docs.rs/rustdoc-json"

--- a/scripts/release-helper/src/version_info.rs
+++ b/scripts/release-helper/src/version_info.rs
@@ -7,6 +7,10 @@ pub struct CargoPublicApiVersionInfo {
 
 pub static TABLE: &[CargoPublicApiVersionInfo] = &[
     CargoPublicApiVersionInfo {
+        cargo_public_api_version: "0.50.x",
+        min_nightly_rust_version: "nightly-2025-08-02",
+    },
+    CargoPublicApiVersionInfo {
         cargo_public_api_version: "0.49.x",
         min_nightly_rust_version: "nightly-2025-07-17",
     },


### PR DESCRIPTION
Closes https://github.com/cargo-public-api/cargo-public-api/issues/813

Opened by https://github.com/rust-lang/rust/pull/144700