### PR TITLE
ci: Use Rust 1.92 for linting

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,7 +50,7 @@ jobs:
           checksum: true
           fallback: none
       # Use a fixed version for lints to avoid CI failure with new versions. Bump as needed.
-      - run: rustup install 1.88 --profile default && rustup default 1.88
+      - run: lint_toolchain=1.92 ; rustup install $lint_toolchain --profile default && rustup default $lint_toolchain
       - run: cargo version --verbose # Make it easier to debug version-specific issues
       - run: ./scripts/lint.sh
 

--- a/public-api/src/crate_wrapper.rs
+++ b/public-api/src/crate_wrapper.rs
@@ -6,7 +6,7 @@ pub struct CrateWrapper<'c> {
     crate_: &'c Crate,
 
     /// Normally, an item referenced by [`Id`] is present in the rustdoc JSON.
-    /// If [`Self::crate_.index`] is missing an [`Id`], then we add it here, to
+    /// If `Self::crate_.index` is missing an [`Id`], then we add it here, to
     /// aid with debugging. It will typically be missing because of bugs (or
     /// borderline bug such as re-exports of foreign items like discussed in
     /// <https://github.com/rust-lang/rust/pull/99287#issuecomment-1186586518>)


### PR DESCRIPTION
And fix this:

    error: unresolved link to `Self::crate_.index`
     --> public-api/src/crate_wrapper.rs:9:14
      |
    9 |     /// If [`Self::crate_.index`] is missing an [`Id`], then we add it here, to
      |              ^^^^^^^^^^^^^^^^^^ the struct `CrateWrapper` has no field or associated item named `crate_.index`
      |
      = note: `-D rustdoc::broken-intra-doc-links` implied by `-D warnings`
      = help: to override `-D warnings` add `#[allow(rustdoc::broken_intra_doc_links)]`