### PR TITLE
Add traits with default methods to comprehensive_api test suite

### DIFF
--- a/cargo-public-api/tests/snapshots/comprehensive_api.txt
+++ b/cargo-public-api/tests/snapshots/comprehensive_api.txt
@@ -147,6 +147,15 @@ pub struct comprehensive_api::impls::GatTestStruct1<'a, T>(_)
 impl<'a, T> comprehensive_api::traits::Simple for comprehensive_api::impls::GatTestStruct1<'a, T>
 pub fn comprehensive_api::impls::GatTestStruct1<'a, T>::act()
 pub struct comprehensive_api::impls::GatTestStruct2<T>(_)
+pub struct comprehensive_api::impls::OverridesAllDefaults
+impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::OverridesAllDefaults
+pub fn comprehensive_api::impls::OverridesAllDefaults::another_default(&self) -> &str
+pub fn comprehensive_api::impls::OverridesAllDefaults::defaulted(&self) -> u32
+pub fn comprehensive_api::impls::OverridesAllDefaults::required(&self) -> bool
+pub struct comprehensive_api::impls::OverridesSomeDefaults
+impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::OverridesSomeDefaults
+pub fn comprehensive_api::impls::OverridesSomeDefaults::defaulted(&self) -> u32
+pub fn comprehensive_api::impls::OverridesSomeDefaults::required(&self) -> bool
 pub struct comprehensive_api::impls::TestItemGrouping
 impl comprehensive_api::traits::TraitReferencingOwnAssociatedType for comprehensive_api::impls::TestItemGrouping
 pub type comprehensive_api::impls::TestItemGrouping::OwnAssociatedType = bool
@@ -155,6 +164,9 @@ pub fn comprehensive_api::impls::TestItemGrouping::own_associated_type_output_ex
 impl<T, U> comprehensive_api::traits::TraitWithGenerics<T, U> for comprehensive_api::impls::TestItemGrouping
 pub type comprehensive_api::impls::TestItemGrouping::Foo = u8
 pub fn comprehensive_api::impls::TestItemGrouping::bar() -> <Self as comprehensive_api::traits::TraitWithGenerics<T, U>>::Foo
+pub struct comprehensive_api::impls::UsesAllDefaults
+impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::UsesAllDefaults
+pub fn comprehensive_api::impls::UsesAllDefaults::required(&self) -> bool
 pub trait comprehensive_api::impls::ForUnit
 pub fn comprehensive_api::impls::ForUnit::for_unit()
 impl comprehensive_api::impls::ForUnit for ()
