### PR TITLE
Add support for passing environment variables to the child process

### DIFF
--- a/public-api/tests/snapshots/rustdoc-json_public-api.txt
+++ b/public-api/tests/snapshots/rustdoc-json_public-api.txt
@@ -140,7 +140,7 @@ pub fn rustdoc_json::Builder::clear_target_dir(self) -> Self
 pub fn rustdoc_json::Builder::clear_toolchain(self) -> Self
 pub const fn rustdoc_json::Builder::color(self, color: rustdoc_json::Color) -> Self
 pub fn rustdoc_json::Builder::document_private_items(self, document_private_items: bool) -> Self
-pub fn rustdoc_json::Builder::env<K, V>(self, key: K, val: V) -> Self where K: core::convert::AsRef<std::ffi::os_str::OsStr>, V: core::convert::AsRef<std::ffi::os_str::OsStr>
+pub fn rustdoc_json::Builder::env(self, key: impl core::convert::AsRef<std::ffi::os_str::OsStr>, val: impl core::convert::AsRef<std::ffi::os_str::OsStr>) -> Self
 pub fn rustdoc_json::Builder::features<I: core::iter::traits::collect::IntoIterator<Item = S>, S: core::convert::AsRef<str>>(self, features: I) -> Self
 pub fn rustdoc_json::Builder::manifest_path(self, manifest_path: impl core::convert::AsRef<std::path::Path>) -> Self
 pub const fn rustdoc_json::Builder::no_default_features(self, no_default_features: bool) -> Self

--- a/public-api/tests/snapshots/rustdoc-json_public-api.txt
+++ b/public-api/tests/snapshots/rustdoc-json_public-api.txt
@@ -140,6 +140,7 @@ pub fn rustdoc_json::Builder::clear_target_dir(self) -> Self
 pub fn rustdoc_json::Builder::clear_toolchain(self) -> Self
 pub const fn rustdoc_json::Builder::color(self, color: rustdoc_json::Color) -> Self
 pub fn rustdoc_json::Builder::document_private_items(self, document_private_items: bool) -> Self
+pub fn rustdoc_json::Builder::env<K, V>(self, key: K, val: V) -> Self where K: core::convert::AsRef<std::ffi::os_str::OsStr>, V: core::convert::AsRef<std::ffi::os_str::OsStr>
 pub fn rustdoc_json::Builder::features<I: core::iter::traits::collect::IntoIterator<Item = S>, S: core::convert::AsRef<str>>(self, features: I) -> Self
 pub fn rustdoc_json::Builder::manifest_path(self, manifest_path: impl core::convert::AsRef<std::path::Path>) -> Self
 pub const fn rustdoc_json::Builder::no_default_features(self, no_default_features: bool) -> Self

--- a/rustdoc-json/src/builder.rs
+++ b/rustdoc-json/src/builder.rs
@@ -445,11 +445,7 @@ impl Builder {
     /// - Spawned `cargo rustdoc` processes will inherit environment variables from their parent process by default.
     ///   Environment variables explicitly set using this take precedence over inherited variables.
     #[must_use]
-    pub fn env<K, V>(mut self, key: K, val: V) -> Self
-    where
-        K: AsRef<OsStr>,
-        V: AsRef<OsStr>,
-    {
+    pub fn env(mut self, key: impl AsRef<OsStr>, val: impl AsRef<OsStr>) -> Self {
         self.envs
             .insert(key.as_ref().to_owned(), val.as_ref().to_owned());
         self

--- a/rustdoc-json/tests/rustdoc-json-lib-tests.rs
+++ b/rustdoc-json/tests/rustdoc-json-lib-tests.rs
@@ -134,7 +134,13 @@ fn pass_environment_variable() {
     let mut stdout = vec![];
     let mut stderr = vec![];
 
-    let non_existent_rustdoc_executable = "/non/existent/rustdoc/executable";
+    let non_existent_rustdoc_executable = if std::env::consts::OS.eq("windows") {
+        // Windows needs a disk drive in the path.
+        // Otherwise it will add it implicitly and test will fail.
+        "D:/non/existent/rustdoc/executable"
+    } else {
+        "/non/existent/rustdoc/executable"
+    };
 
     let result = rustdoc_json::Builder::default()
         .toolchain("nightly")

--- a/rustdoc-json/tests/rustdoc-json-lib-tests.rs
+++ b/rustdoc-json/tests/rustdoc-json-lib-tests.rs
@@ -143,7 +143,7 @@ fn pass_environment_variable() {
         .color(rustdoc_json::Color::Never)
         // Pass an invalid rustdoc executable path via the environment variable.
         // This should cause a fail with the expected error message.
-        .env("RUSTDOC", &non_existent_rustdoc_executable)
+        .env("RUSTDOC", non_existent_rustdoc_executable)
         .target_dir(&target_dir)
         .build_with_captured_output(&mut stdout, &mut stderr);
 


### PR DESCRIPTION
Hi! 👋

First of all, thank you for this project!

I ran into a use case where I need `rustdoc-json` as a library in multi-threaded code.
I need to pass an environment variables to the `rustc` that is running in the child process spawned by `rustdoc-json`.
The problem is that using `std::env::set_var` is not an option for me because it is unsafe in a multi-threaded code.
Setting environment variables in the `shell` is not feasible for me as well.

This PR is a proposal to add support for passing environment variables to the spawned child process.
I hope this could be useful to others as well.

### What?

- Add Builder::env(key, val) (mirroring std::process::Command::env).
- Update snapshot.
- Add a test.

Please let me know are you interested in this contribution.
If you’re open to it, I’ll be happy to make any adjustments needed to get this merged.