### PR TITLE
Stop enforcing clippy::all to make maintenance easier

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -46,7 +46,6 @@
 				"--all-features",
 				"--",
 				"--deny",
-				"clippy::all",
 				"--deny",
 				"clippy::pedantic",
 				"--deny",

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -1,6 +1,3 @@
-// deny in CI, only warn here
-#![warn(clippy::all)]
-
 use std::ffi::OsString;
 use std::io::{stderr, stdout};
 use std::path::{Path, PathBuf};

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -1,6 +1,3 @@
-// deny in CI, only warn here
-#![warn(clippy::all)]
-
 //! To update expected output it is in many cases sufficient to run
 //! ```bash
 //! ./scripts/cargo-test.sh --update-snapshots

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -32,7 +32,7 @@
 //! ```
 
 // deny in CI, only warn here
-#![warn(clippy::all, missing_docs)]
+#![warn(missing_docs)]
 
 mod crate_wrapper;
 mod error;

--- a/public-api/tests/public-api-lib-tests.rs
+++ b/public-api/tests/public-api-lib-tests.rs
@@ -1,6 +1,3 @@
-// deny in CI, only warn here
-#![warn(clippy::all)]
-
 use std::{fs, io::Write, path::PathBuf};
 
 use public_api::Error;

--- a/repo-tests/tests/repo-tests.rs
+++ b/repo-tests/tests/repo-tests.rs
@@ -1,6 +1,3 @@
-// deny in CI, only warn here
-#![warn(clippy::all)]
-
 use std::{ffi::OsStr, fs::read_to_string, path::PathBuf};
 
 use public_api::MINIMUM_NIGHTLY_RUST_VERSION;

--- a/rustdoc-json/src/lib.rs
+++ b/rustdoc-json/src/lib.rs
@@ -18,7 +18,7 @@
 //! [here](https://github.com/cargo-public-api/cargo-public-api/blob/main/rustdoc-json/examples/build-rustdoc-json.rs)
 
 // deny in CI, only warn here
-#![warn(clippy::all, missing_docs)]
+#![warn(missing_docs)]
 
 use std::path::PathBuf;
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -10,7 +10,6 @@ cargo clippy \
     --all-targets \
     --all-features \
     -- \
-    --deny clippy::all \
     --deny warnings \
     --forbid unsafe_code
 


### PR DESCRIPTION
Making long-term maintenance as easy as possible has been a high prio goal for quite a while. Just never got around to doing this before.