### PR TITLE
CI: Use latest version of cargo-deny and cargo-audit

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,9 +44,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup install nightly --profile minimal
-      - uses: taiki-e/install-action@ae97ff9daf1cd2e216671a047d80ff48461e30bb # v2.49.1
+      - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-deny@0.17.0, cargo-audit@0.21.1, shfmt@3.10.0
+          tool: cargo-deny, cargo-audit, shfmt@3.10.0
           checksum: true
           fallback: none
       # Use a fixed version for lints to avoid CI failure with new versions. Bump as needed.


### PR DESCRIPTION
To avoid CI flakiness such as

    error: error loading advisory database: parse error: \
    error parsing /home/martin/.cargo/advisory-db/crates/cap-primitives/RUSTSEC-2024-0445.md: \
    parse error: TOML parse error at line 8, column 8
      |
    8 | cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N"
      |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    unsupported CVSS version: 4.0

because the tools got too old. That CI job is low-privileged so we don't need to be paranoid. Keep shfmt at a fixed version however to avoid changes to auto-formating.

Closes https://github.com/cargo-public-api/cargo-public-api/issues/847