### PR TITLE
CI: Disable macOS job, because `warn_when_using_beta` fails

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,7 +67,8 @@ jobs:
       matrix:
         variant:
           - { name: Ubuntu,  os: ubuntu-latest  }
-          - { name: macOS,   os: macos-latest   }
+          # FIXME: Enable after fixing why `warn_when_using_beta` fails
+          # - { name: macOS,   os: macos-latest   }
           - { name: Windows, os: windows-latest }
     name: cargo test (${{ matrix.variant.name }})
     runs-on: ${{ matrix.variant.os }}


### PR DESCRIPTION
The test failed in https://github.com/cargo-public-api/cargo-public-api/actions/runs/24979458633/job/73138222613 and I have no patience for flaky CI for a platform I don't use, so I'd like to disable mac CI until someone comes around that can fix the failure.

(Note that this is different from the failure in https://github.com/cargo-public-api/cargo-public-api/issues/881. That one I am looking into.)