### PR TITLE
CI: Add zizmor check and make it pass

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,10 @@ jobs:
       - lint
       - cargo-test
     steps:
-      - run: jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'
+      - env:
+          NEEDS_JSON: ${{ toJson(needs) }}
+        run: |
+          jq --exit-status 'all(.result == "success")' <<< "${NEEDS_JSON}"
 
   check-version-info:
     name: check version info
@@ -32,6 +35,8 @@ jobs:
       contents: read # For actions/checkout@v4
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - run: cargo run --bin update-version-info
       - run: |
           [ -z "$(git diff)" ] || { echo "ERROR: You forgot to 'cargo run --bin update-version-info'" ; exit 1 ; }
@@ -43,10 +48,12 @@ jobs:
       contents: read # For actions/checkout@v4
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - run: rustup install nightly --profile minimal
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-deny, cargo-audit, shfmt@3.10.0
+          tool: cargo-deny, cargo-audit, shfmt@3.10.0, zizmor@1.22.0
           checksum: true
           fallback: none
       # Use a fixed version for lints to avoid CI failure with new versions. Bump as needed.
@@ -68,6 +75,8 @@ jobs:
       contents: read # For actions/checkout@v4
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - run: zsh --version || (sudo apt-get install -y zsh && zsh --version)
         if: runner.os != 'Windows'
       - run: rustup install nightly --profile minimal

--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -27,10 +27,10 @@ jobs:
     if: ${{ !cancelled() && needs.ci.result == 'failure' && needs.auto-bless.outputs.changes-detected != 'yes' }}
     permissions:
       issues: write # For `gh issue create`
-    env:
-      GH_TOKEN: ${{ github.token }}
     steps:
-      - run: |
+      - env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
           gh issue list \
             --repo cargo-public-api/cargo-public-api | grep "CI failed with " || \
           gh issue create \
@@ -55,6 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: true # Needed for git push below
           token: ${{ secrets.ENSELICCICD_GITHUB_TOKEN }} # for git push
       - run: rustup install nightly --profile minimal
       - run: sudo apt-get install -y zsh && zsh --version

--- a/.github/workflows/Release-cargo-public-api.yml
+++ b/.github/workflows/Release-cargo-public-api.yml
@@ -26,6 +26,8 @@ jobs:
       id-token: write # https://crates.io/docs/trusted-publishing
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: true # Needed for git push below
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
 
@@ -45,9 +47,11 @@ jobs:
 
       # Push the tag to git.
       - name: push tag
+        env:
+          THE_GIT_TAG: ${{ steps.version.outputs.GIT_TAG }}
         run: |
-          git tag ${{ steps.version.outputs.GIT_TAG }}
-          git push origin ${{ steps.version.outputs.GIT_TAG }}
+          git tag ${THE_GIT_TAG}
+          git push origin ${THE_GIT_TAG}
 
   release:
     needs: publish
@@ -56,6 +60,8 @@ jobs:
       contents: write # So we can create a release.
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: true # Needed for gh release create below
       - name: calculate version
         id: version
         run: |
@@ -66,7 +72,9 @@ jobs:
       - name: create release
         env:
           GH_TOKEN: ${{ github.token }}
+          THE_VERSION: ${{ steps.version.outputs.VERSION }}
+          THE_GIT_TAG: ${{ steps.version.outputs.GIT_TAG }}
         run: |
-          notes="$(parse-changelog CHANGELOG.md ${{ steps.version.outputs.VERSION }})"
-          title="${{ steps.version.outputs.GIT_TAG }}"
-          gh release create --title "$title" --notes "$notes" ${{ steps.version.outputs.GIT_TAG }}
+          notes="$(parse-changelog CHANGELOG.md ${THE_VERSION})"
+          title="${THE_GIT_TAG}"
+          gh release create --title "$title" --notes "$notes" ${THE_GIT_TAG}

--- a/.github/workflows/Release-public-api.yml
+++ b/.github/workflows/Release-public-api.yml
@@ -26,6 +26,8 @@ jobs:
       id-token: write # https://crates.io/docs/trusted-publishing
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: true # Needed for git push below
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
 
@@ -45,9 +47,11 @@ jobs:
 
       # Push the tag to git.
       - name: push tag
+        env:
+          THE_GIT_TAG: ${{ steps.version.outputs.GIT_TAG }}
         run: |
-          git tag ${{ steps.version.outputs.GIT_TAG }}
-          git push origin ${{ steps.version.outputs.GIT_TAG }}
+          git tag ${THE_GIT_TAG}
+          git push origin ${THE_GIT_TAG}
 
       # Do not create a GitHub release. That is only done for cargo-public-api.
       # A git tag is sufficient for public-api.

--- a/.github/workflows/Release-rustdoc-json.yml
+++ b/.github/workflows/Release-rustdoc-json.yml
@@ -26,6 +26,8 @@ jobs:
       id-token: write # https://crates.io/docs/trusted-publishing
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: true # Needed for git push below
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
 
@@ -45,9 +47,11 @@ jobs:
 
       # Push the tag to git.
       - name: push tag
+        env:
+          THE_GIT_TAG: ${{ steps.version.outputs.GIT_TAG }}
         run: |
-          git tag ${{ steps.version.outputs.GIT_TAG }}
-          git push origin ${{ steps.version.outputs.GIT_TAG }}
+          git tag ${THE_GIT_TAG}
+          git push origin ${THE_GIT_TAG}
 
       # Do not create a GitHub release. That is only done for public-api and
       # cargo-public-api. A git tag is sufficient for rustdoc-json.

--- a/.github/workflows/Release-rustup-toolchain.yml
+++ b/.github/workflows/Release-rustup-toolchain.yml
@@ -26,6 +26,8 @@ jobs:
       id-token: write # https://crates.io/docs/trusted-publishing
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: true # Needed for git push below
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
 
@@ -45,9 +47,11 @@ jobs:
 
       # Push the tag to git.
       - name: push tag
+        env:
+          THE_GIT_TAG: ${{ steps.version.outputs.GIT_TAG }}
         run: |
-          git tag ${{ steps.version.outputs.GIT_TAG }}
-          git push origin ${{ steps.version.outputs.GIT_TAG }}
+          git tag ${THE_GIT_TAG}
+          git push origin ${THE_GIT_TAG}
 
       # Do not create a GitHub release. That is only done for public-api and
       # cargo-public-api. A git tag is sufficient for rustup-toolchain.

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -37,3 +37,7 @@ fi
 if if_command_exists_or_in_ci shfmt; then
     ./scripts/shfmt.sh --diff
 fi
+
+if if_command_exists_or_in_ci zizmor; then
+    ./scripts/zizmor.sh
+fi

--- a/scripts/zizmor.sh
+++ b/scripts/zizmor.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -o nounset -o pipefail -o errexit
+
+zizmor \
+    --config zizmor.yml \
+    .github/workflows/* \
+    "$@"

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,13 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # We trust GitHub
+        actions/checkout: ref-pin
+
+        # We trust rust-lang.
+        rust-lang/crates-io-auth-action: ref-pin
+
+        # We trust taiki-e, partly because we run it in a low-privilege job with
+        # only read access to contents.
+        taiki-e/install-action: ref-pin


### PR DESCRIPTION
This helps us harden our workflow against malicious use.

We were already pretty hardened but it doesn't hurt to add CI checks for it and take it a few steps further.