### PR TITLE
`Box<dyn ...>` with two or more traits

### DIFF
--- a/cargo-public-api/tests/snapshots/comprehensive_api.txt
+++ b/cargo-public-api/tests/snapshots/comprehensive_api.txt
@@ -93,6 +93,7 @@ pub fn comprehensive_api::exports::v1::foo2()
 pub mod comprehensive_api::functions
 pub async fn comprehensive_api::functions::async_fn()
 pub async fn comprehensive_api::functions::async_fn_ret_bool() -> bool
+pub fn comprehensive_api::functions::box_dyn_arg_two_traits(d: alloc::boxed::Box<(dyn std::io::Write + core::marker::Send)>)
 pub const fn comprehensive_api::functions::const_fn()
 pub fn comprehensive_api::functions::dyn_arg_one_trait(d: &dyn std::io::Write)
 pub fn comprehensive_api::functions::dyn_arg_one_trait_one_lifetime(d: &(dyn std::io::Write + 'static))

--- a/public-api/tests/snapshots/comprehensive_api.txt
+++ b/public-api/tests/snapshots/comprehensive_api.txt
@@ -93,6 +93,7 @@ pub fn comprehensive_api::exports::v1::foo2()
 pub mod comprehensive_api::functions
 pub async fn comprehensive_api::functions::async_fn()
 pub async fn comprehensive_api::functions::async_fn_ret_bool() -> bool
+pub fn comprehensive_api::functions::box_dyn_arg_two_traits(d: alloc::boxed::Box<(dyn std::io::Write + core::marker::Send)>)
 pub const fn comprehensive_api::functions::const_fn()
 pub fn comprehensive_api::functions::dyn_arg_one_trait(d: &dyn std::io::Write)
 pub fn comprehensive_api::functions::dyn_arg_one_trait_one_lifetime(d: &(dyn std::io::Write + 'static))

--- a/test-apis/comprehensive_api/src/functions.rs
+++ b/test-apis/comprehensive_api/src/functions.rs
@@ -113,6 +113,8 @@ pub fn dyn_arg_two_traits(d: &(dyn std::io::Write + Send)) {}
 
 pub fn dyn_arg_two_traits_one_lifetime(d: &(dyn std::io::Write + Send + 'static)) {}
 
+pub fn box_dyn_arg_two_traits(d: Box<dyn std::io::Write + Send>) {}
+
 pub unsafe fn unsafe_fn() {}
 
 pub async fn async_fn() {}


### PR DESCRIPTION
This is more of an issue than a PR.

If you have a `Box<dyn ...>` type with two or more traits, `public-api` wants to wrap the `dyn ...` in parentheses.

However, nightly Rust then complains about the parentheses ([playground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&gist=85c40071d77d08c5c104fec63f065562)).

The problem appears to be here: https://github.com/cargo-public-api/cargo-public-api/blob/0d022e13912af7036340729b2df254c5ef467ad6/public-api/src/render.rs#L423-L426

I don't know how easy this would be to fix.