### PR TITLE
Use `cargo_bin_cmd!()` instead of deprecated `assert_cmd::Command::cargo_bin()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `cargo-public-api` changelog
 
+## v0.50.2
+* Bump deps (to stop using deprecated `assert_cmd::Command::cargo_bin()` in tests).
+
 ## v0.50.1
 * Support `nightly-2025-08-02` and later.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-public-api"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,7 +1004,7 @@ checksum = "2febf9acc5ee5e99d1ad0afcdbccc02d87aa3f857a1f01f825b80eacf8edfcd1"
 
 [[package]]
 name = "rustdoc-json"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "assert_cmd",
  "cargo-manifest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.0"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -85,13 +85,12 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.17"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+checksum = "bcbb6924530aa9e0432442af08bbcafdad182db80d2e560da42a6d442535bf85"
 dependencies = [
  "anstyle",
  "bstr",
- "doc-comment",
  "libc",
  "predicates",
  "predicates-core",
@@ -131,13 +130,12 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.4.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
- "once_cell",
- "regex-automata 0.1.10",
+ "regex-automata",
  "serde",
 ]
 
@@ -504,12 +502,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,9 +700,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libz-sys"
@@ -748,14 +740,14 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.4.10",
+ "regex-automata",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "miow"
@@ -798,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl-probe"
@@ -860,15 +852,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -886,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -914,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -949,12 +941,6 @@ dependencies = [
  "redox_syscall 0.2.16",
  "thiserror 1.0.69",
 ]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-automata"
@@ -1109,18 +1095,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1249,9 +1245,9 @@ checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1283,9 +1279,9 @@ dependencies = [
 
 [[package]]
 name = "termtree"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -1462,7 +1458,7 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex-automata 0.4.10",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -1479,9 +1475,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "utf8parse"
@@ -1509,9 +1505,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wait-timeout"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "public-api"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -40,7 +40,7 @@ features = ["serde"]
 
 [dependencies.rustdoc-json]
 path = "../rustdoc-json"
-version = "0.9.7"
+version = "0.9.8"
 
 [dependencies.public-api]
 path = "../public-api"

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -44,7 +44,7 @@ version = "0.9.8"
 
 [dependencies.public-api]
 path = "../public-api"
-version = "0.50.1"
+version = "0.50.2"
 
 [dependencies.serde]
 version = "1.0.179"

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -76,7 +76,7 @@ default-features = false
 features = ["alloc"]
 
 [dev-dependencies]
-assert_cmd = "2.0.17"
+assert_cmd = "2.1.1"
 home = "0.5.12"
 remove_dir_all = "1.0.0"
 tempfile = "3.19.1"

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "cargo-public-api"
-version = "0.50.1"
+version = "0.50.2"
 default-run = "cargo-public-api"
 description = "List and diff the public API of Rust library crates between releases and commits. Detect breaking API changes and semver violations via CI or a CLI."
 homepage = "https://github.com/cargo-public-api/cargo-public-api"

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -14,6 +14,7 @@ use std::{
 
 use assert_cmd::Command;
 use assert_cmd::assert::Assert;
+use assert_cmd::cargo::cargo_bin_cmd;
 use jiff::ToSpan;
 use jiff::civil::Date;
 use predicates::prelude::PredicateBooleanExt;
@@ -37,7 +38,7 @@ const COMPILATION_ERROR_TOOLCHAIN: &str = "nightly-2022-06-01";
 
 #[test]
 fn list_public_items() {
-    let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();
+    let mut cmd = cargo_bin_cmd!("cargo-public-api");
 
     // Other tests use --simplified. Here we use -s to make sure that also works
     cmd.arg("-s");
@@ -1082,7 +1083,7 @@ fn long_diff_help() {
 fn long_help_wraps() {
     let max_allowed_line_length = 125; // 120 with some margin
 
-    let mut cmd = Command::cargo_bin("cargo-public-api").unwrap();
+    let mut cmd = cargo_bin_cmd!("cargo-public-api");
     cmd.arg("--help");
 
     let output = cmd.output().unwrap();
@@ -1387,7 +1388,7 @@ impl From<TestCmdType<'_>> for Command {
 
                 Command::from_std(cargo_cmd)
             }
-            TestCmdType::Bin => Command::cargo_bin("cargo-public-api").unwrap(),
+            TestCmdType::Bin => cargo_bin_cmd!("cargo-public-api"),
         }
     }
 }
@@ -1533,10 +1534,8 @@ impl AssertOrUpdate for Assert {
 
 /// Figures out the `./target/debug` dir
 fn bin_dir() -> PathBuf {
-    let mut bin_dir = env::current_exe().unwrap(); // ".../target/debug/deps/cargo_public_api_bin_tests-d0f2f926b349fbb9"
-    bin_dir.pop(); // Pop "cargo_public_api_bin_tests-d0f2f926b349fbb9"
-    bin_dir.pop(); // Pop "deps"
-    bin_dir // ".../target/debug"
+    let bin_dir = assert_cmd::cargo::cargo_bin!(); // ".../target/debug/cargo-public-api"
+    bin_dir.parent().unwrap().to_path_buf() // ".../target/debug"
 }
 
 /// Since `rustup` always prepends `$CARGO_HOME/bin` to `$PATH` [1], make sure

--- a/public-api/CHANGELOG.md
+++ b/public-api/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `public-api` changelog
 
+## v0.50.2
+* Bump deps (to stop using deprecated `assert_cmd::Command::cargo_bin()` in tests).
+
 ## v0.50.1
 * Add a new method `PublicApi::assert_eq_or_update(&self, snapshot_path: impl AsRef<Path>)` to enable convenient snapshot testing of the public API. Uses the same excellent diffing engine that `insta` is using. You can-opt out from the new `[dependencies]` by disabling the `"snapshot-testing"` feature that is enabled by default. See https://github.com/cargo-public-api/cargo-public-api/pull/818 for more info.
 

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "public-api"
-version = "0.50.1"
+version = "0.50.2"
 description = "List and diff the public API of Rust library crates. Relies on rustdoc JSON output from the nightly toolchain."
 homepage = "https://github.com/cargo-public-api/cargo-public-api/tree/main/public-api"
 documentation = "https://docs.rs/public-api"

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -35,7 +35,7 @@ version = "0.56.0"
 
 [dev-dependencies]
 anyhow = "1.0.75"
-assert_cmd = "2.0.17"
+assert_cmd = "2.1.1"
 pretty_assertions = "1.4.1"
 snapshot-testing = "0.1.8"
 tempfile = "3.19.1"

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [dev-dependencies.rustdoc-json]
 path = "../rustdoc-json"
-version = "0.9.7"
+version = "0.9.8"
 
 [dev-dependencies.predicates]
 version = "3.1.3"

--- a/repo-tests/Cargo.toml
+++ b/repo-tests/Cargo.toml
@@ -7,5 +7,5 @@ license = "MIT"
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.50.1"
+version = "0.50.2"
 

--- a/rustdoc-json/CHANGELOG.md
+++ b/rustdoc-json/CHANGELOG.md
@@ -1,5 +1,8 @@
 # rustdoc-json
 
+## v0.9.8
+* Add `rustdoc_json::Builder::env()` which simply forwards to underlying `Command::env()`.
+
 ## v0.9.7
 * Bump `cargo_metadata` from `0.19.2` to `0.21.0`.
 

--- a/rustdoc-json/Cargo.toml
+++ b/rustdoc-json/Cargo.toml
@@ -22,7 +22,7 @@ version = "0.1.43"
 features = ["attributes"]
 
 [dev-dependencies]
-assert_cmd = "2.0.17"
+assert_cmd = "2.1.1"
 tempfile = "3.19.1"
 
 [dev-dependencies.predicates]

--- a/rustdoc-json/Cargo.toml
+++ b/rustdoc-json/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "rustdoc-json"
-version = "0.9.7"
+version = "0.9.8"
 description = "Utilities for working with rustdoc JSON."
 homepage = "https://github.com/cargo-public-api/cargo-public-api/tree/main/rustdoc-json"
 documentation = "https://docs.rs/rustdoc-json"

--- a/rustdoc-json/tests/rustdoc-json-lib-tests.rs
+++ b/rustdoc-json/tests/rustdoc-json-lib-tests.rs
@@ -80,18 +80,16 @@ fn test_alternative_package_target(package_target: PackageTarget) {
 /// simple program and capture its stderr to test if `silent(true)` works.
 #[test]
 fn silent_build() {
-    use assert_cmd::Command;
+    use assert_cmd::cargo::cargo_bin_cmd;
     use predicates::str::contains;
 
     let stderr_substring_if_not_silent = "invalid/because/we/want/it/to/fail/Cargo.toml";
-    Command::cargo_bin("test-silent-build")
-        .unwrap()
+    cargo_bin_cmd!("test-silent-build")
         .assert()
         .stderr(contains(stderr_substring_if_not_silent))
         .failure();
 
-    Command::cargo_bin("test-silent-build")
-        .unwrap()
+    cargo_bin_cmd!("test-silent-build")
         .arg("--silent")
         .assert()
         .try_stderr(contains(stderr_substring_if_not_silent))


### PR DESCRIPTION
Closes https://github.com/cargo-public-api/cargo-public-api/issues/844

Also prepare to make new releases.