### PR TITLE
feat: optionally omit parameter names flag

### DIFF
--- a/cargo-public-api/tests/snapshots/list_public_items.txt
+++ b/cargo-public-api/tests/snapshots/list_public_items.txt
@@ -105,6 +105,7 @@ pub fn public_api::Builder::from_rustdoc_json(path: impl core::convert::Into<std
 pub fn public_api::Builder::omit_auto_derived_impls(self, omit_auto_derived_impls: bool) -> Self
 pub fn public_api::Builder::omit_auto_trait_impls(self, omit_auto_trait_impls: bool) -> Self
 pub fn public_api::Builder::omit_blanket_impls(self, omit_blanket_impls: bool) -> Self
+pub fn public_api::Builder::omit_param_names(self, omit_param_names: bool) -> Self
 pub fn public_api::Builder::sorted(self, sorted: bool) -> Self
 impl core::clone::Clone for public_api::Builder
 pub fn public_api::Builder::clone(&self) -> public_api::Builder

--- a/cargo-public-api/tests/snapshots/subcommand_invocation_public_api_arg.txt
+++ b/cargo-public-api/tests/snapshots/subcommand_invocation_public_api_arg.txt
@@ -81,6 +81,7 @@ pub fn public_api::Builder::from_rustdoc_json(path: impl core::convert::Into<std
 pub fn public_api::Builder::omit_auto_derived_impls(self, omit_auto_derived_impls: bool) -> Self
 pub fn public_api::Builder::omit_auto_trait_impls(self, omit_auto_trait_impls: bool) -> Self
 pub fn public_api::Builder::omit_blanket_impls(self, omit_blanket_impls: bool) -> Self
+pub fn public_api::Builder::omit_param_names(self, omit_param_names: bool) -> Self
 pub fn public_api::Builder::sorted(self, sorted: bool) -> Self
 impl core::clone::Clone for public_api::Builder
 pub fn public_api::Builder::clone(&self) -> public_api::Builder

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -73,6 +73,7 @@ struct BuilderOptions {
     omit_blanket_impls: bool,
     omit_auto_trait_impls: bool,
     omit_auto_derived_impls: bool,
+    omit_param_names: bool,
 }
 
 /// Builds [`PublicApi`]s. See the [top level][`crate`] module docs for example
@@ -94,6 +95,7 @@ impl Builder {
             omit_blanket_impls: false,
             omit_auto_trait_impls: false,
             omit_auto_derived_impls: false,
+            omit_param_names: false,
         };
         Self {
             rustdoc_json: path.into(),
@@ -164,6 +166,22 @@ impl Builder {
     #[must_use]
     pub fn omit_auto_derived_impls(mut self, omit_auto_derived_impls: bool) -> Self {
         self.options.omit_auto_derived_impls = omit_auto_derived_impls;
+        self
+    }
+
+    /// If `true`, function parameter names are omitted from the output. Since
+    /// parameter names are not part of Rust's public API (callers pass
+    /// arguments positionally), including them causes spurious diffs when
+    /// parameters are merely renamed.
+    ///
+    /// `self`/`&self`/`&mut self` receiver names are always preserved
+    /// regardless of this setting.
+    ///
+    /// The default value is `false` so that the output matches the original
+    /// source signatures by default.
+    #[must_use]
+    pub fn omit_param_names(mut self, omit_param_names: bool) -> Self {
+        self.options.omit_param_names = omit_param_names;
         self
     }
 

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -169,16 +169,17 @@ impl Builder {
         self
     }
 
-    /// If `true`, function parameter names are omitted from the output. Since
-    /// parameter names are not part of Rust's public API (callers pass
-    /// arguments positionally), including them causes spurious diffs when
-    /// parameters are merely renamed.
+    /// If `false` (default), function parameter names are contained in the output.
     ///
-    /// `self`/`&self`/`&mut self` receiver names are always preserved
-    /// regardless of this setting.
+    /// ```
+    /// pub fn public_api::Builder::omit_param_names(self, omit_param_names: bool) -> Self
+    /// ```
     ///
-    /// The default value is `false` so that the output matches the original
-    /// source signatures by default.
+    /// If `true`, function parameter names are omitted from the output.
+    ///
+    /// ```
+    //  pub fn public_api::Builder::omit_param_names(self, bool) -> Self
+    //  ```
     #[must_use]
     pub fn omit_param_names(mut self, omit_param_names: bool) -> Self {
         self.options.omit_param_names = omit_param_names;

--- a/public-api/src/render.rs
+++ b/public-api/src/render.rs
@@ -511,7 +511,9 @@ impl<'c> RenderingContext<'c> {
             |(name, ty)| {
                 self.simplified_self(name, ty).unwrap_or_else(|| {
                     let mut output = vec![];
-                    let ignore_name = name.is_empty() || (name == "_" && !include_underscores);
+                    let ignore_name = self.options.omit_param_names
+                        || name.is_empty()
+                        || (name == "_" && !include_underscores);
                     if !ignore_name {
                         output.extend(vec![Token::identifier(name), Token::symbol(":"), ws!()]);
                     }

--- a/public-api/tests/snapshots/public-api_public-api.txt
+++ b/public-api/tests/snapshots/public-api_public-api.txt
@@ -189,6 +189,7 @@ pub fn public_api::Builder::from_rustdoc_json(path: impl core::convert::Into<std
 pub fn public_api::Builder::omit_auto_derived_impls(self, omit_auto_derived_impls: bool) -> Self
 pub fn public_api::Builder::omit_auto_trait_impls(self, omit_auto_trait_impls: bool) -> Self
 pub fn public_api::Builder::omit_blanket_impls(self, omit_blanket_impls: bool) -> Self
+pub fn public_api::Builder::omit_param_names(self, omit_param_names: bool) -> Self
 pub fn public_api::Builder::sorted(self, sorted: bool) -> Self
 impl core::clone::Clone for public_api::Builder
 pub fn public_api::Builder::clone(&self) -> public_api::Builder


### PR DESCRIPTION
I have just added the option to remove parameter names from the publicly generated API files, I was wondering if this would be something you want to upstream.

## Motivation

Our usage of this is to store the public api for all crates in our project and we found that having the names of public method cases extra noise. Renaming or not using a variable doesn't change the method signature.

## Usage

```rust
let builder = MAKE_BUILDER
  .omit_param_names(true)
```

relevant issue: https://github.com/cargo-public-api/cargo-public-api/issues/766