### PR TITLE
Bump cargo-public-api and public-api to 0.51.0 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `cargo-public-api` changelog
 
+## v0.51.0
+* Also include default trait methods in impls, even if not overridden, just like in rustdoc HTML.
+
 ## v0.50.2
 * Bump deps (to stop using deprecated `assert_cmd::Command::cargo_bin()` in tests).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-public-api"
-version = "0.50.2"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "public-api"
-version = "0.50.3"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ cargo public-api -sss
 
 | Version          | Understands the rustdoc JSON output of  |
 | ---------------- | --------------------------------------- |
-| 0.50.x           | nightly-2025-08-02 —                    |
+| 0.50.x — 0.51.x  | nightly-2025-08-02 —                    |
 | 0.49.x           | nightly-2025-07-17 — nightly-2025-08-01 |
 | 0.48.x           | nightly-2025-06-22 — nightly-2025-07-16 |
 | 0.47.x           | nightly-2025-03-24 — nightly-2025-06-21 |

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "cargo-public-api"
-version = "0.50.2"
+version = "0.51.0"
 default-run = "cargo-public-api"
 description = "List and diff the public API of Rust library crates between releases and commits. Detect breaking API changes and semver violations via CI or a CLI."
 homepage = "https://github.com/cargo-public-api/cargo-public-api"
@@ -44,7 +44,7 @@ version = "0.9.9"
 
 [dependencies.public-api]
 path = "../public-api"
-version = "0.50.3"
+version = "0.51.0"
 
 [dependencies.serde]
 version = "1.0.179"

--- a/public-api/CHANGELOG.md
+++ b/public-api/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `public-api` changelog
 
+## v0.51.0
+* Also include default trait methods in impls, even if not overridden, just like in rustdoc HTML.
+
 ## v0.50.3
 * Sort rendered attributes so rendering is determinstic and does not change with
   rustdoc JSON changes.

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "public-api"
-version = "0.50.3"
+version = "0.51.0"
 description = "List and diff the public API of Rust library crates. Relies on rustdoc JSON output from the nightly toolchain."
 homepage = "https://github.com/cargo-public-api/cargo-public-api/tree/main/public-api"
 documentation = "https://docs.rs/public-api"

--- a/repo-tests/Cargo.toml
+++ b/repo-tests/Cargo.toml
@@ -7,5 +7,5 @@ license = "MIT"
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.50.3"
+version = "0.51.0"
 

--- a/scripts/release-helper/src/version_info.rs
+++ b/scripts/release-helper/src/version_info.rs
@@ -7,6 +7,10 @@ pub struct CargoPublicApiVersionInfo {
 
 pub static TABLE: &[CargoPublicApiVersionInfo] = &[
     CargoPublicApiVersionInfo {
+        cargo_public_api_version: "0.51.x",
+        min_nightly_rust_version: "nightly-2025-08-02",
+    },
+    CargoPublicApiVersionInfo {
         cargo_public_api_version: "0.50.x",
         min_nightly_rust_version: "nightly-2025-08-02",
     },


### PR DESCRIPTION
I didn't know if you wanted me to bump nightly rust version also. Seems like the only release that hasn't given the formatting in the README.