### PR TITLE
tests: Don't fail tests if cleaning up temporary test dirs fail

### DIFF
--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -1308,7 +1308,7 @@ impl Drop for TestRepo {
                 self.path()
             );
         } else {
-            remove_dir_all::remove_dir_all(self.path()).unwrap();
+            let _ = remove_dir_all::remove_dir_all(self.path());
         }
     }
 }


### PR DESCRIPTION
This should avoid the macOS flakiness observed in #881:

    ---- deny_added_when_not_diffing stdout ----

    thread 'deny_added_when_not_diffing' (81194) panicked at cargo-public-api/tests/cargo-public-api-bin-tests.rs:1311:57:
    called `Result::unwrap()` on an `Err` value: Os { code: 66, kind: DirectoryNotEmpty, message: "Directory not empty" }
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

The root cause is a mystery. But this is just unimportant cleanup code, so let's sweep it under the rug.

Closes #881

We actually disabled macOS CI in https://github.com/cargo-public-api/cargo-public-api/pull/883, but this fix will be needed once/if macOS CI is re-enabled.