@@ -241,6 +253,19 @@ pub fn comprehensive_api::impls::TestItemGrouping::own_associated_type_output(&s
 pub fn comprehensive_api::impls::TestItemGrouping::own_associated_type_output_explicit_as(&self) -> <Self as comprehensive_api::traits::TraitReferencingOwnAssociatedType>::OwnAssociatedType
 pub trait comprehensive_api::traits::TraitWithBounds: comprehensive_api::traits::private_mod::PubTraitInPrivateMod + comprehensive_api::traits::Simple + core::marker::Send
 pub trait comprehensive_api::traits::TraitWithBoundsAndGenerics<U>: comprehensive_api::traits::Simple
+pub trait comprehensive_api::traits::TraitWithDefaultMethod
+pub fn comprehensive_api::traits::TraitWithDefaultMethod::another_default(&self) -> &str
+pub fn comprehensive_api::traits::TraitWithDefaultMethod::defaulted(&self) -> u32
+pub fn comprehensive_api::traits::TraitWithDefaultMethod::required(&self) -> bool
+impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::OverridesAllDefaults
+pub fn comprehensive_api::impls::OverridesAllDefaults::another_default(&self) -> &str
+pub fn comprehensive_api::impls::OverridesAllDefaults::defaulted(&self) -> u32
+pub fn comprehensive_api::impls::OverridesAllDefaults::required(&self) -> bool
+impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::OverridesSomeDefaults
+pub fn comprehensive_api::impls::OverridesSomeDefaults::defaulted(&self) -> u32
+pub fn comprehensive_api::impls::OverridesSomeDefaults::required(&self) -> bool
+impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::UsesAllDefaults
+pub fn comprehensive_api::impls::UsesAllDefaults::required(&self) -> bool
 pub trait comprehensive_api::traits::TraitWithGenerics<T, U>
 pub type comprehensive_api::traits::TraitWithGenerics::Foo
 pub fn comprehensive_api::traits::TraitWithGenerics::bar() -> <Self as comprehensive_api::traits::TraitWithGenerics<T, U>>::Foo

--- a/cargo-public-api/tests/snapshots/comprehensive_api.txt
+++ b/cargo-public-api/tests/snapshots/comprehensive_api.txt
@@ -147,15 +147,18 @@ pub struct comprehensive_api::impls::GatTestStruct1<'a, T>(_)
 impl<'a, T> comprehensive_api::traits::Simple for comprehensive_api::impls::GatTestStruct1<'a, T>
 pub fn comprehensive_api::impls::GatTestStruct1<'a, T>::act()
 pub struct comprehensive_api::impls::GatTestStruct2<T>(_)
-pub struct comprehensive_api::impls::OverridesAllDefaults
-impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::OverridesAllDefaults
-pub fn comprehensive_api::impls::OverridesAllDefaults::another_default(&self) -> &str
-pub fn comprehensive_api::impls::OverridesAllDefaults::defaulted(&self) -> u32
-pub fn comprehensive_api::impls::OverridesAllDefaults::required(&self) -> bool
-pub struct comprehensive_api::impls::OverridesSomeDefaults
-impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::OverridesSomeDefaults
-pub fn comprehensive_api::impls::OverridesSomeDefaults::defaulted(&self) -> u32
-pub fn comprehensive_api::impls::OverridesSomeDefaults::required(&self) -> bool
+pub struct comprehensive_api::impls::OverridesOnlyRequired
+impl comprehensive_api::traits::TraitWithOneRequiredAndTwoDefaultMethods for comprehensive_api::impls::OverridesOnlyRequired
+pub fn comprehensive_api::impls::OverridesOnlyRequired::required(&self) -> bool
+pub struct comprehensive_api::impls::OverridesRequiredAndBothDefaults
+impl comprehensive_api::traits::TraitWithOneRequiredAndTwoDefaultMethods for comprehensive_api::impls::OverridesRequiredAndBothDefaults
+pub fn comprehensive_api::impls::OverridesRequiredAndBothDefaults::another_default(&self) -> &str
+pub fn comprehensive_api::impls::OverridesRequiredAndBothDefaults::defaulted(&self) -> u32
+pub fn comprehensive_api::impls::OverridesRequiredAndBothDefaults::required(&self) -> bool
+pub struct comprehensive_api::impls::OverridesRequiredAndOneOfTwoDefaults
+impl comprehensive_api::traits::TraitWithOneRequiredAndTwoDefaultMethods for comprehensive_api::impls::OverridesRequiredAndOneOfTwoDefaults
+pub fn comprehensive_api::impls::OverridesRequiredAndOneOfTwoDefaults::defaulted(&self) -> u32
+pub fn comprehensive_api::impls::OverridesRequiredAndOneOfTwoDefaults::required(&self) -> bool
 pub struct comprehensive_api::impls::TestItemGrouping
 impl comprehensive_api::traits::TraitReferencingOwnAssociatedType for comprehensive_api::impls::TestItemGrouping
 pub type comprehensive_api::impls::TestItemGrouping::OwnAssociatedType = bool
@@ -164,9 +167,6 @@ pub fn comprehensive_api::impls::TestItemGrouping::own_associated_type_output_ex
 impl<T, U> comprehensive_api::traits::TraitWithGenerics<T, U> for comprehensive_api::impls::TestItemGrouping
 pub type comprehensive_api::impls::TestItemGrouping::Foo = u8
 pub fn comprehensive_api::impls::TestItemGrouping::bar() -> <Self as comprehensive_api::traits::TraitWithGenerics<T, U>>::Foo
-pub struct comprehensive_api::impls::UsesAllDefaults
-impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::UsesAllDefaults
-pub fn comprehensive_api::impls::UsesAllDefaults::required(&self) -> bool
 pub trait comprehensive_api::impls::ForUnit
 pub fn comprehensive_api::impls::ForUnit::for_unit()
 impl comprehensive_api::impls::ForUnit for ()
@@ -253,25 +253,25 @@ pub fn comprehensive_api::impls::TestItemGrouping::own_associated_type_output(&s
 pub fn comprehensive_api::impls::TestItemGrouping::own_associated_type_output_explicit_as(&self) -> <Self as comprehensive_api::traits::TraitReferencingOwnAssociatedType>::OwnAssociatedType
 pub trait comprehensive_api::traits::TraitWithBounds: comprehensive_api::traits::private_mod::PubTraitInPrivateMod + comprehensive_api::traits::Simple + core::marker::Send
 pub trait comprehensive_api::traits::TraitWithBoundsAndGenerics<U>: comprehensive_api::traits::Simple
-pub trait comprehensive_api::traits::TraitWithDefaultMethod
-pub fn comprehensive_api::traits::TraitWithDefaultMethod::another_default(&self) -> &str
-pub fn comprehensive_api::traits::TraitWithDefaultMethod::defaulted(&self) -> u32
-pub fn comprehensive_api::traits::TraitWithDefaultMethod::required(&self) -> bool
-impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::OverridesAllDefaults
-pub fn comprehensive_api::impls::OverridesAllDefaults::another_default(&self) -> &str
-pub fn comprehensive_api::impls::OverridesAllDefaults::defaulted(&self) -> u32
-pub fn comprehensive_api::impls::OverridesAllDefaults::required(&self) -> bool
-impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::OverridesSomeDefaults
-pub fn comprehensive_api::impls::OverridesSomeDefaults::defaulted(&self) -> u32
-pub fn comprehensive_api::impls::OverridesSomeDefaults::required(&self) -> bool
-impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::UsesAllDefaults
-pub fn comprehensive_api::impls::UsesAllDefaults::required(&self) -> bool
 pub trait comprehensive_api::traits::TraitWithGenerics<T, U>
 pub type comprehensive_api::traits::TraitWithGenerics::Foo
 pub fn comprehensive_api::traits::TraitWithGenerics::bar() -> <Self as comprehensive_api::traits::TraitWithGenerics<T, U>>::Foo
 impl<T, U> comprehensive_api::traits::TraitWithGenerics<T, U> for comprehensive_api::impls::TestItemGrouping
 pub type comprehensive_api::impls::TestItemGrouping::Foo = u8
 pub fn comprehensive_api::impls::TestItemGrouping::bar() -> <Self as comprehensive_api::traits::TraitWithGenerics<T, U>>::Foo
+pub trait comprehensive_api::traits::TraitWithOneRequiredAndTwoDefaultMethods
+pub fn comprehensive_api::traits::TraitWithOneRequiredAndTwoDefaultMethods::another_default(&self) -> &str
+pub fn comprehensive_api::traits::TraitWithOneRequiredAndTwoDefaultMethods::defaulted(&self) -> u32
+pub fn comprehensive_api::traits::TraitWithOneRequiredAndTwoDefaultMethods::required(&self) -> bool
+impl comprehensive_api::traits::TraitWithOneRequiredAndTwoDefaultMethods for comprehensive_api::impls::OverridesOnlyRequired
+pub fn comprehensive_api::impls::OverridesOnlyRequired::required(&self) -> bool
+impl comprehensive_api::traits::TraitWithOneRequiredAndTwoDefaultMethods for comprehensive_api::impls::OverridesRequiredAndBothDefaults
+pub fn comprehensive_api::impls::OverridesRequiredAndBothDefaults::another_default(&self) -> &str
+pub fn comprehensive_api::impls::OverridesRequiredAndBothDefaults::defaulted(&self) -> u32
+pub fn comprehensive_api::impls::OverridesRequiredAndBothDefaults::required(&self) -> bool
+impl comprehensive_api::traits::TraitWithOneRequiredAndTwoDefaultMethods for comprehensive_api::impls::OverridesRequiredAndOneOfTwoDefaults
+pub fn comprehensive_api::impls::OverridesRequiredAndOneOfTwoDefaults::defaulted(&self) -> u32
+pub fn comprehensive_api::impls::OverridesRequiredAndOneOfTwoDefaults::required(&self) -> bool
 pub unsafe trait comprehensive_api::traits::UnsafeTrait
 pub mod comprehensive_api::typedefs
 pub type comprehensive_api::typedefs::ConstArg120 = comprehensive_api::structs::OnlyConstArg<120>

--- a/public-api/tests/snapshots/comprehensive_api.txt
+++ b/public-api/tests/snapshots/comprehensive_api.txt
@@ -147,6 +147,15 @@ pub struct comprehensive_api::impls::GatTestStruct1<'a, T>(_)
 impl<'a, T> comprehensive_api::traits::Simple for comprehensive_api::impls::GatTestStruct1<'a, T>
 pub fn comprehensive_api::impls::GatTestStruct1<'a, T>::act()
 pub struct comprehensive_api::impls::GatTestStruct2<T>(_)
+pub struct comprehensive_api::impls::OverridesAllDefaults
+impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::OverridesAllDefaults
+pub fn comprehensive_api::impls::OverridesAllDefaults::another_default(&self) -> &str
+pub fn comprehensive_api::impls::OverridesAllDefaults::defaulted(&self) -> u32
+pub fn comprehensive_api::impls::OverridesAllDefaults::required(&self) -> bool
+pub struct comprehensive_api::impls::OverridesSomeDefaults
+impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::OverridesSomeDefaults
+pub fn comprehensive_api::impls::OverridesSomeDefaults::defaulted(&self) -> u32
+pub fn comprehensive_api::impls::OverridesSomeDefaults::required(&self) -> bool
 pub struct comprehensive_api::impls::TestItemGrouping
 impl comprehensive_api::traits::TraitReferencingOwnAssociatedType for comprehensive_api::impls::TestItemGrouping
 pub type comprehensive_api::impls::TestItemGrouping::OwnAssociatedType = bool
@@ -155,6 +164,9 @@ pub fn comprehensive_api::impls::TestItemGrouping::own_associated_type_output_ex
 impl<T, U> comprehensive_api::traits::TraitWithGenerics<T, U> for comprehensive_api::impls::TestItemGrouping
 pub type comprehensive_api::impls::TestItemGrouping::Foo = u8
 pub fn comprehensive_api::impls::TestItemGrouping::bar() -> <Self as comprehensive_api::traits::TraitWithGenerics<T, U>>::Foo
+pub struct comprehensive_api::impls::UsesAllDefaults
+impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::UsesAllDefaults
+pub fn comprehensive_api::impls::UsesAllDefaults::required(&self) -> bool
 pub trait comprehensive_api::impls::ForUnit
 pub fn comprehensive_api::impls::ForUnit::for_unit()
 impl comprehensive_api::impls::ForUnit for ()
@@ -241,6 +253,19 @@ pub fn comprehensive_api::impls::TestItemGrouping::own_associated_type_output(&s
 pub fn comprehensive_api::impls::TestItemGrouping::own_associated_type_output_explicit_as(&self) -> <Self as comprehensive_api::traits::TraitReferencingOwnAssociatedType>::OwnAssociatedType
 pub trait comprehensive_api::traits::TraitWithBounds: comprehensive_api::traits::private_mod::PubTraitInPrivateMod + comprehensive_api::traits::Simple + core::marker::Send
 pub trait comprehensive_api::traits::TraitWithBoundsAndGenerics<U>: comprehensive_api::traits::Simple
+pub trait comprehensive_api::traits::TraitWithDefaultMethod
+pub fn comprehensive_api::traits::TraitWithDefaultMethod::another_default(&self) -> &str
+pub fn comprehensive_api::traits::TraitWithDefaultMethod::defaulted(&self) -> u32
+pub fn comprehensive_api::traits::TraitWithDefaultMethod::required(&self) -> bool
+impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::OverridesAllDefaults
+pub fn comprehensive_api::impls::OverridesAllDefaults::another_default(&self) -> &str
+pub fn comprehensive_api::impls::OverridesAllDefaults::defaulted(&self) -> u32
+pub fn comprehensive_api::impls::OverridesAllDefaults::required(&self) -> bool
+impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::OverridesSomeDefaults
+pub fn comprehensive_api::impls::OverridesSomeDefaults::defaulted(&self) -> u32
+pub fn comprehensive_api::impls::OverridesSomeDefaults::required(&self) -> bool
+impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::UsesAllDefaults
+pub fn comprehensive_api::impls::UsesAllDefaults::required(&self) -> bool
 pub trait comprehensive_api::traits::TraitWithGenerics<T, U>
 pub type comprehensive_api::traits::TraitWithGenerics::Foo
 pub fn comprehensive_api::traits::TraitWithGenerics::bar() -> <Self as comprehensive_api::traits::TraitWithGenerics<T, U>>::Foo

--- a/public-api/tests/snapshots/comprehensive_api.txt
+++ b/public-api/tests/snapshots/comprehensive_api.txt
@@ -147,15 +147,18 @@ pub struct comprehensive_api::impls::GatTestStruct1<'a, T>(_)
 impl<'a, T> comprehensive_api::traits::Simple for comprehensive_api::impls::GatTestStruct1<'a, T>
 pub fn comprehensive_api::impls::GatTestStruct1<'a, T>::act()
 pub struct comprehensive_api::impls::GatTestStruct2<T>(_)
-pub struct comprehensive_api::impls::OverridesAllDefaults
-impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::OverridesAllDefaults
-pub fn comprehensive_api::impls::OverridesAllDefaults::another_default(&self) -> &str
-pub fn comprehensive_api::impls::OverridesAllDefaults::defaulted(&self) -> u32
-pub fn comprehensive_api::impls::OverridesAllDefaults::required(&self) -> bool
-pub struct comprehensive_api::impls::OverridesSomeDefaults
-impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::OverridesSomeDefaults
-pub fn comprehensive_api::impls::OverridesSomeDefaults::defaulted(&self) -> u32
-pub fn comprehensive_api::impls::OverridesSomeDefaults::required(&self) -> bool
+pub struct comprehensive_api::impls::OverridesOnlyRequired
+impl comprehensive_api::traits::TraitWithOneRequiredAndTwoDefaultMethods for comprehensive_api::impls::OverridesOnlyRequired
+pub fn comprehensive_api::impls::OverridesOnlyRequired::required(&self) -> bool
+pub struct comprehensive_api::impls::OverridesRequiredAndBothDefaults
+impl comprehensive_api::traits::TraitWithOneRequiredAndTwoDefaultMethods for comprehensive_api::impls::OverridesRequiredAndBothDefaults
+pub fn comprehensive_api::impls::OverridesRequiredAndBothDefaults::another_default(&self) -> &str
+pub fn comprehensive_api::impls::OverridesRequiredAndBothDefaults::defaulted(&self) -> u32
+pub fn comprehensive_api::impls::OverridesRequiredAndBothDefaults::required(&self) -> bool
+pub struct comprehensive_api::impls::OverridesRequiredAndOneOfTwoDefaults
+impl comprehensive_api::traits::TraitWithOneRequiredAndTwoDefaultMethods for comprehensive_api::impls::OverridesRequiredAndOneOfTwoDefaults
+pub fn comprehensive_api::impls::OverridesRequiredAndOneOfTwoDefaults::defaulted(&self) -> u32
+pub fn comprehensive_api::impls::OverridesRequiredAndOneOfTwoDefaults::required(&self) -> bool
 pub struct comprehensive_api::impls::TestItemGrouping
 impl comprehensive_api::traits::TraitReferencingOwnAssociatedType for comprehensive_api::impls::TestItemGrouping
 pub type comprehensive_api::impls::TestItemGrouping::OwnAssociatedType = bool
@@ -164,9 +167,6 @@ pub fn comprehensive_api::impls::TestItemGrouping::own_associated_type_output_ex
 impl<T, U> comprehensive_api::traits::TraitWithGenerics<T, U> for comprehensive_api::impls::TestItemGrouping
 pub type comprehensive_api::impls::TestItemGrouping::Foo = u8
 pub fn comprehensive_api::impls::TestItemGrouping::bar() -> <Self as comprehensive_api::traits::TraitWithGenerics<T, U>>::Foo
-pub struct comprehensive_api::impls::UsesAllDefaults
-impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::UsesAllDefaults
-pub fn comprehensive_api::impls::UsesAllDefaults::required(&self) -> bool
 pub trait comprehensive_api::impls::ForUnit
 pub fn comprehensive_api::impls::ForUnit::for_unit()
 impl comprehensive_api::impls::ForUnit for ()
@@ -253,25 +253,25 @@ pub fn comprehensive_api::impls::TestItemGrouping::own_associated_type_output(&s
 pub fn comprehensive_api::impls::TestItemGrouping::own_associated_type_output_explicit_as(&self) -> <Self as comprehensive_api::traits::TraitReferencingOwnAssociatedType>::OwnAssociatedType
 pub trait comprehensive_api::traits::TraitWithBounds: comprehensive_api::traits::private_mod::PubTraitInPrivateMod + comprehensive_api::traits::Simple + core::marker::Send
 pub trait comprehensive_api::traits::TraitWithBoundsAndGenerics<U>: comprehensive_api::traits::Simple
-pub trait comprehensive_api::traits::TraitWithDefaultMethod
-pub fn comprehensive_api::traits::TraitWithDefaultMethod::another_default(&self) -> &str
-pub fn comprehensive_api::traits::TraitWithDefaultMethod::defaulted(&self) -> u32
-pub fn comprehensive_api::traits::TraitWithDefaultMethod::required(&self) -> bool
-impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::OverridesAllDefaults
-pub fn comprehensive_api::impls::OverridesAllDefaults::another_default(&self) -> &str
-pub fn comprehensive_api::impls::OverridesAllDefaults::defaulted(&self) -> u32
-pub fn comprehensive_api::impls::OverridesAllDefaults::required(&self) -> bool
-impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::OverridesSomeDefaults
-pub fn comprehensive_api::impls::OverridesSomeDefaults::defaulted(&self) -> u32
-pub fn comprehensive_api::impls::OverridesSomeDefaults::required(&self) -> bool
-impl comprehensive_api::traits::TraitWithDefaultMethod for comprehensive_api::impls::UsesAllDefaults
-pub fn comprehensive_api::impls::UsesAllDefaults::required(&self) -> bool
 pub trait comprehensive_api::traits::TraitWithGenerics<T, U>
 pub type comprehensive_api::traits::TraitWithGenerics::Foo
 pub fn comprehensive_api::traits::TraitWithGenerics::bar() -> <Self as comprehensive_api::traits::TraitWithGenerics<T, U>>::Foo
 impl<T, U> comprehensive_api::traits::TraitWithGenerics<T, U> for comprehensive_api::impls::TestItemGrouping
 pub type comprehensive_api::impls::TestItemGrouping::Foo = u8
 pub fn comprehensive_api::impls::TestItemGrouping::bar() -> <Self as comprehensive_api::traits::TraitWithGenerics<T, U>>::Foo
+pub trait comprehensive_api::traits::TraitWithOneRequiredAndTwoDefaultMethods
+pub fn comprehensive_api::traits::TraitWithOneRequiredAndTwoDefaultMethods::another_default(&self) -> &str
+pub fn comprehensive_api::traits::TraitWithOneRequiredAndTwoDefaultMethods::defaulted(&self) -> u32
+pub fn comprehensive_api::traits::TraitWithOneRequiredAndTwoDefaultMethods::required(&self) -> bool
+impl comprehensive_api::traits::TraitWithOneRequiredAndTwoDefaultMethods for comprehensive_api::impls::OverridesOnlyRequired
+pub fn comprehensive_api::impls::OverridesOnlyRequired::required(&self) -> bool
+impl comprehensive_api::traits::TraitWithOneRequiredAndTwoDefaultMethods for comprehensive_api::impls::OverridesRequiredAndBothDefaults
+pub fn comprehensive_api::impls::OverridesRequiredAndBothDefaults::another_default(&self) -> &str
+pub fn comprehensive_api::impls::OverridesRequiredAndBothDefaults::defaulted(&self) -> u32
+pub fn comprehensive_api::impls::OverridesRequiredAndBothDefaults::required(&self) -> bool
+impl comprehensive_api::traits::TraitWithOneRequiredAndTwoDefaultMethods for comprehensive_api::impls::OverridesRequiredAndOneOfTwoDefaults
+pub fn comprehensive_api::impls::OverridesRequiredAndOneOfTwoDefaults::defaulted(&self) -> u32
+pub fn comprehensive_api::impls::OverridesRequiredAndOneOfTwoDefaults::required(&self) -> bool
 pub unsafe trait comprehensive_api::traits::UnsafeTrait
 pub mod comprehensive_api::typedefs
 pub type comprehensive_api::typedefs::ConstArg120 = comprehensive_api::structs::OnlyConstArg<120>

--- a/test-apis/comprehensive_api/src/impls.rs
+++ b/test-apis/comprehensive_api/src/impls.rs
@@ -1,7 +1,7 @@
 use crate::{
     structs::{Plain, Unit, WithLifetimeAndGenericParam},
     traits::{
-        GenericAssociatedTypes, Simple, TraitReferencingOwnAssociatedType, TraitWithDefaultMethod,
+        GenericAssociatedTypes, Simple, TraitReferencingOwnAssociatedType, TraitWithOneRequiredAndTwoDefaultMethods,
         TraitWithGenerics,
     },
 };
@@ -119,18 +119,18 @@ impl GenericAssociatedTypes for Unit {
 }
 
 /// Only overrides `required`, leaving both defaults.
-pub struct UsesAllDefaults;
+pub struct OverridesOnlyRequired;
 
-impl TraitWithDefaultMethod for UsesAllDefaults {
+impl TraitWithOneRequiredAndTwoDefaultMethods for OverridesOnlyRequired {
     fn required(&self) -> bool {
         true
     }
 }
 
 /// Overrides `required` and `defaulted`, but leaves `another_default`.
-pub struct OverridesSomeDefaults;
+pub struct OverridesRequiredAndOneOfTwoDefaults;
 
-impl TraitWithDefaultMethod for OverridesSomeDefaults {
+impl TraitWithOneRequiredAndTwoDefaultMethods for OverridesRequiredAndOneOfTwoDefaults {
     fn required(&self) -> bool {
         false
     }
@@ -141,9 +141,9 @@ impl TraitWithDefaultMethod for OverridesSomeDefaults {
 }
 
 /// Overrides all methods, no defaults used.
-pub struct OverridesAllDefaults;
+pub struct OverridesRequiredAndBothDefaults;
 
-impl TraitWithDefaultMethod for OverridesAllDefaults {
+impl TraitWithOneRequiredAndTwoDefaultMethods for OverridesRequiredAndBothDefaults {
     fn required(&self) -> bool {
         true
     }

--- a/test-apis/comprehensive_api/src/impls.rs
+++ b/test-apis/comprehensive_api/src/impls.rs
@@ -1,7 +1,8 @@
 use crate::{
     structs::{Plain, Unit, WithLifetimeAndGenericParam},
     traits::{
-        GenericAssociatedTypes, Simple, TraitReferencingOwnAssociatedType, TraitWithGenerics,
+        GenericAssociatedTypes, Simple, TraitReferencingOwnAssociatedType, TraitWithDefaultMethod,
+        TraitWithGenerics,
     },
 };
 
@@ -115,6 +116,45 @@ impl GenericAssociatedTypes for Unit {
     type SimpleBound = GatTestStruct1<'static, usize>;
 
     type WithLifetime<'a> = GatTestStruct1<'a, bool>;
+}
+
+/// Only overrides `required`, leaving both defaults.
+pub struct UsesAllDefaults;
+
+impl TraitWithDefaultMethod for UsesAllDefaults {
+    fn required(&self) -> bool {
+        true
+    }
+}
+
+/// Overrides `required` and `defaulted`, but leaves `another_default`.
+pub struct OverridesSomeDefaults;
+
+impl TraitWithDefaultMethod for OverridesSomeDefaults {
+    fn required(&self) -> bool {
+        false
+    }
+
+    fn defaulted(&self) -> u32 {
+        99
+    }
+}
+
+/// Overrides all methods, no defaults used.
+pub struct OverridesAllDefaults;
+
+impl TraitWithDefaultMethod for OverridesAllDefaults {
+    fn required(&self) -> bool {
+        true
+    }
+
+    fn defaulted(&self) -> u32 {
+        0
+    }
+
+    fn another_default(&self) -> &str {
+        "world"
+    }
 }
 
 /// Regression test for <https://github.com/cargo-public-api/cargo-public-api/issues/429>

--- a/test-apis/comprehensive_api/src/traits.rs
+++ b/test-apis/comprehensive_api/src/traits.rs
@@ -57,3 +57,15 @@ pub trait GenericAssociatedTypes {
     type SimpleBound: Simple;
     type WithLifetime<'a>;
 }
+
+pub trait TraitWithDefaultMethod {
+    fn required(&self) -> bool;
+
+    fn defaulted(&self) -> u32 {
+        42
+    }
+
+    fn another_default(&self) -> &str {
+        "hello"
+    }
+}

--- a/test-apis/comprehensive_api/src/traits.rs
+++ b/test-apis/comprehensive_api/src/traits.rs
@@ -58,7 +58,7 @@ pub trait GenericAssociatedTypes {
     type WithLifetime<'a>;
 }
 
-pub trait TraitWithDefaultMethod {
+pub trait TraitWithOneRequiredAndTwoDefaultMethods {
     fn required(&self) -> bool;
 
     fn defaulted(&self) -> u32 {


### PR DESCRIPTION
Add TraitWithDefaultMethod with required and default methods, plus three structs (UsesAllDefaults, OverridesSomeDefaults, OverridesAllDefaults) that exercise different override patterns.

The API lock file shows only the overridden methods are included, not the defaulted ones. A follow up PR will fix this to include the defaulted functions.