### PR TITLE
Fixup 0.50.0 release with 0.50.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # `cargo-public-api` changelog
 
-## v0.50.0
+## v0.50.1
 * Support `nightly-2025-08-02` and later.
 
 ## v0.49.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-public-api"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "public-api"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "cargo-public-api"
-version = "0.50.0"
+version = "0.50.1"
 default-run = "cargo-public-api"
 description = "List and diff the public API of Rust library crates between releases and commits. Detect breaking API changes and semver violations via CI or a CLI."
 homepage = "https://github.com/cargo-public-api/cargo-public-api"
@@ -44,7 +44,7 @@ version = "0.9.7"
 
 [dependencies.public-api]
 path = "../public-api"
-version = "0.49.0"
+version = "0.50.0"
 
 [dependencies.serde]
 version = "1.0.179"

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "public-api"
-version = "0.49.0"
+version = "0.50.0"
 description = "List and diff the public API of Rust library crates. Relies on rustdoc JSON output from the nightly toolchain."
 homepage = "https://github.com/cargo-public-api/cargo-public-api/tree/main/public-api"
 documentation = "https://docs.rs/public-api"

--- a/repo-tests/Cargo.toml
+++ b/repo-tests/Cargo.toml
@@ -7,5 +7,5 @@ license = "MIT"
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.49.0"
+version = "0.50.0"
 


### PR DESCRIPTION
version of public-api was forgotten to be bumped to 0.50.0.