### PR TITLE
Stop including parameter names in function signatures by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # `cargo-public-api` changelog
 
-## v0.51.1
+## v0.52.0
+* Stop including function parameter names by default in the output. This avoids issues where
+  renaming parameters shows up as API diffs. This is especially relevant for trait impls, where fn
+  parameter names are often `_`-prefixed.
+
+  To opt-in to the old behavior of including parameter names, use the new `--include
+  function-parameter-names` CLI option (or the `-v` / `--verbose` shorthand).
 * Make renamed lib targets with `crate-type = ["rlib"]` work
 
 ## v0.51.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "public-api"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-public-api"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,7 +1012,7 @@ checksum = "2febf9acc5ee5e99d1ad0afcdbccc02d87aa3f857a1f01f825b80eacf8edfcd1"
 
 [[package]]
 name = "rustdoc-json"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "assert_cmd",
  "cargo-manifest",

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ cargo public-api -sss
 
 | Version          | Understands the rustdoc JSON output of  |
 | ---------------- | --------------------------------------- |
-| 0.50.x — 0.51.x  | nightly-2025-08-02 —                    |
+| 0.50.x — 0.52.x  | nightly-2025-08-02 —                    |
 | 0.49.x           | nightly-2025-07-17 — nightly-2025-08-01 |
 | 0.48.x           | nightly-2025-06-22 — nightly-2025-07-16 |
 | 0.47.x           | nightly-2025-03-24 — nightly-2025-06-21 |

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -40,7 +40,7 @@ features = ["serde"]
 
 [dependencies.rustdoc-json]
 path = "../rustdoc-json"
-version = "0.9.9"
+version = "0.9.10"
 
 [dependencies.public-api]
 path = "../public-api"

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "cargo-public-api"
-version = "0.51.0"
+version = "0.52.0"
 default-run = "cargo-public-api"
 description = "List and diff the public API of Rust library crates between releases and commits. Detect breaking API changes and semver violations via CI or a CLI."
 homepage = "https://github.com/cargo-public-api/cargo-public-api"

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -44,7 +44,7 @@ version = "0.9.10"
 
 [dependencies.public-api]
 path = "../public-api"
-version = "0.51.0"
+version = "0.52.0"
 
 [dependencies.serde]
 version = "1.0.179"

--- a/cargo-public-api/src/api_source.rs
+++ b/cargo-public-api/src/api_source.rs
@@ -133,6 +133,7 @@ fn public_api_builder_from_args(rustdoc_json: &Path, args: &Args) -> public_api:
         .omit_blanket_impls(args.omit_blanket_impls())
         .omit_auto_trait_impls(args.omit_auto_trait_impls())
         .omit_auto_derived_impls(args.omit_auto_derived_impls())
+        .include_function_parameter_names(args.include_function_parameter_names())
 }
 
 /// Creates a rustdoc JSON builder based on the args to this program.

--- a/cargo-public-api/src/arg_types.rs
+++ b/cargo-public-api/src/arg_types.rs
@@ -72,6 +72,15 @@ pub enum Omit {
     AutoDerivedImpls,
 }
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq, clap::ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum Include {
+    /// Include function parameter names in the output. They are omitted by
+    /// default to avoid spurious API diffs when parameter names change. But
+    /// they can sometimes be helpful to include in the output.
+    FunctionParameterNames,
+}
+
 #[cfg(test)]
 mod tests {
     use super::DenyMethod;

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -37,7 +37,11 @@ pub struct Args {
     #[arg(global = true, long, short)]
     package: Option<String>,
 
-    /// Omit noisy items. Can be used more than once.
+    /// Omit noisy items.
+    #[arg(global = true, long, value_enum, value_delimiter = ',')]
+    omit: Option<Vec<Omit>>,
+
+    /// Shorthand for omitting noisy items. Can be used more than once.
     ///
     /// | Usage | Corresponds to                                           |
     /// |-------|----------------------------------------------------------|
@@ -49,6 +53,10 @@ pub struct Args {
     simplified: u8,
 
     /// Include extra details.
+    #[arg(global = true, long, value_enum, value_delimiter = ',')]
+    include: Option<Vec<Include>>,
+
+    /// Shorthand for including extra details.
     ///
     /// | Usage | Corresponds to                                           |
     /// |-------|----------------------------------------------------------|
@@ -56,14 +64,6 @@ pub struct Args {
     #[clap(verbatim_doc_comment)]
     #[arg(global = true, short, long, action = clap::ArgAction::Count)]
     verbose: u8,
-
-    /// Omit specified items.
-    #[arg(global = true, long, value_enum, value_delimiter = ',')]
-    omit: Option<Vec<Omit>>,
-
-    /// Include specified details.
-    #[arg(global = true, long, value_enum, value_delimiter = ',')]
-    include: Option<Vec<Include>>,
 
     /// Space or comma separated list of features to activate
     #[arg(global = true, long, short = 'F')]

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow, bail};
 use api_source::{ApiSource, Commit, CurrentDir, PublishedCrate, RustdocJson};
-use arg_types::{Color, DenyMethod, Omit};
+use arg_types::{Color, DenyMethod, Include, Omit};
 use git_utils::current_branch_or_commit;
 use plain::Plain;
 use public_api::diff::PublicApiDiff;
@@ -48,9 +48,22 @@ pub struct Args {
     #[arg(global = true, short, long, action = clap::ArgAction::Count)]
     simplified: u8,
 
+    /// Include extra details.
+    ///
+    /// | Usage | Corresponds to                                           |
+    /// |-------|----------------------------------------------------------|
+    /// | -v    | --include function-parameter-names                       |
+    #[clap(verbatim_doc_comment)]
+    #[arg(global = true, short, long, action = clap::ArgAction::Count)]
+    verbose: u8,
+
     /// Omit specified items.
     #[arg(global = true, long, value_enum, value_delimiter = ',')]
     omit: Option<Vec<Omit>>,
+
+    /// Include specified details.
+    #[arg(global = true, long, value_enum, value_delimiter = ',')]
+    include: Option<Vec<Include>>,
 
     /// Space or comma separated list of features to activate
     #[arg(global = true, long, short = 'F')]
@@ -517,6 +530,14 @@ impl Args {
         self.omit.iter().flatten().any(|o| *o == to_omit)
     }
 
+    fn include_function_parameter_names(&self) -> bool {
+        self.includes(Include::FunctionParameterNames)
+    }
+
+    fn includes(&self, to_include: Include) -> bool {
+        self.include.iter().flatten().any(|i| *i == to_include)
+    }
+
     fn git_root(&self) -> Result<PathBuf> {
         git_utils::git_root_from_manifest_path(self.manifest_path.as_path())
     }
@@ -545,6 +566,7 @@ fn get_args() -> ArgsAndToolchain {
 
     let mut args = Args::parse_from(args_os);
     resolve_simplified(&mut args);
+    resolve_verbose(&mut args);
     resolve_toolchain(args)
 }
 
@@ -598,6 +620,16 @@ fn resolve_simplified(args: &mut Args) {
 
         if args.simplified > 2 {
             omit.push(Omit::AutoDerivedImpls);
+        }
+    }
+}
+
+fn resolve_verbose(args: &mut Args) {
+    if args.verbose > 0 {
+        let include = args.include.get_or_insert_with(Vec::new);
+
+        if args.verbose > 0 {
+            include.push(Include::FunctionParameterNames);
         }
     }
 }

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -79,6 +79,37 @@ fn list_public_items_omit_auto_derived_impls() {
         .success();
 }
 
+// All three tests should have the same output.
+const FUNCTION_PARAMETER_NAMES_OUTPUT_PATH: &str = "include-function-parameter-names";
+
+#[test]
+fn list_public_items_include_function_parameter_names() {
+    let mut cmd = TestCmd::as_subcommand_without_args().with_test_repo();
+    cmd.arg("--include");
+    cmd.arg("function-parameter-names");
+    cmd.assert()
+        .stdout_with_insta(FUNCTION_PARAMETER_NAMES_OUTPUT_PATH)
+        .success();
+}
+
+#[test]
+fn list_public_items_include_function_parameter_names_with_v() {
+    let mut cmd = TestCmd::as_subcommand_without_args().with_test_repo();
+    cmd.arg("-v"); // Note the verbose flag
+    cmd.assert()
+        .stdout_with_insta(FUNCTION_PARAMETER_NAMES_OUTPUT_PATH)
+        .success();
+}
+
+#[test]
+fn list_public_items_include_function_parameter_names_with_verbose() {
+    let mut cmd = TestCmd::as_subcommand_without_args().with_test_repo();
+    cmd.arg("--verbose"); // Note the verbose flag
+    cmd.assert()
+        .stdout_with_insta(FUNCTION_PARAMETER_NAMES_OUTPUT_PATH)
+        .success();
+}
+
 #[test]
 fn list_public_items_omit_auto_derived_impls_with_double_s() {
     let mut cmd = TestCmd::as_subcommand_without_args().with_test_repo();
@@ -730,7 +761,7 @@ fn deny_removed_with_diff() {
     cmd.arg("--deny=removed");
     cmd.assert()
         .stderr(contains(
-            "The API diff is not allowed as per --deny: Removed items not allowed: [pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize)]",
+            "The API diff is not allowed as per --deny: Removed items not allowed: [pub fn example_api::function(example_api::Struct, usize)]",
         ))
         .failure();
 }

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -187,7 +187,7 @@ fn renamed_binary_works_as_subcommand() {
     Command::from_std(cmd)
         .assert()
         .stderr(contains(""))
-        .stdout_with_insta("short-help")
+        .stdout_with_insta("help-short")
         .success();
 }
 
@@ -1064,7 +1064,7 @@ fn debug_processing() {
 fn short_help() {
     let mut cmd = TestCmd::new().with_separate_target_dir();
     cmd.arg("-h");
-    cmd.assert().stdout_with_insta("short-help").success();
+    cmd.assert().stdout_with_insta("help-short").success();
 }
 
 #[test]
@@ -1072,7 +1072,7 @@ fn short_diff_help() {
     let mut cmd = TestCmd::new().with_separate_target_dir();
     cmd.arg("diff");
     cmd.arg("-h");
-    cmd.assert().stdout_with_insta("short-diff-help").success();
+    cmd.assert().stdout_with_insta("help-short-diff").success();
 }
 
 #[test]
@@ -1081,7 +1081,7 @@ fn short_completions_help() {
     cmd.arg("completions");
     cmd.arg("-h");
     cmd.assert()
-        .stdout_with_insta("short-completions-help")
+        .stdout_with_insta("help-short-completions")
         .success();
 }
 
@@ -1089,7 +1089,7 @@ fn short_completions_help() {
 fn long_help() {
     let mut cmd = TestCmd::new();
     cmd.arg("--help");
-    cmd.assert().stdout_with_insta("long-help").success();
+    cmd.assert().stdout_with_insta("help-long").success();
 }
 
 #[test]
@@ -1098,7 +1098,7 @@ fn long_completions_help() {
     cmd.arg("completions");
     cmd.arg("--help");
     cmd.assert()
-        .stdout_with_insta("long-completions-help")
+        .stdout_with_insta("help-long-completions")
         .success();
 }
 
@@ -1107,7 +1107,7 @@ fn long_diff_help() {
     let mut cmd = TestCmd::new();
     cmd.arg("diff");
     cmd.arg("--help");
-    cmd.assert().stdout_with_insta("long-diff-help").success();
+    cmd.assert().stdout_with_insta("help-long-diff").success();
 }
 
 #[test]

--- a/cargo-public-api/tests/snapshots/comprehensive_api.txt
+++ b/cargo-public-api/tests/snapshots/comprehensive_api.txt
@@ -62,13 +62,13 @@ pub struct comprehensive_api::exports::issue_145::external_3::External
 pub mod comprehensive_api::exports::issue_145::publicly_renamed
 pub struct comprehensive_api::exports::issue_145::publicly_renamed::External
 pub struct comprehensive_api::exports::issue_145::PubliclyRenamedFromPrivateMod
-pub fn comprehensive_api::exports::issue_145::external_arg_type(_transform: comprehensive_api::exports::issue_145::external::External)
-pub fn comprehensive_api::exports::issue_145::external_external_arg_type(_transform: comprehensive_api::exports::issue_145::external::External)
-pub fn comprehensive_api::exports::issue_145::privately_renamed_2_arg_type(_transform: comprehensive_api::exports::issue_145::external_2::External)
-pub fn comprehensive_api::exports::issue_145::privately_renamed_arg_type(_transform: comprehensive_api::exports::issue_145::external::External)
-pub fn comprehensive_api::exports::issue_145::privately_renamed_external_arg_type(_transform: comprehensive_api::exports::issue_145::external::External)
-pub fn comprehensive_api::exports::issue_145::publicly_renamed_external(_transform: comprehensive_api::exports::issue_145::external_2::External)
-pub fn comprehensive_api::exports::issue_145::publicly_renamed_from_private_mod_arg_type(_transform: comprehensive_api::exports::issue_145::external_3::External)
+pub fn comprehensive_api::exports::issue_145::external_arg_type(comprehensive_api::exports::issue_145::external::External)
+pub fn comprehensive_api::exports::issue_145::external_external_arg_type(comprehensive_api::exports::issue_145::external::External)
+pub fn comprehensive_api::exports::issue_145::privately_renamed_2_arg_type(comprehensive_api::exports::issue_145::external_2::External)
+pub fn comprehensive_api::exports::issue_145::privately_renamed_arg_type(comprehensive_api::exports::issue_145::external::External)
+pub fn comprehensive_api::exports::issue_145::privately_renamed_external_arg_type(comprehensive_api::exports::issue_145::external::External)
+pub fn comprehensive_api::exports::issue_145::publicly_renamed_external(comprehensive_api::exports::issue_145::external_2::External)
+pub fn comprehensive_api::exports::issue_145::publicly_renamed_from_private_mod_arg_type(comprehensive_api::exports::issue_145::external_3::External)
 pub mod comprehensive_api::exports::issue_410
 pub mod comprehensive_api::exports::issue_410::container
 pub mod comprehensive_api::exports::issue_410::container::super_glob
@@ -93,41 +93,41 @@ pub fn comprehensive_api::exports::v1::foo2()
 pub mod comprehensive_api::functions
 pub async fn comprehensive_api::functions::async_fn()
 pub async fn comprehensive_api::functions::async_fn_ret_bool() -> bool
-pub fn comprehensive_api::functions::box_dyn_arg_two_traits(d: alloc::boxed::Box<(dyn std::io::Write + core::marker::Send)>)
+pub fn comprehensive_api::functions::box_dyn_arg_two_traits(alloc::boxed::Box<(dyn std::io::Write + core::marker::Send)>)
 pub const fn comprehensive_api::functions::const_fn()
-pub fn comprehensive_api::functions::dyn_arg_one_trait(d: &dyn std::io::Write)
-pub fn comprehensive_api::functions::dyn_arg_one_trait_one_lifetime(d: &(dyn std::io::Write + 'static))
-pub fn comprehensive_api::functions::dyn_arg_two_traits(d: &(dyn std::io::Write + core::marker::Send))
-pub fn comprehensive_api::functions::dyn_arg_two_traits_one_lifetime(d: &(dyn std::io::Write + core::marker::Send + 'static))
-pub fn comprehensive_api::functions::fn_arg(f: impl core::ops::function::Fn(bool, comprehensive_api::structs::Plain) -> bool, f_mut: impl core::ops::function::FnMut())
-pub fn comprehensive_api::functions::generic_arg<T>(t: T) -> T
-pub fn comprehensive_api::functions::generic_bound<T: core::marker::Sized>(t: T) -> T
-pub fn comprehensive_api::functions::impl_multiple<T>(t: impl comprehensive_api::traits::Simple + core::convert::AsRef<T>) -> impl comprehensive_api::traits::Simple
-pub fn comprehensive_api::functions::inferred_lifetime(foo: &usize) -> usize
-pub fn comprehensive_api::functions::multiple_bounds<T>(t: T) where T: core::fmt::Debug + core::fmt::Display
-pub fn comprehensive_api::functions::multiple_bounds_inline<T: core::fmt::Debug + core::fmt::Display>(t: T)
-pub fn comprehensive_api::functions::one_arg(x: usize)
-pub fn comprehensive_api::functions::outlives<'a, 'b: 'a, 'c: 'b + 'a>(x: &'a bool, y: &'b i128, z: &'c comprehensive_api::structs::TupleStructSingle) -> usize
+pub fn comprehensive_api::functions::dyn_arg_one_trait(&dyn std::io::Write)
+pub fn comprehensive_api::functions::dyn_arg_one_trait_one_lifetime(&(dyn std::io::Write + 'static))
+pub fn comprehensive_api::functions::dyn_arg_two_traits(&(dyn std::io::Write + core::marker::Send))
+pub fn comprehensive_api::functions::dyn_arg_two_traits_one_lifetime(&(dyn std::io::Write + core::marker::Send + 'static))
+pub fn comprehensive_api::functions::fn_arg(impl core::ops::function::Fn(bool, comprehensive_api::structs::Plain) -> bool, impl core::ops::function::FnMut())
+pub fn comprehensive_api::functions::generic_arg<T>(T) -> T
+pub fn comprehensive_api::functions::generic_bound<T: core::marker::Sized>(T) -> T
+pub fn comprehensive_api::functions::impl_multiple<T>(impl comprehensive_api::traits::Simple + core::convert::AsRef<T>) -> impl comprehensive_api::traits::Simple
+pub fn comprehensive_api::functions::inferred_lifetime(&usize) -> usize
+pub fn comprehensive_api::functions::multiple_bounds<T>(T) where T: core::fmt::Debug + core::fmt::Display
+pub fn comprehensive_api::functions::multiple_bounds_inline<T: core::fmt::Debug + core::fmt::Display>(T)
+pub fn comprehensive_api::functions::one_arg(usize)
+pub fn comprehensive_api::functions::outlives<'a, 'b: 'a, 'c: 'b + 'a>(&'a bool, &'b i128, &'c comprehensive_api::structs::TupleStructSingle) -> usize
 pub fn comprehensive_api::functions::plain()
 pub fn comprehensive_api::functions::return_array() -> [u8; 2]
 pub fn comprehensive_api::functions::return_iterator() -> impl core::iter::traits::iterator::Iterator<Item = u32>
-pub fn comprehensive_api::functions::return_mut_raw_pointer(input: &mut usize) -> *mut usize
-pub fn comprehensive_api::functions::return_raw_pointer(input: &usize) -> *const usize
-pub fn comprehensive_api::functions::return_slice<'a>(input: &'a [usize]) -> &'a [usize]
+pub fn comprehensive_api::functions::return_mut_raw_pointer(&mut usize) -> *mut usize
+pub fn comprehensive_api::functions::return_raw_pointer(&usize) -> *const usize
+pub fn comprehensive_api::functions::return_slice<'a>(&'a [usize]) -> &'a [usize]
 pub fn comprehensive_api::functions::return_tuple() -> (bool, comprehensive_api::unions::Basic)
-pub fn comprehensive_api::functions::somewhere<T, U>(t: T, u: U) where T: core::fmt::Display, U: core::fmt::Debug
-pub fn comprehensive_api::functions::struct_arg(s: comprehensive_api::structs::PrivateField)
-pub fn comprehensive_api::functions::synthetic_arg(t: impl comprehensive_api::traits::Simple) -> impl comprehensive_api::traits::Simple
-pub fn comprehensive_api::functions::synthetic_use_capture<'a, 'b, T>(x: &'a (), y: T) -> impl core::marker::Sized + use<'a, T>
-pub fn comprehensive_api::functions::synthetic_use_no_capture<'a>(x: &'a usize) -> impl core::marker::Sized + use<>
+pub fn comprehensive_api::functions::somewhere<T, U>(T, U) where T: core::fmt::Display, U: core::fmt::Debug
+pub fn comprehensive_api::functions::struct_arg(comprehensive_api::structs::PrivateField)
+pub fn comprehensive_api::functions::synthetic_arg(impl comprehensive_api::traits::Simple) -> impl comprehensive_api::traits::Simple
+pub fn comprehensive_api::functions::synthetic_use_capture<'a, 'b, T>(&'a (), T) -> impl core::marker::Sized + use<'a, T>
+pub fn comprehensive_api::functions::synthetic_use_no_capture<'a>(&'a usize) -> impl core::marker::Sized + use<>
 pub unsafe fn comprehensive_api::functions::unsafe_fn()
-pub fn comprehensive_api::functions::unused_argument(_: u32)
+pub fn comprehensive_api::functions::unused_argument(u32)
 pub mod comprehensive_api::higher_ranked_trait_bounds
 pub struct comprehensive_api::higher_ranked_trait_bounds::Bar<'a>
 pub comprehensive_api::higher_ranked_trait_bounds::Bar::bar: &'a (dyn for<'b> comprehensive_api::higher_ranked_trait_bounds::Trait<'b> + core::marker::Unpin)
 pub comprehensive_api::higher_ranked_trait_bounds::Bar::baz: &'a (dyn core::marker::Unpin + for<'b> comprehensive_api::higher_ranked_trait_bounds::Trait<'b>)
 pub struct comprehensive_api::higher_ranked_trait_bounds::Foo<'a>
-pub comprehensive_api::higher_ranked_trait_bounds::Foo::some_func: for<'c> fn(val: &'c i32) -> i32
+pub comprehensive_api::higher_ranked_trait_bounds::Foo::some_func: for<'c> fn(&'c i32) -> i32
 pub comprehensive_api::higher_ranked_trait_bounds::Foo::some_trait: &'a dyn for<'b> comprehensive_api::higher_ranked_trait_bounds::Trait<'b>
 impl<'a> comprehensive_api::higher_ranked_trait_bounds::Foo<'a>
 pub fn comprehensive_api::higher_ranked_trait_bounds::Foo<'a>::bar<T>() where T: comprehensive_api::higher_ranked_trait_bounds::Trait<'a>
@@ -212,15 +212,15 @@ pub struct comprehensive_api::structs::WithLifetimeAndGenericParam<'a, T>
 pub comprehensive_api::structs::WithLifetimeAndGenericParam::t: T
 pub comprehensive_api::structs::WithLifetimeAndGenericParam::unit_ref: &'a comprehensive_api::structs::Unit
 impl<'b, 'z> comprehensive_api::structs::WithLifetimeAndGenericParam<'b, alloc::string::String> where 'b: 'z + 'static
-pub fn comprehensive_api::structs::WithLifetimeAndGenericParam<'b, alloc::string::String>::with_two_lifetime_bounds(unit_ref: &'z comprehensive_api::structs::Unit, t: alloc::string::String)
+pub fn comprehensive_api::structs::WithLifetimeAndGenericParam<'b, alloc::string::String>::with_two_lifetime_bounds(&'z comprehensive_api::structs::Unit, alloc::string::String)
 impl<'b, T> comprehensive_api::structs::WithLifetimeAndGenericParam<'b, T>
-pub fn comprehensive_api::structs::WithLifetimeAndGenericParam<'b, T>::new_any(unit_ref: &'b comprehensive_api::structs::Unit, t: T) -> Self
+pub fn comprehensive_api::structs::WithLifetimeAndGenericParam<'b, T>::new_any(&'b comprehensive_api::structs::Unit, T) -> Self
 impl<'b, T> comprehensive_api::structs::WithLifetimeAndGenericParam<'b, T>
-pub fn comprehensive_api::structs::WithLifetimeAndGenericParam<'b, T>::new_any_duplicate(unit_ref: &'b comprehensive_api::structs::Unit, t: T) -> Self
+pub fn comprehensive_api::structs::WithLifetimeAndGenericParam<'b, T>::new_any_duplicate(&'b comprehensive_api::structs::Unit, T) -> Self
 impl<'b> comprehensive_api::structs::WithLifetimeAndGenericParam<'b, alloc::string::String> where 'b: 'static
-pub fn comprehensive_api::structs::WithLifetimeAndGenericParam<'b, alloc::string::String>::new_with_lifetime_bound(unit_ref: &'b comprehensive_api::structs::Unit, t: alloc::string::String) -> Self
+pub fn comprehensive_api::structs::WithLifetimeAndGenericParam<'b, alloc::string::String>::new_with_lifetime_bound(&'b comprehensive_api::structs::Unit, alloc::string::String) -> Self
 impl<'b> comprehensive_api::structs::WithLifetimeAndGenericParam<'b, alloc::string::String>
-pub fn comprehensive_api::structs::WithLifetimeAndGenericParam<'b, alloc::string::String>::new(unit_ref: &'b comprehensive_api::structs::Unit, t: alloc::string::String) -> Self
+pub fn comprehensive_api::structs::WithLifetimeAndGenericParam<'b, alloc::string::String>::new(&'b comprehensive_api::structs::Unit, alloc::string::String) -> Self
 pub struct comprehensive_api::structs::WithTraitBounds<T: core::fmt::Display + core::fmt::Debug>
 pub mod comprehensive_api::traits
 pub trait comprehensive_api::traits::AssociatedConst

--- a/cargo-public-api/tests/snapshots/diff_published.txt
+++ b/cargo-public-api/tests/snapshots/diff_published.txt
@@ -1,6 +1,6 @@
 Removed items from the public API
 =================================
--pub fn example_api::function(v1_param: example_api::Struct)
+-pub fn example_api::function(example_api::Struct)
 
 Changed items in the public API
 ===============================

--- a/cargo-public-api/tests/snapshots/diff_published_with_features.txt
+++ b/cargo-public-api/tests/snapshots/diff_published_with_features.txt
@@ -1,7 +1,7 @@
 Removed items from the public API
 =================================
 -pub example_api::Struct::v1_2_field_gated: usize
--pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize)
+-pub fn example_api::function(example_api::Struct, usize)
 
 Changed items in the public API
 ===============================

--- a/cargo-public-api/tests/snapshots/example_api-v0.3.0.txt
+++ b/cargo-public-api/tests/snapshots/example_api-v0.3.0.txt
@@ -3,6 +3,6 @@ pub mod example_api
 pub example_api::Struct::v1_field: usize
 pub example_api::Struct::v2_field: usize
 impl core::fmt::Debug for example_api::Struct
-pub fn example_api::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn example_api::Struct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct example_api::StructV2
 pub example_api::StructV2::field: usize

--- a/cargo-public-api/tests/snapshots/example_api-v0.3.0_document-private-items.txt
+++ b/cargo-public-api/tests/snapshots/example_api-v0.3.0_document-private-items.txt
@@ -3,7 +3,7 @@ pub mod example_api
 pub example_api::Struct::v1_field: usize
 pub example_api::Struct::v2_field: usize
 impl core::fmt::Debug for example_api::Struct
-pub fn example_api::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn example_api::Struct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct example_api::StructV2
 pub example_api::StructV2::field: usize
 pub example_api::StructV2::private_field: usize

--- a/cargo-public-api/tests/snapshots/example_api_diff_v0.1.0_to_v0.2.0.txt
+++ b/cargo-public-api/tests/snapshots/example_api_diff_v0.1.0_to_v0.2.0.txt
@@ -6,8 +6,8 @@ Changed items in the public API
 ===============================
 -pub struct example_api::Struct
 +#[non_exhaustive] pub struct example_api::Struct
--pub fn example_api::function(v1_param: example_api::Struct)
-+pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize)
+-pub fn example_api::function(example_api::Struct)
++pub fn example_api::function(example_api::Struct, usize)
 
 Added items to the public API
 =============================

--- a/cargo-public-api/tests/snapshots/example_api_diff_v0.1.0_to_v0.2.0_colored.txt
+++ b/cargo-public-api/tests/snapshots/example_api_diff_v0.1.0_to_v0.2.0_colored.txt
@@ -6,8 +6,8 @@ Changed items in the public API
 ===============================
 -[34mpub[0m [34mstruct[0m [36mexample_api[0m::[32mStruct[0m
 +[1;48;5;22;38;5;10m#[non_exhaustive] [0m[34mpub[0m [34mstruct[0m [36mexample_api[0m::[32mStruct[0m
--[34mpub[0m [34mfn[0m [36mexample_api[0m::[33mfunction[0m([36mv1_param[0m: [36mexample_api[0m::[32mStruct[0m)
-+[34mpub[0m [34mfn[0m [36mexample_api[0m::[33mfunction[0m([36mv1_param[0m: [36mexample_api[0m::[32mStruct[1;48;5;22;38;5;10m, v2_param: usize[0m)
+-[34mpub[0m [34mfn[0m [36mexample_api[0m::[33mfunction[0m([36mexample_api[0m::[32mStruct[0m)
++[34mpub[0m [34mfn[0m [36mexample_api[0m::[33mfunction[0m([36mexample_api[0m::[32mStruct[1;48;5;22;38;5;10m, usize[0m)
 
 Added items to the public API
 =============================

--- a/cargo-public-api/tests/snapshots/example_api_diff_v0.2.0_to_v0.3.0.txt
+++ b/cargo-public-api/tests/snapshots/example_api_diff_v0.2.0_to_v0.3.0.txt
@@ -1,6 +1,6 @@
 Removed items from the public API
 =================================
--pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize)
+-pub fn example_api::function(example_api::Struct, usize)
 
 Changed items in the public API
 ===============================

--- a/cargo-public-api/tests/snapshots/example_api_v0.3.0_colored.txt
+++ b/cargo-public-api/tests/snapshots/example_api_v0.3.0_colored.txt
@@ -3,6 +3,6 @@
 [34mpub[0m [36mexample_api[0m::[32mStruct[0m::[36mv1_field[0m: [32musize[0m
 [34mpub[0m [36mexample_api[0m::[32mStruct[0m::[36mv2_field[0m: [32musize[0m
 [34mimpl[0m [36mcore[0m::[36mfmt[0m::[32mDebug[0m [34mfor[0m [36mexample_api[0m::[32mStruct[0m
-[34mpub[0m [34mfn[0m [36mexample_api[0m::[32mStruct[0m::[33mfmt[0m(&[34mself[0m, [36mf[0m: &[34mmut[0m [36mcore[0m::[36mfmt[0m::[32mFormatter[0m<[34m'_[0m>) -> [36mcore[0m::[36mfmt[0m::[32mResult[0m
+[34mpub[0m [34mfn[0m [36mexample_api[0m::[32mStruct[0m::[33mfmt[0m(&[34mself[0m, &[34mmut[0m [36mcore[0m::[36mfmt[0m::[32mFormatter[0m<[34m'_[0m>) -> [36mcore[0m::[36mfmt[0m::[32mResult[0m
 [34mpub[0m [34mstruct[0m [36mexample_api[0m::[32mStructV2[0m
 [34mpub[0m [36mexample_api[0m::[32mStructV2[0m::[36mfield[0m: [32musize[0m

--- a/cargo-public-api/tests/snapshots/help-long-completions.txt
+++ b/cargo-public-api/tests/snapshots/help-long-completions.txt
@@ -29,24 +29,8 @@ Options:
   -p, --package <PACKAGE>
           Name of package in workspace to list or diff the public API for
 
-  -s, --simplified...
-          Omit noisy items. Can be used more than once.
-          
-          | Usage | Corresponds to                                           |
-          |-------|----------------------------------------------------------|
-          | -s    | --omit blanket-impls                                     |
-          | -ss   | --omit blanket-impls,auto-trait-impls                    |
-          | -sss  | --omit blanket-impls,auto-trait-impls,auto-derived-impls |
-
-  -v, --verbose...
-          Include extra details.
-          
-          | Usage | Corresponds to                                           |
-          |-------|----------------------------------------------------------|
-          | -v    | --include function-parameter-names                       |
-
       --omit <OMIT>
-          Omit specified items
+          Omit noisy items
 
           Possible values:
           - blanket-impls:      Omit items that belong to Blanket Implementations such as `impl<T>
@@ -56,13 +40,29 @@ Options:
           - auto-derived-impls: Omit items that belong to Auto Derived Implementations such as
             `Clone`, `Debug`, and `Eq`
 
+  -s, --simplified...
+          Shorthand for omitting noisy items. Can be used more than once.
+          
+          | Usage | Corresponds to                                           |
+          |-------|----------------------------------------------------------|
+          | -s    | --omit blanket-impls                                     |
+          | -ss   | --omit blanket-impls,auto-trait-impls                    |
+          | -sss  | --omit blanket-impls,auto-trait-impls,auto-derived-impls |
+
       --include <INCLUDE>
-          Include specified details
+          Include extra details
 
           Possible values:
           - function-parameter-names: Include function parameter names in the output. They are
             omitted by default to avoid spurious API diffs when parameter names change. But they can
             sometimes be helpful to include in the output
+
+  -v, --verbose...
+          Shorthand for including extra details.
+          
+          | Usage | Corresponds to                                           |
+          |-------|----------------------------------------------------------|
+          | -v    | --include function-parameter-names                       |
 
   -F, --features <FEATURES>
           Space or comma separated list of features to activate

--- a/cargo-public-api/tests/snapshots/help-long-diff.txt
+++ b/cargo-public-api/tests/snapshots/help-long-diff.txt
@@ -108,24 +108,8 @@ Options:
   -p, --package <PACKAGE>
           Name of package in workspace to list or diff the public API for
 
-  -s, --simplified...
-          Omit noisy items. Can be used more than once.
-          
-          | Usage | Corresponds to                                           |
-          |-------|----------------------------------------------------------|
-          | -s    | --omit blanket-impls                                     |
-          | -ss   | --omit blanket-impls,auto-trait-impls                    |
-          | -sss  | --omit blanket-impls,auto-trait-impls,auto-derived-impls |
-
-  -v, --verbose...
-          Include extra details.
-          
-          | Usage | Corresponds to                                           |
-          |-------|----------------------------------------------------------|
-          | -v    | --include function-parameter-names                       |
-
       --omit <OMIT>
-          Omit specified items
+          Omit noisy items
 
           Possible values:
           - blanket-impls:      Omit items that belong to Blanket Implementations such as `impl<T>
@@ -135,13 +119,29 @@ Options:
           - auto-derived-impls: Omit items that belong to Auto Derived Implementations such as
             `Clone`, `Debug`, and `Eq`
 
+  -s, --simplified...
+          Shorthand for omitting noisy items. Can be used more than once.
+          
+          | Usage | Corresponds to                                           |
+          |-------|----------------------------------------------------------|
+          | -s    | --omit blanket-impls                                     |
+          | -ss   | --omit blanket-impls,auto-trait-impls                    |
+          | -sss  | --omit blanket-impls,auto-trait-impls,auto-derived-impls |
+
       --include <INCLUDE>
-          Include specified details
+          Include extra details
 
           Possible values:
           - function-parameter-names: Include function parameter names in the output. They are
             omitted by default to avoid spurious API diffs when parameter names change. But they can
             sometimes be helpful to include in the output
+
+  -v, --verbose...
+          Shorthand for including extra details.
+          
+          | Usage | Corresponds to                                           |
+          |-------|----------------------------------------------------------|
+          | -v    | --include function-parameter-names                       |
 
   -F, --features <FEATURES>
           Space or comma separated list of features to activate

--- a/cargo-public-api/tests/snapshots/help-long.txt
+++ b/cargo-public-api/tests/snapshots/help-long.txt
@@ -15,24 +15,8 @@ Options:
   -p, --package <PACKAGE>
           Name of package in workspace to list or diff the public API for
 
-  -s, --simplified...
-          Omit noisy items. Can be used more than once.
-          
-          | Usage | Corresponds to                                           |
-          |-------|----------------------------------------------------------|
-          | -s    | --omit blanket-impls                                     |
-          | -ss   | --omit blanket-impls,auto-trait-impls                    |
-          | -sss  | --omit blanket-impls,auto-trait-impls,auto-derived-impls |
-
-  -v, --verbose...
-          Include extra details.
-          
-          | Usage | Corresponds to                                           |
-          |-------|----------------------------------------------------------|
-          | -v    | --include function-parameter-names                       |
-
       --omit <OMIT>
-          Omit specified items
+          Omit noisy items
 
           Possible values:
           - blanket-impls:      Omit items that belong to Blanket Implementations such as `impl<T>
@@ -42,13 +26,29 @@ Options:
           - auto-derived-impls: Omit items that belong to Auto Derived Implementations such as
             `Clone`, `Debug`, and `Eq`
 
+  -s, --simplified...
+          Shorthand for omitting noisy items. Can be used more than once.
+          
+          | Usage | Corresponds to                                           |
+          |-------|----------------------------------------------------------|
+          | -s    | --omit blanket-impls                                     |
+          | -ss   | --omit blanket-impls,auto-trait-impls                    |
+          | -sss  | --omit blanket-impls,auto-trait-impls,auto-derived-impls |
+
       --include <INCLUDE>
-          Include specified details
+          Include extra details
 
           Possible values:
           - function-parameter-names: Include function parameter names in the output. They are
             omitted by default to avoid spurious API diffs when parameter names change. But they can
             sometimes be helpful to include in the output
+
+  -v, --verbose...
+          Shorthand for including extra details.
+          
+          | Usage | Corresponds to                                           |
+          |-------|----------------------------------------------------------|
+          | -v    | --include function-parameter-names                       |
 
   -F, --features <FEATURES>
           Space or comma separated list of features to activate

--- a/cargo-public-api/tests/snapshots/help-short-completions.txt
+++ b/cargo-public-api/tests/snapshots/help-short-completions.txt
@@ -8,11 +8,11 @@ Arguments:
 Options:
       --manifest-path <PATH>  Path to `Cargo.toml` [default: Cargo.toml]
   -p, --package <PACKAGE>     Name of package in workspace to list or diff the public API for
-  -s, --simplified...         Omit noisy items. Can be used more than once.
-  -v, --verbose...            Include extra details.
-      --omit <OMIT>           Omit specified items [possible values: blanket-impls,
-                              auto-trait-impls, auto-derived-impls]
-      --include <INCLUDE>     Include specified details [possible values: function-parameter-names]
+      --omit <OMIT>           Omit noisy items [possible values: blanket-impls, auto-trait-impls,
+                              auto-derived-impls]
+  -s, --simplified...         Shorthand for omitting noisy items. Can be used more than once.
+      --include <INCLUDE>     Include extra details [possible values: function-parameter-names]
+  -v, --verbose...            Shorthand for including extra details.
   -F, --features <FEATURES>   Space or comma separated list of features to activate
       --all-features          Activate all available features
       --no-default-features   Do not activate the `default` feature

--- a/cargo-public-api/tests/snapshots/help-short-diff.txt
+++ b/cargo-public-api/tests/snapshots/help-short-diff.txt
@@ -13,11 +13,11 @@ Options:
                               option will discard working tree changes during git checkouts of other
                               commits
   -p, --package <PACKAGE>     Name of package in workspace to list or diff the public API for
-  -s, --simplified...         Omit noisy items. Can be used more than once.
-  -v, --verbose...            Include extra details.
-      --omit <OMIT>           Omit specified items [possible values: blanket-impls,
-                              auto-trait-impls, auto-derived-impls]
-      --include <INCLUDE>     Include specified details [possible values: function-parameter-names]
+      --omit <OMIT>           Omit noisy items [possible values: blanket-impls, auto-trait-impls,
+                              auto-derived-impls]
+  -s, --simplified...         Shorthand for omitting noisy items. Can be used more than once.
+      --include <INCLUDE>     Include extra details [possible values: function-parameter-names]
+  -v, --verbose...            Shorthand for including extra details.
   -F, --features <FEATURES>   Space or comma separated list of features to activate
       --all-features          Activate all available features
       --no-default-features   Do not activate the `default` feature

--- a/cargo-public-api/tests/snapshots/help-short.txt
+++ b/cargo-public-api/tests/snapshots/help-short.txt
@@ -8,11 +8,11 @@ Usage: cargo public-api [OPTIONS]
 Options:
       --manifest-path <PATH>  Path to `Cargo.toml` [default: Cargo.toml]
   -p, --package <PACKAGE>     Name of package in workspace to list or diff the public API for
-  -s, --simplified...         Omit noisy items. Can be used more than once.
-  -v, --verbose...            Include extra details.
-      --omit <OMIT>           Omit specified items [possible values: blanket-impls,
-                              auto-trait-impls, auto-derived-impls]
-      --include <INCLUDE>     Include specified details [possible values: function-parameter-names]
+      --omit <OMIT>           Omit noisy items [possible values: blanket-impls, auto-trait-impls,
+                              auto-derived-impls]
+  -s, --simplified...         Shorthand for omitting noisy items. Can be used more than once.
+      --include <INCLUDE>     Include extra details [possible values: function-parameter-names]
+  -v, --verbose...            Shorthand for including extra details.
   -F, --features <FEATURES>   Space or comma separated list of features to activate
       --all-features          Activate all available features
       --no-default-features   Do not activate the `default` feature

--- a/cargo-public-api/tests/snapshots/include-function-parameter-names-with-v.txt
+++ b/cargo-public-api/tests/snapshots/include-function-parameter-names-with-v.txt
@@ -3,12 +3,19 @@ pub mod example_api
 pub example_api::Struct::v1_field: usize
 pub example_api::Struct::v2_field: usize
 impl core::fmt::Debug for example_api::Struct
-pub fn example_api::Struct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn example_api::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for example_api::Struct
+impl core::marker::Send for example_api::Struct
+impl core::marker::Sync for example_api::Struct
+impl core::marker::Unpin for example_api::Struct
+impl core::marker::UnsafeUnpin for example_api::Struct
+impl core::panic::unwind_safe::RefUnwindSafe for example_api::Struct
+impl core::panic::unwind_safe::UnwindSafe for example_api::Struct
 impl<T, U> core::convert::Into<U> for example_api::Struct where U: core::convert::From<T>
 pub fn example_api::Struct::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for example_api::Struct where U: core::convert::Into<T>
 pub type example_api::Struct::Error = core::convert::Infallible
-pub fn example_api::Struct::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn example_api::Struct::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for example_api::Struct where U: core::convert::TryFrom<T>
 pub type example_api::Struct::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn example_api::Struct::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
@@ -19,14 +26,21 @@ pub fn example_api::Struct::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for example_api::Struct where T: ?core::marker::Sized
 pub fn example_api::Struct::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for example_api::Struct
-pub fn example_api::Struct::from(T) -> T
+pub fn example_api::Struct::from(t: T) -> T
 pub struct example_api::StructV2
 pub example_api::StructV2::field: usize
+impl core::marker::Freeze for example_api::StructV2
+impl core::marker::Send for example_api::StructV2
+impl core::marker::Sync for example_api::StructV2
+impl core::marker::Unpin for example_api::StructV2
+impl core::marker::UnsafeUnpin for example_api::StructV2
+impl core::panic::unwind_safe::RefUnwindSafe for example_api::StructV2
+impl core::panic::unwind_safe::UnwindSafe for example_api::StructV2
 impl<T, U> core::convert::Into<U> for example_api::StructV2 where U: core::convert::From<T>
 pub fn example_api::StructV2::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for example_api::StructV2 where U: core::convert::Into<T>
 pub type example_api::StructV2::Error = core::convert::Infallible
-pub fn example_api::StructV2::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn example_api::StructV2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for example_api::StructV2 where U: core::convert::TryFrom<T>
 pub type example_api::StructV2::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn example_api::StructV2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
@@ -37,5 +51,4 @@ pub fn example_api::StructV2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for example_api::StructV2 where T: ?core::marker::Sized
 pub fn example_api::StructV2::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for example_api::StructV2
-pub fn example_api::StructV2::from(T) -> T
-pub fn example_api::function(example_api::Struct, usize)
+pub fn example_api::StructV2::from(t: T) -> T

--- a/cargo-public-api/tests/snapshots/include-function-parameter-names.txt
+++ b/cargo-public-api/tests/snapshots/include-function-parameter-names.txt
@@ -3,12 +3,19 @@ pub mod example_api
 pub example_api::Struct::v1_field: usize
 pub example_api::Struct::v2_field: usize
 impl core::fmt::Debug for example_api::Struct
-pub fn example_api::Struct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn example_api::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for example_api::Struct
+impl core::marker::Send for example_api::Struct
+impl core::marker::Sync for example_api::Struct
+impl core::marker::Unpin for example_api::Struct
+impl core::marker::UnsafeUnpin for example_api::Struct
+impl core::panic::unwind_safe::RefUnwindSafe for example_api::Struct
+impl core::panic::unwind_safe::UnwindSafe for example_api::Struct
 impl<T, U> core::convert::Into<U> for example_api::Struct where U: core::convert::From<T>
 pub fn example_api::Struct::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for example_api::Struct where U: core::convert::Into<T>
 pub type example_api::Struct::Error = core::convert::Infallible
-pub fn example_api::Struct::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn example_api::Struct::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for example_api::Struct where U: core::convert::TryFrom<T>
 pub type example_api::Struct::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn example_api::Struct::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
@@ -19,14 +26,21 @@ pub fn example_api::Struct::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for example_api::Struct where T: ?core::marker::Sized
 pub fn example_api::Struct::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for example_api::Struct
-pub fn example_api::Struct::from(T) -> T
+pub fn example_api::Struct::from(t: T) -> T
 pub struct example_api::StructV2
 pub example_api::StructV2::field: usize
+impl core::marker::Freeze for example_api::StructV2
+impl core::marker::Send for example_api::StructV2
+impl core::marker::Sync for example_api::StructV2
+impl core::marker::Unpin for example_api::StructV2
+impl core::marker::UnsafeUnpin for example_api::StructV2
+impl core::panic::unwind_safe::RefUnwindSafe for example_api::StructV2
+impl core::panic::unwind_safe::UnwindSafe for example_api::StructV2
 impl<T, U> core::convert::Into<U> for example_api::StructV2 where U: core::convert::From<T>
 pub fn example_api::StructV2::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for example_api::StructV2 where U: core::convert::Into<T>
 pub type example_api::StructV2::Error = core::convert::Infallible
-pub fn example_api::StructV2::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn example_api::StructV2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for example_api::StructV2 where U: core::convert::TryFrom<T>
 pub type example_api::StructV2::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn example_api::StructV2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
@@ -37,5 +51,4 @@ pub fn example_api::StructV2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for example_api::StructV2 where T: ?core::marker::Sized
 pub fn example_api::StructV2::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for example_api::StructV2
-pub fn example_api::StructV2::from(T) -> T
-pub fn example_api::function(example_api::Struct, usize)
+pub fn example_api::StructV2::from(t: T) -> T

--- a/cargo-public-api/tests/snapshots/list_public_items.txt
+++ b/cargo-public-api/tests/snapshots/list_public_items.txt
@@ -4,14 +4,14 @@ pub struct public_api::diff::ChangedPublicItem
 pub public_api::diff::ChangedPublicItem::new: public_api::PublicItem
 pub public_api::diff::ChangedPublicItem::old: public_api::PublicItem
 impl public_api::diff::ChangedPublicItem
-pub fn public_api::diff::ChangedPublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn public_api::diff::ChangedPublicItem::grouping_cmp(&self, &Self) -> core::cmp::Ordering
 impl core::clone::Clone for public_api::diff::ChangedPublicItem
 pub fn public_api::diff::ChangedPublicItem::clone(&self) -> public_api::diff::ChangedPublicItem
 impl core::cmp::Eq for public_api::diff::ChangedPublicItem
 impl core::cmp::PartialEq for public_api::diff::ChangedPublicItem
-pub fn public_api::diff::ChangedPublicItem::eq(&self, other: &public_api::diff::ChangedPublicItem) -> bool
+pub fn public_api::diff::ChangedPublicItem::eq(&self, &public_api::diff::ChangedPublicItem) -> bool
 impl core::fmt::Debug for public_api::diff::ChangedPublicItem
-pub fn public_api::diff::ChangedPublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::diff::ChangedPublicItem::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for public_api::diff::ChangedPublicItem
 impl core::marker::Freeze for public_api::diff::ChangedPublicItem
 impl core::marker::Send for public_api::diff::ChangedPublicItem
@@ -25,15 +25,15 @@ pub public_api::diff::PublicApiDiff::added: alloc::vec::Vec<public_api::PublicIt
 pub public_api::diff::PublicApiDiff::changed: alloc::vec::Vec<public_api::diff::ChangedPublicItem>
 pub public_api::diff::PublicApiDiff::removed: alloc::vec::Vec<public_api::PublicItem>
 impl public_api::diff::PublicApiDiff
-pub fn public_api::diff::PublicApiDiff::between(old: public_api::PublicApi, new: public_api::PublicApi) -> Self
+pub fn public_api::diff::PublicApiDiff::between(public_api::PublicApi, public_api::PublicApi) -> Self
 pub fn public_api::diff::PublicApiDiff::is_empty(&self) -> bool
 impl core::clone::Clone for public_api::diff::PublicApiDiff
 pub fn public_api::diff::PublicApiDiff::clone(&self) -> public_api::diff::PublicApiDiff
 impl core::cmp::Eq for public_api::diff::PublicApiDiff
 impl core::cmp::PartialEq for public_api::diff::PublicApiDiff
-pub fn public_api::diff::PublicApiDiff::eq(&self, other: &public_api::diff::PublicApiDiff) -> bool
+pub fn public_api::diff::PublicApiDiff::eq(&self, &public_api::diff::PublicApiDiff) -> bool
 impl core::fmt::Debug for public_api::diff::PublicApiDiff
-pub fn public_api::diff::PublicApiDiff::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::diff::PublicApiDiff::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for public_api::diff::PublicApiDiff
 impl core::marker::Freeze for public_api::diff::PublicApiDiff
 impl core::marker::Send for public_api::diff::PublicApiDiff
@@ -64,15 +64,15 @@ impl core::clone::Clone for public_api::tokens::Token
 pub fn public_api::tokens::Token::clone(&self) -> public_api::tokens::Token
 impl core::cmp::Eq for public_api::tokens::Token
 impl core::cmp::Ord for public_api::tokens::Token
-pub fn public_api::tokens::Token::cmp(&self, other: &public_api::tokens::Token) -> core::cmp::Ordering
+pub fn public_api::tokens::Token::cmp(&self, &public_api::tokens::Token) -> core::cmp::Ordering
 impl core::cmp::PartialEq for public_api::tokens::Token
-pub fn public_api::tokens::Token::eq(&self, other: &public_api::tokens::Token) -> bool
+pub fn public_api::tokens::Token::eq(&self, &public_api::tokens::Token) -> bool
 impl core::cmp::PartialOrd for public_api::tokens::Token
-pub fn public_api::tokens::Token::partial_cmp(&self, other: &public_api::tokens::Token) -> core::option::Option<core::cmp::Ordering>
+pub fn public_api::tokens::Token::partial_cmp(&self, &public_api::tokens::Token) -> core::option::Option<core::cmp::Ordering>
 impl core::fmt::Debug for public_api::tokens::Token
-pub fn public_api::tokens::Token::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::tokens::Token::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for public_api::tokens::Token
-pub fn public_api::tokens::Token::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn public_api::tokens::Token::hash<__H: core::hash::Hasher>(&self, &mut __H)
 impl core::marker::StructuralPartialEq for public_api::tokens::Token
 impl core::marker::Freeze for public_api::tokens::Token
 impl core::marker::Send for public_api::tokens::Token
@@ -85,15 +85,15 @@ impl core::panic::unwind_safe::UnwindSafe for public_api::tokens::Token
 pub public_api::Error::IoError(std::io::error::Error)
 pub public_api::Error::SerdeJsonError(serde_json::error::Error)
 impl core::convert::From<serde_json::error::Error> for public_api::Error
-pub fn public_api::Error::from(source: serde_json::error::Error) -> Self
+pub fn public_api::Error::from(serde_json::error::Error) -> Self
 impl core::convert::From<std::io::error::Error> for public_api::Error
-pub fn public_api::Error::from(source: std::io::error::Error) -> Self
+pub fn public_api::Error::from(std::io::error::Error) -> Self
 impl core::error::Error for public_api::Error
 pub fn public_api::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for public_api::Error
-pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::Error::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::Error
-pub fn public_api::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::Error::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Freeze for public_api::Error
 impl core::marker::Send for public_api::Error
 impl core::marker::Sync for public_api::Error
@@ -104,16 +104,17 @@ impl !core::panic::unwind_safe::UnwindSafe for public_api::Error
 pub struct public_api::Builder
 impl public_api::Builder
 pub fn public_api::Builder::build(self) -> public_api::Result<public_api::PublicApi>
-pub fn public_api::Builder::debug_sorting(self, debug_sorting: bool) -> Self
-pub fn public_api::Builder::from_rustdoc_json(path: impl core::convert::Into<std::path::PathBuf>) -> Self
-pub fn public_api::Builder::omit_auto_derived_impls(self, omit_auto_derived_impls: bool) -> Self
-pub fn public_api::Builder::omit_auto_trait_impls(self, omit_auto_trait_impls: bool) -> Self
-pub fn public_api::Builder::omit_blanket_impls(self, omit_blanket_impls: bool) -> Self
-pub fn public_api::Builder::sorted(self, sorted: bool) -> Self
+pub fn public_api::Builder::debug_sorting(self, bool) -> Self
+pub fn public_api::Builder::from_rustdoc_json(impl core::convert::Into<std::path::PathBuf>) -> Self
+pub fn public_api::Builder::include_function_parameter_names(self, bool) -> Self
+pub fn public_api::Builder::omit_auto_derived_impls(self, bool) -> Self
+pub fn public_api::Builder::omit_auto_trait_impls(self, bool) -> Self
+pub fn public_api::Builder::omit_blanket_impls(self, bool) -> Self
+pub fn public_api::Builder::sorted(self, bool) -> Self
 impl core::clone::Clone for public_api::Builder
 pub fn public_api::Builder::clone(&self) -> public_api::Builder
 impl core::fmt::Debug for public_api::Builder
-pub fn public_api::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::Builder::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Freeze for public_api::Builder
 impl core::marker::Send for public_api::Builder
 impl core::marker::Sync for public_api::Builder
@@ -123,14 +124,14 @@ impl core::panic::unwind_safe::RefUnwindSafe for public_api::Builder
 impl core::panic::unwind_safe::UnwindSafe for public_api::Builder
 #[non_exhaustive] pub struct public_api::PublicApi
 impl public_api::PublicApi
-pub fn public_api::PublicApi::assert_eq_or_update(&self, snapshot_path: impl core::convert::AsRef<std::path::Path>)
+pub fn public_api::PublicApi::assert_eq_or_update(&self, impl core::convert::AsRef<std::path::Path>)
 pub fn public_api::PublicApi::into_items(self) -> impl core::iter::traits::iterator::Iterator<Item = public_api::PublicItem>
 pub fn public_api::PublicApi::items(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::PublicItem>
 pub fn public_api::PublicApi::missing_item_ids(&self) -> impl core::iter::traits::iterator::Iterator<Item = &u32>
 impl core::fmt::Debug for public_api::PublicApi
-pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::PublicApi::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::PublicApi
-pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::PublicApi::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Freeze for public_api::PublicApi
 impl core::marker::Send for public_api::PublicApi
 impl core::marker::Sync for public_api::PublicApi
@@ -140,7 +141,7 @@ impl core::panic::unwind_safe::RefUnwindSafe for public_api::PublicApi
 impl core::panic::unwind_safe::UnwindSafe for public_api::PublicApi
 pub struct public_api::PublicItem
 impl public_api::PublicItem
-pub fn public_api::PublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn public_api::PublicItem::grouping_cmp(&self, &Self) -> core::cmp::Ordering
 pub fn public_api::PublicItem::id(&self) -> rustdoc_types::Id
 pub fn public_api::PublicItem::parent_id(&self) -> core::option::Option<rustdoc_types::Id>
 pub fn public_api::PublicItem::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::tokens::Token>
@@ -148,13 +149,13 @@ impl core::clone::Clone for public_api::PublicItem
 pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
 impl core::cmp::Eq for public_api::PublicItem
 impl core::cmp::PartialEq for public_api::PublicItem
-pub fn public_api::PublicItem::eq(&self, other: &Self) -> bool
+pub fn public_api::PublicItem::eq(&self, &Self) -> bool
 impl core::fmt::Debug for public_api::PublicItem
-pub fn public_api::PublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::PublicItem::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::PublicItem
-pub fn public_api::PublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::PublicItem::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for public_api::PublicItem
-pub fn public_api::PublicItem::hash<H: core::hash::Hasher>(&self, state: &mut H)
+pub fn public_api::PublicItem::hash<H: core::hash::Hasher>(&self, &mut H)
 impl core::marker::Freeze for public_api::PublicItem
 impl core::marker::Send for public_api::PublicItem
 impl core::marker::Sync for public_api::PublicItem

--- a/cargo-public-api/tests/snapshots/long-completions-help.txt
+++ b/cargo-public-api/tests/snapshots/long-completions-help.txt
@@ -38,6 +38,13 @@ Options:
           | -ss   | --omit blanket-impls,auto-trait-impls                    |
           | -sss  | --omit blanket-impls,auto-trait-impls,auto-derived-impls |
 
+  -v, --verbose...
+          Include extra details.
+          
+          | Usage | Corresponds to                                           |
+          |-------|----------------------------------------------------------|
+          | -v    | --include function-parameter-names                       |
+
       --omit <OMIT>
           Omit specified items
 
@@ -48,6 +55,14 @@ Options:
             Send for ...`, `impl Sync for ...`, and `impl Unpin for ...`
           - auto-derived-impls: Omit items that belong to Auto Derived Implementations such as
             `Clone`, `Debug`, and `Eq`
+
+      --include <INCLUDE>
+          Include specified details
+
+          Possible values:
+          - function-parameter-names: Include function parameter names in the output. They are
+            omitted by default to avoid spurious API diffs when parameter names change. But they can
+            sometimes be helpful to include in the output
 
   -F, --features <FEATURES>
           Space or comma separated list of features to activate

--- a/cargo-public-api/tests/snapshots/long-diff-help.txt
+++ b/cargo-public-api/tests/snapshots/long-diff-help.txt
@@ -117,6 +117,13 @@ Options:
           | -ss   | --omit blanket-impls,auto-trait-impls                    |
           | -sss  | --omit blanket-impls,auto-trait-impls,auto-derived-impls |
 
+  -v, --verbose...
+          Include extra details.
+          
+          | Usage | Corresponds to                                           |
+          |-------|----------------------------------------------------------|
+          | -v    | --include function-parameter-names                       |
+
       --omit <OMIT>
           Omit specified items
 
@@ -127,6 +134,14 @@ Options:
             Send for ...`, `impl Sync for ...`, and `impl Unpin for ...`
           - auto-derived-impls: Omit items that belong to Auto Derived Implementations such as
             `Clone`, `Debug`, and `Eq`
+
+      --include <INCLUDE>
+          Include specified details
+
+          Possible values:
+          - function-parameter-names: Include function parameter names in the output. They are
+            omitted by default to avoid spurious API diffs when parameter names change. But they can
+            sometimes be helpful to include in the output
 
   -F, --features <FEATURES>
           Space or comma separated list of features to activate

--- a/cargo-public-api/tests/snapshots/long-help.txt
+++ b/cargo-public-api/tests/snapshots/long-help.txt
@@ -24,6 +24,13 @@ Options:
           | -ss   | --omit blanket-impls,auto-trait-impls                    |
           | -sss  | --omit blanket-impls,auto-trait-impls,auto-derived-impls |
 
+  -v, --verbose...
+          Include extra details.
+          
+          | Usage | Corresponds to                                           |
+          |-------|----------------------------------------------------------|
+          | -v    | --include function-parameter-names                       |
+
       --omit <OMIT>
           Omit specified items
 
@@ -34,6 +41,14 @@ Options:
             Send for ...`, `impl Sync for ...`, and `impl Unpin for ...`
           - auto-derived-impls: Omit items that belong to Auto Derived Implementations such as
             `Clone`, `Debug`, and `Eq`
+
+      --include <INCLUDE>
+          Include specified details
+
+          Possible values:
+          - function-parameter-names: Include function parameter names in the output. They are
+            omitted by default to avoid spurious API diffs when parameter names change. But they can
+            sometimes be helpful to include in the output
 
   -F, --features <FEATURES>
           Space or comma separated list of features to activate

--- a/cargo-public-api/tests/snapshots/omit-auto-derived-impls-with-double-s.txt
+++ b/cargo-public-api/tests/snapshots/omit-auto-derived-impls-with-double-s.txt
@@ -3,6 +3,6 @@ pub mod example_api
 pub example_api::Struct::v1_field: usize
 pub example_api::Struct::v2_field: usize
 impl core::fmt::Debug for example_api::Struct
-pub fn example_api::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn example_api::Struct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct example_api::StructV2
 pub example_api::StructV2::field: usize

--- a/cargo-public-api/tests/snapshots/omit-auto-derived-impls.txt
+++ b/cargo-public-api/tests/snapshots/omit-auto-derived-impls.txt
@@ -13,7 +13,7 @@ impl<T, U> core::convert::Into<U> for example_api::Struct where U: core::convert
 pub fn example_api::Struct::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for example_api::Struct where U: core::convert::Into<T>
 pub type example_api::Struct::Error = core::convert::Infallible
-pub fn example_api::Struct::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn example_api::Struct::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for example_api::Struct where U: core::convert::TryFrom<T>
 pub type example_api::Struct::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn example_api::Struct::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
@@ -24,7 +24,7 @@ pub fn example_api::Struct::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for example_api::Struct where T: ?core::marker::Sized
 pub fn example_api::Struct::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for example_api::Struct
-pub fn example_api::Struct::from(t: T) -> T
+pub fn example_api::Struct::from(T) -> T
 pub struct example_api::StructV2
 pub example_api::StructV2::field: usize
 impl core::marker::Freeze for example_api::StructV2
@@ -38,7 +38,7 @@ impl<T, U> core::convert::Into<U> for example_api::StructV2 where U: core::conve
 pub fn example_api::StructV2::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for example_api::StructV2 where U: core::convert::Into<T>
 pub type example_api::StructV2::Error = core::convert::Infallible
-pub fn example_api::StructV2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn example_api::StructV2::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for example_api::StructV2 where U: core::convert::TryFrom<T>
 pub type example_api::StructV2::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn example_api::StructV2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
@@ -49,4 +49,4 @@ pub fn example_api::StructV2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for example_api::StructV2 where T: ?core::marker::Sized
 pub fn example_api::StructV2::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for example_api::StructV2
-pub fn example_api::StructV2::from(t: T) -> T
+pub fn example_api::StructV2::from(T) -> T

--- a/cargo-public-api/tests/snapshots/omit-auto-trait-impls.txt
+++ b/cargo-public-api/tests/snapshots/omit-auto-trait-impls.txt
@@ -3,12 +3,12 @@ pub mod example_api
 pub example_api::Struct::v1_field: usize
 pub example_api::Struct::v2_field: usize
 impl core::fmt::Debug for example_api::Struct
-pub fn example_api::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn example_api::Struct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<T, U> core::convert::Into<U> for example_api::Struct where U: core::convert::From<T>
 pub fn example_api::Struct::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for example_api::Struct where U: core::convert::Into<T>
 pub type example_api::Struct::Error = core::convert::Infallible
-pub fn example_api::Struct::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn example_api::Struct::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for example_api::Struct where U: core::convert::TryFrom<T>
 pub type example_api::Struct::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn example_api::Struct::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
@@ -19,14 +19,14 @@ pub fn example_api::Struct::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for example_api::Struct where T: ?core::marker::Sized
 pub fn example_api::Struct::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for example_api::Struct
-pub fn example_api::Struct::from(t: T) -> T
+pub fn example_api::Struct::from(T) -> T
 pub struct example_api::StructV2
 pub example_api::StructV2::field: usize
 impl<T, U> core::convert::Into<U> for example_api::StructV2 where U: core::convert::From<T>
 pub fn example_api::StructV2::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for example_api::StructV2 where U: core::convert::Into<T>
 pub type example_api::StructV2::Error = core::convert::Infallible
-pub fn example_api::StructV2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn example_api::StructV2::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for example_api::StructV2 where U: core::convert::TryFrom<T>
 pub type example_api::StructV2::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn example_api::StructV2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
@@ -37,4 +37,4 @@ pub fn example_api::StructV2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for example_api::StructV2 where T: ?core::marker::Sized
 pub fn example_api::StructV2::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for example_api::StructV2
-pub fn example_api::StructV2::from(t: T) -> T
+pub fn example_api::StructV2::from(T) -> T

--- a/cargo-public-api/tests/snapshots/omit-blanket-impls.txt
+++ b/cargo-public-api/tests/snapshots/omit-blanket-impls.txt
@@ -3,7 +3,7 @@ pub mod example_api
 pub example_api::Struct::v1_field: usize
 pub example_api::Struct::v2_field: usize
 impl core::fmt::Debug for example_api::Struct
-pub fn example_api::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn example_api::Struct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Freeze for example_api::Struct
 impl core::marker::Send for example_api::Struct
 impl core::marker::Sync for example_api::Struct

--- a/cargo-public-api/tests/snapshots/short-completions-help.txt
+++ b/cargo-public-api/tests/snapshots/short-completions-help.txt
@@ -9,8 +9,10 @@ Options:
       --manifest-path <PATH>  Path to `Cargo.toml` [default: Cargo.toml]
   -p, --package <PACKAGE>     Name of package in workspace to list or diff the public API for
   -s, --simplified...         Omit noisy items. Can be used more than once.
+  -v, --verbose...            Include extra details.
       --omit <OMIT>           Omit specified items [possible values: blanket-impls,
                               auto-trait-impls, auto-derived-impls]
+      --include <INCLUDE>     Include specified details [possible values: function-parameter-names]
   -F, --features <FEATURES>   Space or comma separated list of features to activate
       --all-features          Activate all available features
       --no-default-features   Do not activate the `default` feature

--- a/cargo-public-api/tests/snapshots/short-diff-help.txt
+++ b/cargo-public-api/tests/snapshots/short-diff-help.txt
@@ -14,8 +14,10 @@ Options:
                               commits
   -p, --package <PACKAGE>     Name of package in workspace to list or diff the public API for
   -s, --simplified...         Omit noisy items. Can be used more than once.
+  -v, --verbose...            Include extra details.
       --omit <OMIT>           Omit specified items [possible values: blanket-impls,
                               auto-trait-impls, auto-derived-impls]
+      --include <INCLUDE>     Include specified details [possible values: function-parameter-names]
   -F, --features <FEATURES>   Space or comma separated list of features to activate
       --all-features          Activate all available features
       --no-default-features   Do not activate the `default` feature

--- a/cargo-public-api/tests/snapshots/short-help.txt
+++ b/cargo-public-api/tests/snapshots/short-help.txt
@@ -9,8 +9,10 @@ Options:
       --manifest-path <PATH>  Path to `Cargo.toml` [default: Cargo.toml]
   -p, --package <PACKAGE>     Name of package in workspace to list or diff the public API for
   -s, --simplified...         Omit noisy items. Can be used more than once.
+  -v, --verbose...            Include extra details.
       --omit <OMIT>           Omit specified items [possible values: blanket-impls,
                               auto-trait-impls, auto-derived-impls]
+      --include <INCLUDE>     Include specified details [possible values: function-parameter-names]
   -F, --features <FEATURES>   Space or comma separated list of features to activate
       --all-features          Activate all available features
       --no-default-features   Do not activate the `default` feature

--- a/cargo-public-api/tests/snapshots/subcommand_invocation_public_api_arg.txt
+++ b/cargo-public-api/tests/snapshots/subcommand_invocation_public_api_arg.txt
@@ -4,29 +4,29 @@ pub struct public_api::diff::ChangedPublicItem
 pub public_api::diff::ChangedPublicItem::new: public_api::PublicItem
 pub public_api::diff::ChangedPublicItem::old: public_api::PublicItem
 impl public_api::diff::ChangedPublicItem
-pub fn public_api::diff::ChangedPublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn public_api::diff::ChangedPublicItem::grouping_cmp(&self, &Self) -> core::cmp::Ordering
 impl core::clone::Clone for public_api::diff::ChangedPublicItem
 pub fn public_api::diff::ChangedPublicItem::clone(&self) -> public_api::diff::ChangedPublicItem
 impl core::cmp::Eq for public_api::diff::ChangedPublicItem
 impl core::cmp::PartialEq for public_api::diff::ChangedPublicItem
-pub fn public_api::diff::ChangedPublicItem::eq(&self, other: &public_api::diff::ChangedPublicItem) -> bool
+pub fn public_api::diff::ChangedPublicItem::eq(&self, &public_api::diff::ChangedPublicItem) -> bool
 impl core::fmt::Debug for public_api::diff::ChangedPublicItem
-pub fn public_api::diff::ChangedPublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::diff::ChangedPublicItem::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for public_api::diff::ChangedPublicItem
 pub struct public_api::diff::PublicApiDiff
 pub public_api::diff::PublicApiDiff::added: alloc::vec::Vec<public_api::PublicItem>
 pub public_api::diff::PublicApiDiff::changed: alloc::vec::Vec<public_api::diff::ChangedPublicItem>
 pub public_api::diff::PublicApiDiff::removed: alloc::vec::Vec<public_api::PublicItem>
 impl public_api::diff::PublicApiDiff
-pub fn public_api::diff::PublicApiDiff::between(old: public_api::PublicApi, new: public_api::PublicApi) -> Self
+pub fn public_api::diff::PublicApiDiff::between(public_api::PublicApi, public_api::PublicApi) -> Self
 pub fn public_api::diff::PublicApiDiff::is_empty(&self) -> bool
 impl core::clone::Clone for public_api::diff::PublicApiDiff
 pub fn public_api::diff::PublicApiDiff::clone(&self) -> public_api::diff::PublicApiDiff
 impl core::cmp::Eq for public_api::diff::PublicApiDiff
 impl core::cmp::PartialEq for public_api::diff::PublicApiDiff
-pub fn public_api::diff::PublicApiDiff::eq(&self, other: &public_api::diff::PublicApiDiff) -> bool
+pub fn public_api::diff::PublicApiDiff::eq(&self, &public_api::diff::PublicApiDiff) -> bool
 impl core::fmt::Debug for public_api::diff::PublicApiDiff
-pub fn public_api::diff::PublicApiDiff::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::diff::PublicApiDiff::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for public_api::diff::PublicApiDiff
 pub mod public_api::tokens
 pub enum public_api::tokens::Token
@@ -50,55 +50,56 @@ impl core::clone::Clone for public_api::tokens::Token
 pub fn public_api::tokens::Token::clone(&self) -> public_api::tokens::Token
 impl core::cmp::Eq for public_api::tokens::Token
 impl core::cmp::Ord for public_api::tokens::Token
-pub fn public_api::tokens::Token::cmp(&self, other: &public_api::tokens::Token) -> core::cmp::Ordering
+pub fn public_api::tokens::Token::cmp(&self, &public_api::tokens::Token) -> core::cmp::Ordering
 impl core::cmp::PartialEq for public_api::tokens::Token
-pub fn public_api::tokens::Token::eq(&self, other: &public_api::tokens::Token) -> bool
+pub fn public_api::tokens::Token::eq(&self, &public_api::tokens::Token) -> bool
 impl core::cmp::PartialOrd for public_api::tokens::Token
-pub fn public_api::tokens::Token::partial_cmp(&self, other: &public_api::tokens::Token) -> core::option::Option<core::cmp::Ordering>
+pub fn public_api::tokens::Token::partial_cmp(&self, &public_api::tokens::Token) -> core::option::Option<core::cmp::Ordering>
 impl core::fmt::Debug for public_api::tokens::Token
-pub fn public_api::tokens::Token::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::tokens::Token::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for public_api::tokens::Token
-pub fn public_api::tokens::Token::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn public_api::tokens::Token::hash<__H: core::hash::Hasher>(&self, &mut __H)
 impl core::marker::StructuralPartialEq for public_api::tokens::Token
 #[non_exhaustive] pub enum public_api::Error
 pub public_api::Error::IoError(std::io::error::Error)
 pub public_api::Error::SerdeJsonError(serde_json::error::Error)
 impl core::convert::From<serde_json::error::Error> for public_api::Error
-pub fn public_api::Error::from(source: serde_json::error::Error) -> Self
+pub fn public_api::Error::from(serde_json::error::Error) -> Self
 impl core::convert::From<std::io::error::Error> for public_api::Error
-pub fn public_api::Error::from(source: std::io::error::Error) -> Self
+pub fn public_api::Error::from(std::io::error::Error) -> Self
 impl core::error::Error for public_api::Error
 pub fn public_api::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for public_api::Error
-pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::Error::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::Error
-pub fn public_api::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::Error::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct public_api::Builder
 impl public_api::Builder
 pub fn public_api::Builder::build(self) -> public_api::Result<public_api::PublicApi>
-pub fn public_api::Builder::debug_sorting(self, debug_sorting: bool) -> Self
-pub fn public_api::Builder::from_rustdoc_json(path: impl core::convert::Into<std::path::PathBuf>) -> Self
-pub fn public_api::Builder::omit_auto_derived_impls(self, omit_auto_derived_impls: bool) -> Self
-pub fn public_api::Builder::omit_auto_trait_impls(self, omit_auto_trait_impls: bool) -> Self
-pub fn public_api::Builder::omit_blanket_impls(self, omit_blanket_impls: bool) -> Self
-pub fn public_api::Builder::sorted(self, sorted: bool) -> Self
+pub fn public_api::Builder::debug_sorting(self, bool) -> Self
+pub fn public_api::Builder::from_rustdoc_json(impl core::convert::Into<std::path::PathBuf>) -> Self
+pub fn public_api::Builder::include_function_parameter_names(self, bool) -> Self
+pub fn public_api::Builder::omit_auto_derived_impls(self, bool) -> Self
+pub fn public_api::Builder::omit_auto_trait_impls(self, bool) -> Self
+pub fn public_api::Builder::omit_blanket_impls(self, bool) -> Self
+pub fn public_api::Builder::sorted(self, bool) -> Self
 impl core::clone::Clone for public_api::Builder
 pub fn public_api::Builder::clone(&self) -> public_api::Builder
 impl core::fmt::Debug for public_api::Builder
-pub fn public_api::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::Builder::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 #[non_exhaustive] pub struct public_api::PublicApi
 impl public_api::PublicApi
-pub fn public_api::PublicApi::assert_eq_or_update(&self, snapshot_path: impl core::convert::AsRef<std::path::Path>)
+pub fn public_api::PublicApi::assert_eq_or_update(&self, impl core::convert::AsRef<std::path::Path>)
 pub fn public_api::PublicApi::into_items(self) -> impl core::iter::traits::iterator::Iterator<Item = public_api::PublicItem>
 pub fn public_api::PublicApi::items(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::PublicItem>
 pub fn public_api::PublicApi::missing_item_ids(&self) -> impl core::iter::traits::iterator::Iterator<Item = &u32>
 impl core::fmt::Debug for public_api::PublicApi
-pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::PublicApi::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::PublicApi
-pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::PublicApi::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct public_api::PublicItem
 impl public_api::PublicItem
-pub fn public_api::PublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn public_api::PublicItem::grouping_cmp(&self, &Self) -> core::cmp::Ordering
 pub fn public_api::PublicItem::id(&self) -> rustdoc_types::Id
 pub fn public_api::PublicItem::parent_id(&self) -> core::option::Option<rustdoc_types::Id>
 pub fn public_api::PublicItem::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::tokens::Token>
@@ -106,12 +107,12 @@ impl core::clone::Clone for public_api::PublicItem
 pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
 impl core::cmp::Eq for public_api::PublicItem
 impl core::cmp::PartialEq for public_api::PublicItem
-pub fn public_api::PublicItem::eq(&self, other: &Self) -> bool
+pub fn public_api::PublicItem::eq(&self, &Self) -> bool
 impl core::fmt::Debug for public_api::PublicItem
-pub fn public_api::PublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::PublicItem::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::PublicItem
-pub fn public_api::PublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::PublicItem::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for public_api::PublicItem
-pub fn public_api::PublicItem::hash<H: core::hash::Hasher>(&self, state: &mut H)
+pub fn public_api::PublicItem::hash<H: core::hash::Hasher>(&self, &mut H)
 pub const public_api::MINIMUM_NIGHTLY_RUST_VERSION: &str
 pub type public_api::Result<T> = core::result::Result<T, public_api::Error>

--- a/cargo-public-api/tests/snapshots/test_repo_api_latest.txt
+++ b/cargo-public-api/tests/snapshots/test_repo_api_latest.txt
@@ -3,6 +3,6 @@ pub mod example_api
 pub example_api::Struct::v1_field: usize
 pub example_api::Struct::v2_field: usize
 impl core::fmt::Debug for example_api::Struct
-pub fn example_api::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn example_api::Struct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct example_api::StructV2
 pub example_api::StructV2::field: usize

--- a/cargo-public-api/tests/snapshots/test_repo_api_latest_not_simplified.txt
+++ b/cargo-public-api/tests/snapshots/test_repo_api_latest_not_simplified.txt
@@ -3,7 +3,7 @@ pub mod example_api
 pub example_api::Struct::v1_field: usize
 pub example_api::Struct::v2_field: usize
 impl core::fmt::Debug for example_api::Struct
-pub fn example_api::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn example_api::Struct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Freeze for example_api::Struct
 impl core::marker::Send for example_api::Struct
 impl core::marker::Sync for example_api::Struct
@@ -15,7 +15,7 @@ impl<T, U> core::convert::Into<U> for example_api::Struct where U: core::convert
 pub fn example_api::Struct::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for example_api::Struct where U: core::convert::Into<T>
 pub type example_api::Struct::Error = core::convert::Infallible
-pub fn example_api::Struct::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn example_api::Struct::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for example_api::Struct where U: core::convert::TryFrom<T>
 pub type example_api::Struct::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn example_api::Struct::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
@@ -26,7 +26,7 @@ pub fn example_api::Struct::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for example_api::Struct where T: ?core::marker::Sized
 pub fn example_api::Struct::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for example_api::Struct
-pub fn example_api::Struct::from(t: T) -> T
+pub fn example_api::Struct::from(T) -> T
 pub struct example_api::StructV2
 pub example_api::StructV2::field: usize
 impl core::marker::Freeze for example_api::StructV2
@@ -40,7 +40,7 @@ impl<T, U> core::convert::Into<U> for example_api::StructV2 where U: core::conve
 pub fn example_api::StructV2::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for example_api::StructV2 where U: core::convert::Into<T>
 pub type example_api::StructV2::Error = core::convert::Infallible
-pub fn example_api::StructV2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn example_api::StructV2::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for example_api::StructV2 where U: core::convert::TryFrom<T>
 pub type example_api::StructV2::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn example_api::StructV2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
@@ -51,4 +51,4 @@ pub fn example_api::StructV2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for example_api::StructV2 where T: ?core::marker::Sized
 pub fn example_api::StructV2::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for example_api::StructV2
-pub fn example_api::StructV2::from(t: T) -> T
+pub fn example_api::StructV2::from(T) -> T

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -35,7 +35,11 @@ UPDATE_SNAPSHOTS=yes ./scripts/cargo-test.sh
 
 ## Expected Output
 
-Output aims to be character-by-character identical to the textual parts of the regular `cargo doc` HTML output. For example, [this item](https://docs.rs/bat/0.20.0/bat/struct.PrettyPrinter.html#method.input_files) has the following textual representation in the rendered HTML:
+Output aims to mostly be character-by-character identical to the textual parts of the regular `cargo doc` HTML output, with the following exceptions:
+
+* **Names of function parameters are not included by default**. Renaming a parameter rarely constitutes a breaking change, and it avoid issues like [Ignore `_`-prefixes of parameter names of trait `impl`s `fn`s](https://github.com/cargo-public-api/cargo-public-api/issues/766).
+
+For example, [this item](https://docs.rs/bat/0.20.0/bat/struct.PrettyPrinter.html#method.input_files) has the following textual representation in the rendered HTML:
 
 ```
 pub fn input_files<I, P>(&mut self, paths: I) -> &mut Self
@@ -47,14 +51,14 @@ where
 and `cargo public-api` renders this item in the following way:
 
 ```
-pub fn bat::PrettyPrinter::input_files<I, P>(&mut self, paths: I) -> &mut Self where I: IntoIterator<Item = P>, P: AsRef<Path>
+pub fn bat::PrettyPrinter::input_files<I, P>(&mut self, I) -> &mut Self where I: IntoIterator<Item = P>, P: AsRef<Path>
 ```
 
-If we remove newline characters and add some whitespace padding to get the alignment right for side-by-side comparison, we can see that they are exactly the same, except an irrelevant trailing comma:
+If we remove newline characters and add some whitespace padding to get the alignment right for side-by-side comparison, we can see that they are exactly the same, except omissions of function parameter names and an irrelevant trailing comma:
 
 ```
 pub fn                     input_files<I, P>(&mut self, paths: I) -> &mut Self where I: IntoIterator<Item = P>, P: AsRef<Path>,
-pub fn bat::PrettyPrinter::input_files<I, P>(&mut self, paths: I) -> &mut Self where I: IntoIterator<Item = P>, P: AsRef<Path>
+pub fn bat::PrettyPrinter::input_files<I, P>(&mut self,        I) -> &mut Self where I: IntoIterator<Item = P>, P: AsRef<Path>
 ```
 
 # Constraints

--- a/public-api/CHANGELOG.md
+++ b/public-api/CHANGELOG.md
@@ -1,6 +1,9 @@
 # `public-api` changelog
 
-## v0.51.1
+## v0.52.0
+* Stop including function parameter names by default in the output. This avoids issues where renaming parameters shows up as API diffs.  This is especially relevant for trait impls, where fn parameter names are often `_`-prefixed.
+
+  To opt-in to the old behavior of including parameter names, use the new `public_api::Builder::include_function_parameter_names(true)` method.
 * Make renamed lib targets with `crate-type = ["rlib"]` work
 
 ## v0.51.0

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [dev-dependencies.rustdoc-json]
 path = "../rustdoc-json"
-version = "0.9.9"
+version = "0.9.10"
 
 [dev-dependencies.predicates]
 version = "3.1.4"

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "public-api"
-version = "0.51.0"
+version = "0.52.0"
 description = "List and diff the public API of Rust library crates. Relies on rustdoc JSON output from the nightly toolchain."
 homepage = "https://github.com/cargo-public-api/cargo-public-api/tree/main/public-api"
 documentation = "https://docs.rs/public-api"

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -73,6 +73,7 @@ struct BuilderOptions {
     omit_blanket_impls: bool,
     omit_auto_trait_impls: bool,
     omit_auto_derived_impls: bool,
+    include_function_parameter_names: bool,
 }
 
 /// Builds [`PublicApi`]s. See the [top level][`crate`] module docs for example
@@ -94,6 +95,7 @@ impl Builder {
             omit_blanket_impls: false,
             omit_auto_trait_impls: false,
             omit_auto_derived_impls: false,
+            include_function_parameter_names: false,
         };
         Self {
             rustdoc_json: path.into(),
@@ -164,6 +166,18 @@ impl Builder {
     #[must_use]
     pub fn omit_auto_derived_impls(mut self, omit_auto_derived_impls: bool) -> Self {
         self.options.omit_auto_derived_impls = omit_auto_derived_impls;
+        self
+    }
+
+    /// If `true`, function parameter names are included in the API output. They
+    /// are omitted by default to avoid spurious diffs when parameter names
+    /// change, but they can sometimes be helpful to include in the output.
+    #[must_use]
+    pub fn include_function_parameter_names(
+        mut self,
+        include_function_parameter_names: bool,
+    ) -> Self {
+        self.options.include_function_parameter_names = include_function_parameter_names;
         self
     }
 

--- a/public-api/src/render.rs
+++ b/public-api/src/render.rs
@@ -511,8 +511,9 @@ impl<'c> RenderingContext<'c> {
             |(name, ty)| {
                 self.simplified_self(name, ty).unwrap_or_else(|| {
                     let mut output = vec![];
+
                     let ignore_name = name.is_empty() || (name == "_" && !include_underscores);
-                    if !ignore_name {
+                    if self.options.include_function_parameter_names && !ignore_name {
                         output.extend(vec![Token::identifier(name), Token::symbol(":"), ws!()]);
                     }
                     output.extend(self.render_type(ty));

--- a/public-api/tests/snapshots/comprehensive_api.txt
+++ b/public-api/tests/snapshots/comprehensive_api.txt
@@ -62,13 +62,13 @@ pub struct comprehensive_api::exports::issue_145::external_3::External
 pub mod comprehensive_api::exports::issue_145::publicly_renamed
 pub struct comprehensive_api::exports::issue_145::publicly_renamed::External
 pub struct comprehensive_api::exports::issue_145::PubliclyRenamedFromPrivateMod
-pub fn comprehensive_api::exports::issue_145::external_arg_type(_transform: comprehensive_api::exports::issue_145::external::External)
-pub fn comprehensive_api::exports::issue_145::external_external_arg_type(_transform: comprehensive_api::exports::issue_145::external::External)
-pub fn comprehensive_api::exports::issue_145::privately_renamed_2_arg_type(_transform: comprehensive_api::exports::issue_145::external_2::External)
-pub fn comprehensive_api::exports::issue_145::privately_renamed_arg_type(_transform: comprehensive_api::exports::issue_145::external::External)
-pub fn comprehensive_api::exports::issue_145::privately_renamed_external_arg_type(_transform: comprehensive_api::exports::issue_145::external::External)
-pub fn comprehensive_api::exports::issue_145::publicly_renamed_external(_transform: comprehensive_api::exports::issue_145::external_2::External)
-pub fn comprehensive_api::exports::issue_145::publicly_renamed_from_private_mod_arg_type(_transform: comprehensive_api::exports::issue_145::external_3::External)
+pub fn comprehensive_api::exports::issue_145::external_arg_type(comprehensive_api::exports::issue_145::external::External)
+pub fn comprehensive_api::exports::issue_145::external_external_arg_type(comprehensive_api::exports::issue_145::external::External)
+pub fn comprehensive_api::exports::issue_145::privately_renamed_2_arg_type(comprehensive_api::exports::issue_145::external_2::External)
+pub fn comprehensive_api::exports::issue_145::privately_renamed_arg_type(comprehensive_api::exports::issue_145::external::External)
+pub fn comprehensive_api::exports::issue_145::privately_renamed_external_arg_type(comprehensive_api::exports::issue_145::external::External)
+pub fn comprehensive_api::exports::issue_145::publicly_renamed_external(comprehensive_api::exports::issue_145::external_2::External)
+pub fn comprehensive_api::exports::issue_145::publicly_renamed_from_private_mod_arg_type(comprehensive_api::exports::issue_145::external_3::External)
 pub mod comprehensive_api::exports::issue_410
 pub mod comprehensive_api::exports::issue_410::container
 pub mod comprehensive_api::exports::issue_410::container::super_glob
@@ -93,41 +93,41 @@ pub fn comprehensive_api::exports::v1::foo2()
 pub mod comprehensive_api::functions
 pub async fn comprehensive_api::functions::async_fn()
 pub async fn comprehensive_api::functions::async_fn_ret_bool() -> bool
-pub fn comprehensive_api::functions::box_dyn_arg_two_traits(d: alloc::boxed::Box<(dyn std::io::Write + core::marker::Send)>)
+pub fn comprehensive_api::functions::box_dyn_arg_two_traits(alloc::boxed::Box<(dyn std::io::Write + core::marker::Send)>)
 pub const fn comprehensive_api::functions::const_fn()
-pub fn comprehensive_api::functions::dyn_arg_one_trait(d: &dyn std::io::Write)
-pub fn comprehensive_api::functions::dyn_arg_one_trait_one_lifetime(d: &(dyn std::io::Write + 'static))
-pub fn comprehensive_api::functions::dyn_arg_two_traits(d: &(dyn std::io::Write + core::marker::Send))
-pub fn comprehensive_api::functions::dyn_arg_two_traits_one_lifetime(d: &(dyn std::io::Write + core::marker::Send + 'static))
-pub fn comprehensive_api::functions::fn_arg(f: impl core::ops::function::Fn(bool, comprehensive_api::structs::Plain) -> bool, f_mut: impl core::ops::function::FnMut())
-pub fn comprehensive_api::functions::generic_arg<T>(t: T) -> T
-pub fn comprehensive_api::functions::generic_bound<T: core::marker::Sized>(t: T) -> T
-pub fn comprehensive_api::functions::impl_multiple<T>(t: impl comprehensive_api::traits::Simple + core::convert::AsRef<T>) -> impl comprehensive_api::traits::Simple
-pub fn comprehensive_api::functions::inferred_lifetime(foo: &usize) -> usize
-pub fn comprehensive_api::functions::multiple_bounds<T>(t: T) where T: core::fmt::Debug + core::fmt::Display
-pub fn comprehensive_api::functions::multiple_bounds_inline<T: core::fmt::Debug + core::fmt::Display>(t: T)
-pub fn comprehensive_api::functions::one_arg(x: usize)
-pub fn comprehensive_api::functions::outlives<'a, 'b: 'a, 'c: 'b + 'a>(x: &'a bool, y: &'b i128, z: &'c comprehensive_api::structs::TupleStructSingle) -> usize
+pub fn comprehensive_api::functions::dyn_arg_one_trait(&dyn std::io::Write)
+pub fn comprehensive_api::functions::dyn_arg_one_trait_one_lifetime(&(dyn std::io::Write + 'static))
+pub fn comprehensive_api::functions::dyn_arg_two_traits(&(dyn std::io::Write + core::marker::Send))
+pub fn comprehensive_api::functions::dyn_arg_two_traits_one_lifetime(&(dyn std::io::Write + core::marker::Send + 'static))
+pub fn comprehensive_api::functions::fn_arg(impl core::ops::function::Fn(bool, comprehensive_api::structs::Plain) -> bool, impl core::ops::function::FnMut())
+pub fn comprehensive_api::functions::generic_arg<T>(T) -> T
+pub fn comprehensive_api::functions::generic_bound<T: core::marker::Sized>(T) -> T
+pub fn comprehensive_api::functions::impl_multiple<T>(impl comprehensive_api::traits::Simple + core::convert::AsRef<T>) -> impl comprehensive_api::traits::Simple
+pub fn comprehensive_api::functions::inferred_lifetime(&usize) -> usize
+pub fn comprehensive_api::functions::multiple_bounds<T>(T) where T: core::fmt::Debug + core::fmt::Display
+pub fn comprehensive_api::functions::multiple_bounds_inline<T: core::fmt::Debug + core::fmt::Display>(T)
+pub fn comprehensive_api::functions::one_arg(usize)
+pub fn comprehensive_api::functions::outlives<'a, 'b: 'a, 'c: 'b + 'a>(&'a bool, &'b i128, &'c comprehensive_api::structs::TupleStructSingle) -> usize
 pub fn comprehensive_api::functions::plain()
 pub fn comprehensive_api::functions::return_array() -> [u8; 2]
 pub fn comprehensive_api::functions::return_iterator() -> impl core::iter::traits::iterator::Iterator<Item = u32>
-pub fn comprehensive_api::functions::return_mut_raw_pointer(input: &mut usize) -> *mut usize
-pub fn comprehensive_api::functions::return_raw_pointer(input: &usize) -> *const usize
-pub fn comprehensive_api::functions::return_slice<'a>(input: &'a [usize]) -> &'a [usize]
+pub fn comprehensive_api::functions::return_mut_raw_pointer(&mut usize) -> *mut usize
+pub fn comprehensive_api::functions::return_raw_pointer(&usize) -> *const usize
+pub fn comprehensive_api::functions::return_slice<'a>(&'a [usize]) -> &'a [usize]
 pub fn comprehensive_api::functions::return_tuple() -> (bool, comprehensive_api::unions::Basic)
-pub fn comprehensive_api::functions::somewhere<T, U>(t: T, u: U) where T: core::fmt::Display, U: core::fmt::Debug
-pub fn comprehensive_api::functions::struct_arg(s: comprehensive_api::structs::PrivateField)
-pub fn comprehensive_api::functions::synthetic_arg(t: impl comprehensive_api::traits::Simple) -> impl comprehensive_api::traits::Simple
-pub fn comprehensive_api::functions::synthetic_use_capture<'a, 'b, T>(x: &'a (), y: T) -> impl core::marker::Sized + use<'a, T>
-pub fn comprehensive_api::functions::synthetic_use_no_capture<'a>(x: &'a usize) -> impl core::marker::Sized + use<>
+pub fn comprehensive_api::functions::somewhere<T, U>(T, U) where T: core::fmt::Display, U: core::fmt::Debug
+pub fn comprehensive_api::functions::struct_arg(comprehensive_api::structs::PrivateField)
+pub fn comprehensive_api::functions::synthetic_arg(impl comprehensive_api::traits::Simple) -> impl comprehensive_api::traits::Simple
+pub fn comprehensive_api::functions::synthetic_use_capture<'a, 'b, T>(&'a (), T) -> impl core::marker::Sized + use<'a, T>
+pub fn comprehensive_api::functions::synthetic_use_no_capture<'a>(&'a usize) -> impl core::marker::Sized + use<>
 pub unsafe fn comprehensive_api::functions::unsafe_fn()
-pub fn comprehensive_api::functions::unused_argument(_: u32)
+pub fn comprehensive_api::functions::unused_argument(u32)
 pub mod comprehensive_api::higher_ranked_trait_bounds
 pub struct comprehensive_api::higher_ranked_trait_bounds::Bar<'a>
 pub comprehensive_api::higher_ranked_trait_bounds::Bar::bar: &'a (dyn for<'b> comprehensive_api::higher_ranked_trait_bounds::Trait<'b> + core::marker::Unpin)
 pub comprehensive_api::higher_ranked_trait_bounds::Bar::baz: &'a (dyn core::marker::Unpin + for<'b> comprehensive_api::higher_ranked_trait_bounds::Trait<'b>)
 pub struct comprehensive_api::higher_ranked_trait_bounds::Foo<'a>
-pub comprehensive_api::higher_ranked_trait_bounds::Foo::some_func: for<'c> fn(val: &'c i32) -> i32
+pub comprehensive_api::higher_ranked_trait_bounds::Foo::some_func: for<'c> fn(&'c i32) -> i32
 pub comprehensive_api::higher_ranked_trait_bounds::Foo::some_trait: &'a dyn for<'b> comprehensive_api::higher_ranked_trait_bounds::Trait<'b>
 impl<'a> comprehensive_api::higher_ranked_trait_bounds::Foo<'a>
 pub fn comprehensive_api::higher_ranked_trait_bounds::Foo<'a>::bar<T>() where T: comprehensive_api::higher_ranked_trait_bounds::Trait<'a>
@@ -212,15 +212,15 @@ pub struct comprehensive_api::structs::WithLifetimeAndGenericParam<'a, T>
 pub comprehensive_api::structs::WithLifetimeAndGenericParam::t: T
 pub comprehensive_api::structs::WithLifetimeAndGenericParam::unit_ref: &'a comprehensive_api::structs::Unit
 impl<'b, 'z> comprehensive_api::structs::WithLifetimeAndGenericParam<'b, alloc::string::String> where 'b: 'z + 'static
-pub fn comprehensive_api::structs::WithLifetimeAndGenericParam<'b, alloc::string::String>::with_two_lifetime_bounds(unit_ref: &'z comprehensive_api::structs::Unit, t: alloc::string::String)
+pub fn comprehensive_api::structs::WithLifetimeAndGenericParam<'b, alloc::string::String>::with_two_lifetime_bounds(&'z comprehensive_api::structs::Unit, alloc::string::String)
 impl<'b, T> comprehensive_api::structs::WithLifetimeAndGenericParam<'b, T>
-pub fn comprehensive_api::structs::WithLifetimeAndGenericParam<'b, T>::new_any(unit_ref: &'b comprehensive_api::structs::Unit, t: T) -> Self
+pub fn comprehensive_api::structs::WithLifetimeAndGenericParam<'b, T>::new_any(&'b comprehensive_api::structs::Unit, T) -> Self
 impl<'b, T> comprehensive_api::structs::WithLifetimeAndGenericParam<'b, T>
-pub fn comprehensive_api::structs::WithLifetimeAndGenericParam<'b, T>::new_any_duplicate(unit_ref: &'b comprehensive_api::structs::Unit, t: T) -> Self
+pub fn comprehensive_api::structs::WithLifetimeAndGenericParam<'b, T>::new_any_duplicate(&'b comprehensive_api::structs::Unit, T) -> Self
 impl<'b> comprehensive_api::structs::WithLifetimeAndGenericParam<'b, alloc::string::String> where 'b: 'static
-pub fn comprehensive_api::structs::WithLifetimeAndGenericParam<'b, alloc::string::String>::new_with_lifetime_bound(unit_ref: &'b comprehensive_api::structs::Unit, t: alloc::string::String) -> Self
+pub fn comprehensive_api::structs::WithLifetimeAndGenericParam<'b, alloc::string::String>::new_with_lifetime_bound(&'b comprehensive_api::structs::Unit, alloc::string::String) -> Self
 impl<'b> comprehensive_api::structs::WithLifetimeAndGenericParam<'b, alloc::string::String>
-pub fn comprehensive_api::structs::WithLifetimeAndGenericParam<'b, alloc::string::String>::new(unit_ref: &'b comprehensive_api::structs::Unit, t: alloc::string::String) -> Self
+pub fn comprehensive_api::structs::WithLifetimeAndGenericParam<'b, alloc::string::String>::new(&'b comprehensive_api::structs::Unit, alloc::string::String) -> Self
 pub struct comprehensive_api::structs::WithTraitBounds<T: core::fmt::Display + core::fmt::Debug>
 pub mod comprehensive_api::traits
 pub trait comprehensive_api::traits::AssociatedConst

--- a/public-api/tests/snapshots/diff_with_added_items.txt
+++ b/public-api/tests/snapshots/diff_with_added_items.txt
@@ -6,8 +6,8 @@ PublicApiDiff {
             new: #[non_exhaustive] pub struct example_api::Struct,
         },
         ChangedPublicItem {
-            old: pub fn example_api::function(v1_param: example_api::Struct),
-            new: pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize),
+            old: pub fn example_api::function(example_api::Struct),
+            new: pub fn example_api::function(example_api::Struct, usize),
         },
     ],
     added: [
@@ -25,7 +25,7 @@ PublicApiDiff {
         pub fn example_api::StructV2::into(self) -> U,
         impl<T, U> core::convert::TryFrom<U> for example_api::StructV2 where U: core::convert::Into<T>,
         pub type example_api::StructV2::Error = core::convert::Infallible,
-        pub fn example_api::StructV2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>,
+        pub fn example_api::StructV2::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>,
         impl<T, U> core::convert::TryInto<U> for example_api::StructV2 where U: core::convert::TryFrom<T>,
         pub type example_api::StructV2::Error = <U as core::convert::TryFrom<T>>::Error,
         pub fn example_api::StructV2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>,
@@ -36,6 +36,6 @@ PublicApiDiff {
         impl<T> core::borrow::BorrowMut<T> for example_api::StructV2 where T: ?core::marker::Sized,
         pub fn example_api::StructV2::borrow_mut(&mut self) -> &mut T,
         impl<T> core::convert::From<T> for example_api::StructV2,
-        pub fn example_api::StructV2::from(t: T) -> T,
+        pub fn example_api::StructV2::from(T) -> T,
     ],
 }

--- a/public-api/tests/snapshots/diff_with_removed_items.txt
+++ b/public-api/tests/snapshots/diff_with_removed_items.txt
@@ -14,7 +14,7 @@ PublicApiDiff {
         pub fn example_api::StructV2::into(self) -> U,
         impl<T, U> core::convert::TryFrom<U> for example_api::StructV2 where U: core::convert::Into<T>,
         pub type example_api::StructV2::Error = core::convert::Infallible,
-        pub fn example_api::StructV2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>,
+        pub fn example_api::StructV2::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>,
         impl<T, U> core::convert::TryInto<U> for example_api::StructV2 where U: core::convert::TryFrom<T>,
         pub type example_api::StructV2::Error = <U as core::convert::TryFrom<T>>::Error,
         pub fn example_api::StructV2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>,
@@ -25,7 +25,7 @@ PublicApiDiff {
         impl<T> core::borrow::BorrowMut<T> for example_api::StructV2 where T: ?core::marker::Sized,
         pub fn example_api::StructV2::borrow_mut(&mut self) -> &mut T,
         impl<T> core::convert::From<T> for example_api::StructV2,
-        pub fn example_api::StructV2::from(t: T) -> T,
+        pub fn example_api::StructV2::from(T) -> T,
     ],
     changed: [
         ChangedPublicItem {
@@ -33,8 +33,8 @@ PublicApiDiff {
             new: pub struct example_api::Struct,
         },
         ChangedPublicItem {
-            old: pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize),
-            new: pub fn example_api::function(v1_param: example_api::Struct),
+            old: pub fn example_api::function(example_api::Struct, usize),
+            new: pub fn example_api::function(example_api::Struct),
         },
     ],
     added: [],

--- a/public-api/tests/snapshots/example_api-v0.2.0-not-simplified.txt
+++ b/public-api/tests/snapshots/example_api-v0.2.0-not-simplified.txt
@@ -3,7 +3,7 @@ pub mod example_api
 pub example_api::Struct::v1_field: usize
 pub example_api::Struct::v2_field: usize
 impl core::fmt::Debug for example_api::Struct
-pub fn example_api::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn example_api::Struct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Freeze for example_api::Struct
 impl core::marker::Send for example_api::Struct
 impl core::marker::Sync for example_api::Struct
@@ -15,7 +15,7 @@ impl<T, U> core::convert::Into<U> for example_api::Struct where U: core::convert
 pub fn example_api::Struct::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for example_api::Struct where U: core::convert::Into<T>
 pub type example_api::Struct::Error = core::convert::Infallible
-pub fn example_api::Struct::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn example_api::Struct::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for example_api::Struct where U: core::convert::TryFrom<T>
 pub type example_api::Struct::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn example_api::Struct::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
@@ -26,7 +26,7 @@ pub fn example_api::Struct::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for example_api::Struct where T: ?core::marker::Sized
 pub fn example_api::Struct::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for example_api::Struct
-pub fn example_api::Struct::from(t: T) -> T
+pub fn example_api::Struct::from(T) -> T
 pub struct example_api::StructV2
 pub example_api::StructV2::field: usize
 impl core::marker::Freeze for example_api::StructV2
@@ -40,7 +40,7 @@ impl<T, U> core::convert::Into<U> for example_api::StructV2 where U: core::conve
 pub fn example_api::StructV2::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for example_api::StructV2 where U: core::convert::Into<T>
 pub type example_api::StructV2::Error = core::convert::Infallible
-pub fn example_api::StructV2::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn example_api::StructV2::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for example_api::StructV2 where U: core::convert::TryFrom<T>
 pub type example_api::StructV2::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn example_api::StructV2::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
@@ -51,5 +51,5 @@ pub fn example_api::StructV2::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for example_api::StructV2 where T: ?core::marker::Sized
 pub fn example_api::StructV2::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for example_api::StructV2
-pub fn example_api::StructV2::from(t: T) -> T
-pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize)
+pub fn example_api::StructV2::from(T) -> T
+pub fn example_api::function(example_api::Struct, usize)

--- a/public-api/tests/snapshots/example_api-v0.2.0-omit_blanket_impls.txt
+++ b/public-api/tests/snapshots/example_api-v0.2.0-omit_blanket_impls.txt
@@ -3,7 +3,7 @@ pub mod example_api
 pub example_api::Struct::v1_field: usize
 pub example_api::Struct::v2_field: usize
 impl core::fmt::Debug for example_api::Struct
-pub fn example_api::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn example_api::Struct::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Freeze for example_api::Struct
 impl core::marker::Send for example_api::Struct
 impl core::marker::Sync for example_api::Struct
@@ -20,4 +20,4 @@ impl core::marker::Unpin for example_api::StructV2
 impl core::marker::UnsafeUnpin for example_api::StructV2
 impl core::panic::unwind_safe::RefUnwindSafe for example_api::StructV2
 impl core::panic::unwind_safe::UnwindSafe for example_api::StructV2
-pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize)
+pub fn example_api::function(example_api::Struct, usize)

--- a/public-api/tests/snapshots/example_api-v0.2.0-simplified_without_auto_derived_impls.txt
+++ b/public-api/tests/snapshots/example_api-v0.2.0-simplified_without_auto_derived_impls.txt
@@ -4,4 +4,4 @@ pub example_api::Struct::v1_field: usize
 pub example_api::Struct::v2_field: usize
 pub struct example_api::StructV2
 pub example_api::StructV2::field: usize
-pub fn example_api::function(v1_param: example_api::Struct, v2_param: usize)
+pub fn example_api::function(example_api::Struct, usize)

--- a/public-api/tests/snapshots/public-api_public-api.txt
+++ b/public-api/tests/snapshots/public-api_public-api.txt
@@ -4,14 +4,14 @@ pub struct public_api::diff::ChangedPublicItem
 pub public_api::diff::ChangedPublicItem::new: public_api::PublicItem
 pub public_api::diff::ChangedPublicItem::old: public_api::PublicItem
 impl public_api::diff::ChangedPublicItem
-pub fn public_api::diff::ChangedPublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn public_api::diff::ChangedPublicItem::grouping_cmp(&self, &Self) -> core::cmp::Ordering
 impl core::clone::Clone for public_api::diff::ChangedPublicItem
 pub fn public_api::diff::ChangedPublicItem::clone(&self) -> public_api::diff::ChangedPublicItem
 impl core::cmp::Eq for public_api::diff::ChangedPublicItem
 impl core::cmp::PartialEq for public_api::diff::ChangedPublicItem
-pub fn public_api::diff::ChangedPublicItem::eq(&self, other: &public_api::diff::ChangedPublicItem) -> bool
+pub fn public_api::diff::ChangedPublicItem::eq(&self, &public_api::diff::ChangedPublicItem) -> bool
 impl core::fmt::Debug for public_api::diff::ChangedPublicItem
-pub fn public_api::diff::ChangedPublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::diff::ChangedPublicItem::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for public_api::diff::ChangedPublicItem
 impl core::marker::Freeze for public_api::diff::ChangedPublicItem
 impl core::marker::Send for public_api::diff::ChangedPublicItem
@@ -24,13 +24,13 @@ impl<T, U> core::convert::Into<U> for public_api::diff::ChangedPublicItem where 
 pub fn public_api::diff::ChangedPublicItem::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for public_api::diff::ChangedPublicItem where U: core::convert::Into<T>
 pub type public_api::diff::ChangedPublicItem::Error = core::convert::Infallible
-pub fn public_api::diff::ChangedPublicItem::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn public_api::diff::ChangedPublicItem::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for public_api::diff::ChangedPublicItem where U: core::convert::TryFrom<T>
 pub type public_api::diff::ChangedPublicItem::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn public_api::diff::ChangedPublicItem::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
 impl<T> alloc::borrow::ToOwned for public_api::diff::ChangedPublicItem where T: core::clone::Clone
 pub type public_api::diff::ChangedPublicItem::Owned = T
-pub fn public_api::diff::ChangedPublicItem::clone_into(&self, target: &mut T)
+pub fn public_api::diff::ChangedPublicItem::clone_into(&self, &mut T)
 pub fn public_api::diff::ChangedPublicItem::to_owned(&self) -> T
 impl<T> core::any::Any for public_api::diff::ChangedPublicItem where T: 'static + ?core::marker::Sized
 pub fn public_api::diff::ChangedPublicItem::type_id(&self) -> core::any::TypeId
@@ -39,23 +39,23 @@ pub fn public_api::diff::ChangedPublicItem::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for public_api::diff::ChangedPublicItem where T: ?core::marker::Sized
 pub fn public_api::diff::ChangedPublicItem::borrow_mut(&mut self) -> &mut T
 impl<T> core::clone::CloneToUninit for public_api::diff::ChangedPublicItem where T: core::clone::Clone
-pub unsafe fn public_api::diff::ChangedPublicItem::clone_to_uninit(&self, dest: *mut u8)
+pub unsafe fn public_api::diff::ChangedPublicItem::clone_to_uninit(&self, *mut u8)
 impl<T> core::convert::From<T> for public_api::diff::ChangedPublicItem
-pub fn public_api::diff::ChangedPublicItem::from(t: T) -> T
+pub fn public_api::diff::ChangedPublicItem::from(T) -> T
 pub struct public_api::diff::PublicApiDiff
 pub public_api::diff::PublicApiDiff::added: alloc::vec::Vec<public_api::PublicItem>
 pub public_api::diff::PublicApiDiff::changed: alloc::vec::Vec<public_api::diff::ChangedPublicItem>
 pub public_api::diff::PublicApiDiff::removed: alloc::vec::Vec<public_api::PublicItem>
 impl public_api::diff::PublicApiDiff
-pub fn public_api::diff::PublicApiDiff::between(old: public_api::PublicApi, new: public_api::PublicApi) -> Self
+pub fn public_api::diff::PublicApiDiff::between(public_api::PublicApi, public_api::PublicApi) -> Self
 pub fn public_api::diff::PublicApiDiff::is_empty(&self) -> bool
 impl core::clone::Clone for public_api::diff::PublicApiDiff
 pub fn public_api::diff::PublicApiDiff::clone(&self) -> public_api::diff::PublicApiDiff
 impl core::cmp::Eq for public_api::diff::PublicApiDiff
 impl core::cmp::PartialEq for public_api::diff::PublicApiDiff
-pub fn public_api::diff::PublicApiDiff::eq(&self, other: &public_api::diff::PublicApiDiff) -> bool
+pub fn public_api::diff::PublicApiDiff::eq(&self, &public_api::diff::PublicApiDiff) -> bool
 impl core::fmt::Debug for public_api::diff::PublicApiDiff
-pub fn public_api::diff::PublicApiDiff::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::diff::PublicApiDiff::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for public_api::diff::PublicApiDiff
 impl core::marker::Freeze for public_api::diff::PublicApiDiff
 impl core::marker::Send for public_api::diff::PublicApiDiff
@@ -68,13 +68,13 @@ impl<T, U> core::convert::Into<U> for public_api::diff::PublicApiDiff where U: c
 pub fn public_api::diff::PublicApiDiff::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for public_api::diff::PublicApiDiff where U: core::convert::Into<T>
 pub type public_api::diff::PublicApiDiff::Error = core::convert::Infallible
-pub fn public_api::diff::PublicApiDiff::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn public_api::diff::PublicApiDiff::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for public_api::diff::PublicApiDiff where U: core::convert::TryFrom<T>
 pub type public_api::diff::PublicApiDiff::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn public_api::diff::PublicApiDiff::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
 impl<T> alloc::borrow::ToOwned for public_api::diff::PublicApiDiff where T: core::clone::Clone
 pub type public_api::diff::PublicApiDiff::Owned = T
-pub fn public_api::diff::PublicApiDiff::clone_into(&self, target: &mut T)
+pub fn public_api::diff::PublicApiDiff::clone_into(&self, &mut T)
 pub fn public_api::diff::PublicApiDiff::to_owned(&self) -> T
 impl<T> core::any::Any for public_api::diff::PublicApiDiff where T: 'static + ?core::marker::Sized
 pub fn public_api::diff::PublicApiDiff::type_id(&self) -> core::any::TypeId
@@ -83,9 +83,9 @@ pub fn public_api::diff::PublicApiDiff::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for public_api::diff::PublicApiDiff where T: ?core::marker::Sized
 pub fn public_api::diff::PublicApiDiff::borrow_mut(&mut self) -> &mut T
 impl<T> core::clone::CloneToUninit for public_api::diff::PublicApiDiff where T: core::clone::Clone
-pub unsafe fn public_api::diff::PublicApiDiff::clone_to_uninit(&self, dest: *mut u8)
+pub unsafe fn public_api::diff::PublicApiDiff::clone_to_uninit(&self, *mut u8)
 impl<T> core::convert::From<T> for public_api::diff::PublicApiDiff
-pub fn public_api::diff::PublicApiDiff::from(t: T) -> T
+pub fn public_api::diff::PublicApiDiff::from(T) -> T
 pub mod public_api::tokens
 pub enum public_api::tokens::Token
 pub public_api::tokens::Token::Annotation(alloc::string::String)
@@ -108,15 +108,15 @@ impl core::clone::Clone for public_api::tokens::Token
 pub fn public_api::tokens::Token::clone(&self) -> public_api::tokens::Token
 impl core::cmp::Eq for public_api::tokens::Token
 impl core::cmp::Ord for public_api::tokens::Token
-pub fn public_api::tokens::Token::cmp(&self, other: &public_api::tokens::Token) -> core::cmp::Ordering
+pub fn public_api::tokens::Token::cmp(&self, &public_api::tokens::Token) -> core::cmp::Ordering
 impl core::cmp::PartialEq for public_api::tokens::Token
-pub fn public_api::tokens::Token::eq(&self, other: &public_api::tokens::Token) -> bool
+pub fn public_api::tokens::Token::eq(&self, &public_api::tokens::Token) -> bool
 impl core::cmp::PartialOrd for public_api::tokens::Token
-pub fn public_api::tokens::Token::partial_cmp(&self, other: &public_api::tokens::Token) -> core::option::Option<core::cmp::Ordering>
+pub fn public_api::tokens::Token::partial_cmp(&self, &public_api::tokens::Token) -> core::option::Option<core::cmp::Ordering>
 impl core::fmt::Debug for public_api::tokens::Token
-pub fn public_api::tokens::Token::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::tokens::Token::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for public_api::tokens::Token
-pub fn public_api::tokens::Token::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn public_api::tokens::Token::hash<__H: core::hash::Hasher>(&self, &mut __H)
 impl core::marker::StructuralPartialEq for public_api::tokens::Token
 impl core::marker::Freeze for public_api::tokens::Token
 impl core::marker::Send for public_api::tokens::Token
@@ -129,13 +129,13 @@ impl<T, U> core::convert::Into<U> for public_api::tokens::Token where U: core::c
 pub fn public_api::tokens::Token::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for public_api::tokens::Token where U: core::convert::Into<T>
 pub type public_api::tokens::Token::Error = core::convert::Infallible
-pub fn public_api::tokens::Token::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn public_api::tokens::Token::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for public_api::tokens::Token where U: core::convert::TryFrom<T>
 pub type public_api::tokens::Token::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn public_api::tokens::Token::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
 impl<T> alloc::borrow::ToOwned for public_api::tokens::Token where T: core::clone::Clone
 pub type public_api::tokens::Token::Owned = T
-pub fn public_api::tokens::Token::clone_into(&self, target: &mut T)
+pub fn public_api::tokens::Token::clone_into(&self, &mut T)
 pub fn public_api::tokens::Token::to_owned(&self) -> T
 impl<T> core::any::Any for public_api::tokens::Token where T: 'static + ?core::marker::Sized
 pub fn public_api::tokens::Token::type_id(&self) -> core::any::TypeId
@@ -144,22 +144,22 @@ pub fn public_api::tokens::Token::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for public_api::tokens::Token where T: ?core::marker::Sized
 pub fn public_api::tokens::Token::borrow_mut(&mut self) -> &mut T
 impl<T> core::clone::CloneToUninit for public_api::tokens::Token where T: core::clone::Clone
-pub unsafe fn public_api::tokens::Token::clone_to_uninit(&self, dest: *mut u8)
+pub unsafe fn public_api::tokens::Token::clone_to_uninit(&self, *mut u8)
 impl<T> core::convert::From<T> for public_api::tokens::Token
-pub fn public_api::tokens::Token::from(t: T) -> T
+pub fn public_api::tokens::Token::from(T) -> T
 #[non_exhaustive] pub enum public_api::Error
 pub public_api::Error::IoError(std::io::error::Error)
 pub public_api::Error::SerdeJsonError(serde_json::error::Error)
 impl core::convert::From<serde_json::error::Error> for public_api::Error
-pub fn public_api::Error::from(source: serde_json::error::Error) -> Self
+pub fn public_api::Error::from(serde_json::error::Error) -> Self
 impl core::convert::From<std::io::error::Error> for public_api::Error
-pub fn public_api::Error::from(source: std::io::error::Error) -> Self
+pub fn public_api::Error::from(std::io::error::Error) -> Self
 impl core::error::Error for public_api::Error
 pub fn public_api::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for public_api::Error
-pub fn public_api::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::Error::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::Error
-pub fn public_api::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::Error::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Freeze for public_api::Error
 impl core::marker::Send for public_api::Error
 impl core::marker::Sync for public_api::Error
@@ -171,7 +171,7 @@ impl<T, U> core::convert::Into<U> for public_api::Error where U: core::convert::
 pub fn public_api::Error::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for public_api::Error where U: core::convert::Into<T>
 pub type public_api::Error::Error = core::convert::Infallible
-pub fn public_api::Error::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn public_api::Error::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for public_api::Error where U: core::convert::TryFrom<T>
 pub type public_api::Error::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn public_api::Error::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
@@ -184,20 +184,21 @@ pub fn public_api::Error::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for public_api::Error where T: ?core::marker::Sized
 pub fn public_api::Error::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for public_api::Error
-pub fn public_api::Error::from(t: T) -> T
+pub fn public_api::Error::from(T) -> T
 pub struct public_api::Builder
 impl public_api::Builder
 pub fn public_api::Builder::build(self) -> public_api::Result<public_api::PublicApi>
-pub fn public_api::Builder::debug_sorting(self, debug_sorting: bool) -> Self
-pub fn public_api::Builder::from_rustdoc_json(path: impl core::convert::Into<std::path::PathBuf>) -> Self
-pub fn public_api::Builder::omit_auto_derived_impls(self, omit_auto_derived_impls: bool) -> Self
-pub fn public_api::Builder::omit_auto_trait_impls(self, omit_auto_trait_impls: bool) -> Self
-pub fn public_api::Builder::omit_blanket_impls(self, omit_blanket_impls: bool) -> Self
-pub fn public_api::Builder::sorted(self, sorted: bool) -> Self
+pub fn public_api::Builder::debug_sorting(self, bool) -> Self
+pub fn public_api::Builder::from_rustdoc_json(impl core::convert::Into<std::path::PathBuf>) -> Self
+pub fn public_api::Builder::include_function_parameter_names(self, bool) -> Self
+pub fn public_api::Builder::omit_auto_derived_impls(self, bool) -> Self
+pub fn public_api::Builder::omit_auto_trait_impls(self, bool) -> Self
+pub fn public_api::Builder::omit_blanket_impls(self, bool) -> Self
+pub fn public_api::Builder::sorted(self, bool) -> Self
 impl core::clone::Clone for public_api::Builder
 pub fn public_api::Builder::clone(&self) -> public_api::Builder
 impl core::fmt::Debug for public_api::Builder
-pub fn public_api::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::Builder::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Freeze for public_api::Builder
 impl core::marker::Send for public_api::Builder
 impl core::marker::Sync for public_api::Builder
@@ -209,13 +210,13 @@ impl<T, U> core::convert::Into<U> for public_api::Builder where U: core::convert
 pub fn public_api::Builder::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for public_api::Builder where U: core::convert::Into<T>
 pub type public_api::Builder::Error = core::convert::Infallible
-pub fn public_api::Builder::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn public_api::Builder::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for public_api::Builder where U: core::convert::TryFrom<T>
 pub type public_api::Builder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn public_api::Builder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
 impl<T> alloc::borrow::ToOwned for public_api::Builder where T: core::clone::Clone
 pub type public_api::Builder::Owned = T
-pub fn public_api::Builder::clone_into(&self, target: &mut T)
+pub fn public_api::Builder::clone_into(&self, &mut T)
 pub fn public_api::Builder::to_owned(&self) -> T
 impl<T> core::any::Any for public_api::Builder where T: 'static + ?core::marker::Sized
 pub fn public_api::Builder::type_id(&self) -> core::any::TypeId
@@ -224,19 +225,19 @@ pub fn public_api::Builder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for public_api::Builder where T: ?core::marker::Sized
 pub fn public_api::Builder::borrow_mut(&mut self) -> &mut T
 impl<T> core::clone::CloneToUninit for public_api::Builder where T: core::clone::Clone
-pub unsafe fn public_api::Builder::clone_to_uninit(&self, dest: *mut u8)
+pub unsafe fn public_api::Builder::clone_to_uninit(&self, *mut u8)
 impl<T> core::convert::From<T> for public_api::Builder
-pub fn public_api::Builder::from(t: T) -> T
+pub fn public_api::Builder::from(T) -> T
 #[non_exhaustive] pub struct public_api::PublicApi
 impl public_api::PublicApi
-pub fn public_api::PublicApi::assert_eq_or_update(&self, snapshot_path: impl core::convert::AsRef<std::path::Path>)
+pub fn public_api::PublicApi::assert_eq_or_update(&self, impl core::convert::AsRef<std::path::Path>)
 pub fn public_api::PublicApi::into_items(self) -> impl core::iter::traits::iterator::Iterator<Item = public_api::PublicItem>
 pub fn public_api::PublicApi::items(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::PublicItem>
 pub fn public_api::PublicApi::missing_item_ids(&self) -> impl core::iter::traits::iterator::Iterator<Item = &u32>
 impl core::fmt::Debug for public_api::PublicApi
-pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::PublicApi::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::PublicApi
-pub fn public_api::PublicApi::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::PublicApi::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Freeze for public_api::PublicApi
 impl core::marker::Send for public_api::PublicApi
 impl core::marker::Sync for public_api::PublicApi
@@ -248,7 +249,7 @@ impl<T, U> core::convert::Into<U> for public_api::PublicApi where U: core::conve
 pub fn public_api::PublicApi::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for public_api::PublicApi where U: core::convert::Into<T>
 pub type public_api::PublicApi::Error = core::convert::Infallible
-pub fn public_api::PublicApi::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn public_api::PublicApi::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for public_api::PublicApi where U: core::convert::TryFrom<T>
 pub type public_api::PublicApi::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn public_api::PublicApi::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
@@ -261,10 +262,10 @@ pub fn public_api::PublicApi::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for public_api::PublicApi where T: ?core::marker::Sized
 pub fn public_api::PublicApi::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for public_api::PublicApi
-pub fn public_api::PublicApi::from(t: T) -> T
+pub fn public_api::PublicApi::from(T) -> T
 pub struct public_api::PublicItem
 impl public_api::PublicItem
-pub fn public_api::PublicItem::grouping_cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn public_api::PublicItem::grouping_cmp(&self, &Self) -> core::cmp::Ordering
 pub fn public_api::PublicItem::id(&self) -> rustdoc_types::Id
 pub fn public_api::PublicItem::parent_id(&self) -> core::option::Option<rustdoc_types::Id>
 pub fn public_api::PublicItem::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = &public_api::tokens::Token>
@@ -272,13 +273,13 @@ impl core::clone::Clone for public_api::PublicItem
 pub fn public_api::PublicItem::clone(&self) -> public_api::PublicItem
 impl core::cmp::Eq for public_api::PublicItem
 impl core::cmp::PartialEq for public_api::PublicItem
-pub fn public_api::PublicItem::eq(&self, other: &Self) -> bool
+pub fn public_api::PublicItem::eq(&self, &Self) -> bool
 impl core::fmt::Debug for public_api::PublicItem
-pub fn public_api::PublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::PublicItem::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for public_api::PublicItem
-pub fn public_api::PublicItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn public_api::PublicItem::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for public_api::PublicItem
-pub fn public_api::PublicItem::hash<H: core::hash::Hasher>(&self, state: &mut H)
+pub fn public_api::PublicItem::hash<H: core::hash::Hasher>(&self, &mut H)
 impl core::marker::Freeze for public_api::PublicItem
 impl core::marker::Send for public_api::PublicItem
 impl core::marker::Sync for public_api::PublicItem
@@ -290,13 +291,13 @@ impl<T, U> core::convert::Into<U> for public_api::PublicItem where U: core::conv
 pub fn public_api::PublicItem::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for public_api::PublicItem where U: core::convert::Into<T>
 pub type public_api::PublicItem::Error = core::convert::Infallible
-pub fn public_api::PublicItem::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn public_api::PublicItem::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for public_api::PublicItem where U: core::convert::TryFrom<T>
 pub type public_api::PublicItem::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn public_api::PublicItem::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
 impl<T> alloc::borrow::ToOwned for public_api::PublicItem where T: core::clone::Clone
 pub type public_api::PublicItem::Owned = T
-pub fn public_api::PublicItem::clone_into(&self, target: &mut T)
+pub fn public_api::PublicItem::clone_into(&self, &mut T)
 pub fn public_api::PublicItem::to_owned(&self) -> T
 impl<T> alloc::string::ToString for public_api::PublicItem where T: core::fmt::Display + ?core::marker::Sized
 pub fn public_api::PublicItem::to_string(&self) -> alloc::string::String
@@ -307,8 +308,8 @@ pub fn public_api::PublicItem::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for public_api::PublicItem where T: ?core::marker::Sized
 pub fn public_api::PublicItem::borrow_mut(&mut self) -> &mut T
 impl<T> core::clone::CloneToUninit for public_api::PublicItem where T: core::clone::Clone
-pub unsafe fn public_api::PublicItem::clone_to_uninit(&self, dest: *mut u8)
+pub unsafe fn public_api::PublicItem::clone_to_uninit(&self, *mut u8)
 impl<T> core::convert::From<T> for public_api::PublicItem
-pub fn public_api::PublicItem::from(t: T) -> T
+pub fn public_api::PublicItem::from(T) -> T
 pub const public_api::MINIMUM_NIGHTLY_RUST_VERSION: &str
 pub type public_api::Result<T> = core::result::Result<T, public_api::Error>

--- a/public-api/tests/snapshots/rustdoc-json_public-api.txt
+++ b/public-api/tests/snapshots/rustdoc-json_public-api.txt
@@ -9,17 +9,17 @@ pub rustdoc_json::BuildError::General(alloc::string::String)
 pub rustdoc_json::BuildError::IoError(std::io::error::Error)
 pub rustdoc_json::BuildError::VirtualManifest(std::path::PathBuf)
 impl core::convert::From<cargo_manifest::error::Error> for rustdoc_json::BuildError
-pub fn rustdoc_json::BuildError::from(source: cargo_manifest::error::Error) -> Self
+pub fn rustdoc_json::BuildError::from(cargo_manifest::error::Error) -> Self
 impl core::convert::From<cargo_metadata::errors::Error> for rustdoc_json::BuildError
-pub fn rustdoc_json::BuildError::from(source: cargo_metadata::errors::Error) -> Self
+pub fn rustdoc_json::BuildError::from(cargo_metadata::errors::Error) -> Self
 impl core::convert::From<std::io::error::Error> for rustdoc_json::BuildError
-pub fn rustdoc_json::BuildError::from(source: std::io::error::Error) -> Self
+pub fn rustdoc_json::BuildError::from(std::io::error::Error) -> Self
 impl core::error::Error for rustdoc_json::BuildError
 pub fn rustdoc_json::BuildError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for rustdoc_json::BuildError
-pub fn rustdoc_json::BuildError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn rustdoc_json::BuildError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for rustdoc_json::BuildError
-pub fn rustdoc_json::BuildError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn rustdoc_json::BuildError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Freeze for rustdoc_json::BuildError
 impl core::marker::Send for rustdoc_json::BuildError
 impl core::marker::Sync for rustdoc_json::BuildError
@@ -31,7 +31,7 @@ impl<T, U> core::convert::Into<U> for rustdoc_json::BuildError where U: core::co
 pub fn rustdoc_json::BuildError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for rustdoc_json::BuildError where U: core::convert::Into<T>
 pub type rustdoc_json::BuildError::Error = core::convert::Infallible
-pub fn rustdoc_json::BuildError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn rustdoc_json::BuildError::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for rustdoc_json::BuildError where U: core::convert::TryFrom<T>
 pub type rustdoc_json::BuildError::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn rustdoc_json::BuildError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
@@ -44,7 +44,7 @@ pub fn rustdoc_json::BuildError::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for rustdoc_json::BuildError where T: ?core::marker::Sized
 pub fn rustdoc_json::BuildError::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for rustdoc_json::BuildError
-pub fn rustdoc_json::BuildError::from(t: T) -> T
+pub fn rustdoc_json::BuildError::from(T) -> T
 impl<T> tracing::instrument::Instrument for rustdoc_json::BuildError
 impl<T> tracing::instrument::WithSubscriber for rustdoc_json::BuildError
 pub enum rustdoc_json::Color
@@ -54,7 +54,7 @@ pub rustdoc_json::Color::Never
 impl core::clone::Clone for rustdoc_json::Color
 pub fn rustdoc_json::Color::clone(&self) -> rustdoc_json::Color
 impl core::fmt::Debug for rustdoc_json::Color
-pub fn rustdoc_json::Color::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn rustdoc_json::Color::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for rustdoc_json::Color
 impl core::marker::Freeze for rustdoc_json::Color
 impl core::marker::Send for rustdoc_json::Color
@@ -67,13 +67,13 @@ impl<T, U> core::convert::Into<U> for rustdoc_json::Color where U: core::convert
 pub fn rustdoc_json::Color::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for rustdoc_json::Color where U: core::convert::Into<T>
 pub type rustdoc_json::Color::Error = core::convert::Infallible
-pub fn rustdoc_json::Color::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn rustdoc_json::Color::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for rustdoc_json::Color where U: core::convert::TryFrom<T>
 pub type rustdoc_json::Color::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn rustdoc_json::Color::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
 impl<T> alloc::borrow::ToOwned for rustdoc_json::Color where T: core::clone::Clone
 pub type rustdoc_json::Color::Owned = T
-pub fn rustdoc_json::Color::clone_into(&self, target: &mut T)
+pub fn rustdoc_json::Color::clone_into(&self, &mut T)
 pub fn rustdoc_json::Color::to_owned(&self) -> T
 impl<T> core::any::Any for rustdoc_json::Color where T: 'static + ?core::marker::Sized
 pub fn rustdoc_json::Color::type_id(&self) -> core::any::TypeId
@@ -82,9 +82,9 @@ pub fn rustdoc_json::Color::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for rustdoc_json::Color where T: ?core::marker::Sized
 pub fn rustdoc_json::Color::borrow_mut(&mut self) -> &mut T
 impl<T> core::clone::CloneToUninit for rustdoc_json::Color where T: core::clone::Clone
-pub unsafe fn rustdoc_json::Color::clone_to_uninit(&self, dest: *mut u8)
+pub unsafe fn rustdoc_json::Color::clone_to_uninit(&self, *mut u8)
 impl<T> core::convert::From<T> for rustdoc_json::Color
-pub fn rustdoc_json::Color::from(t: T) -> T
+pub fn rustdoc_json::Color::from(T) -> T
 impl<T> tracing::instrument::Instrument for rustdoc_json::Color
 impl<T> tracing::instrument::WithSubscriber for rustdoc_json::Color
 #[non_exhaustive] pub enum rustdoc_json::PackageTarget
@@ -98,7 +98,7 @@ pub fn rustdoc_json::PackageTarget::clone(&self) -> rustdoc_json::PackageTarget
 impl core::default::Default for rustdoc_json::PackageTarget
 pub fn rustdoc_json::PackageTarget::default() -> rustdoc_json::PackageTarget
 impl core::fmt::Debug for rustdoc_json::PackageTarget
-pub fn rustdoc_json::PackageTarget::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn rustdoc_json::PackageTarget::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Freeze for rustdoc_json::PackageTarget
 impl core::marker::Send for rustdoc_json::PackageTarget
 impl core::marker::Sync for rustdoc_json::PackageTarget
@@ -110,13 +110,13 @@ impl<T, U> core::convert::Into<U> for rustdoc_json::PackageTarget where U: core:
 pub fn rustdoc_json::PackageTarget::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for rustdoc_json::PackageTarget where U: core::convert::Into<T>
 pub type rustdoc_json::PackageTarget::Error = core::convert::Infallible
-pub fn rustdoc_json::PackageTarget::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn rustdoc_json::PackageTarget::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for rustdoc_json::PackageTarget where U: core::convert::TryFrom<T>
 pub type rustdoc_json::PackageTarget::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn rustdoc_json::PackageTarget::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
 impl<T> alloc::borrow::ToOwned for rustdoc_json::PackageTarget where T: core::clone::Clone
 pub type rustdoc_json::PackageTarget::Owned = T
-pub fn rustdoc_json::PackageTarget::clone_into(&self, target: &mut T)
+pub fn rustdoc_json::PackageTarget::clone_into(&self, &mut T)
 pub fn rustdoc_json::PackageTarget::to_owned(&self) -> T
 impl<T> core::any::Any for rustdoc_json::PackageTarget where T: 'static + ?core::marker::Sized
 pub fn rustdoc_json::PackageTarget::type_id(&self) -> core::any::TypeId
@@ -125,38 +125,38 @@ pub fn rustdoc_json::PackageTarget::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for rustdoc_json::PackageTarget where T: ?core::marker::Sized
 pub fn rustdoc_json::PackageTarget::borrow_mut(&mut self) -> &mut T
 impl<T> core::clone::CloneToUninit for rustdoc_json::PackageTarget where T: core::clone::Clone
-pub unsafe fn rustdoc_json::PackageTarget::clone_to_uninit(&self, dest: *mut u8)
+pub unsafe fn rustdoc_json::PackageTarget::clone_to_uninit(&self, *mut u8)
 impl<T> core::convert::From<T> for rustdoc_json::PackageTarget
-pub fn rustdoc_json::PackageTarget::from(t: T) -> T
+pub fn rustdoc_json::PackageTarget::from(T) -> T
 impl<T> tracing::instrument::Instrument for rustdoc_json::PackageTarget
 impl<T> tracing::instrument::WithSubscriber for rustdoc_json::PackageTarget
 pub struct rustdoc_json::Builder
 impl rustdoc_json::Builder
-pub const fn rustdoc_json::Builder::all_features(self, all_features: bool) -> Self
+pub const fn rustdoc_json::Builder::all_features(self, bool) -> Self
 pub fn rustdoc_json::Builder::build(self) -> core::result::Result<std::path::PathBuf, rustdoc_json::BuildError>
-pub fn rustdoc_json::Builder::build_with_captured_output(self, stdout: impl std::io::Write, stderr: impl std::io::Write) -> core::result::Result<std::path::PathBuf, rustdoc_json::BuildError>
-pub fn rustdoc_json::Builder::cap_lints(self, cap_lints: core::option::Option<impl core::convert::AsRef<str>>) -> Self
+pub fn rustdoc_json::Builder::build_with_captured_output(self, impl std::io::Write, impl std::io::Write) -> core::result::Result<std::path::PathBuf, rustdoc_json::BuildError>
+pub fn rustdoc_json::Builder::cap_lints(self, core::option::Option<impl core::convert::AsRef<str>>) -> Self
 pub fn rustdoc_json::Builder::clear_target_dir(self) -> Self
 pub fn rustdoc_json::Builder::clear_toolchain(self) -> Self
-pub const fn rustdoc_json::Builder::color(self, color: rustdoc_json::Color) -> Self
-pub fn rustdoc_json::Builder::document_private_items(self, document_private_items: bool) -> Self
-pub fn rustdoc_json::Builder::env(self, key: impl core::convert::AsRef<std::ffi::os_str::OsStr>, val: impl core::convert::AsRef<std::ffi::os_str::OsStr>) -> Self
-pub fn rustdoc_json::Builder::features<I: core::iter::traits::collect::IntoIterator<Item = S>, S: core::convert::AsRef<str>>(self, features: I) -> Self
-pub fn rustdoc_json::Builder::manifest_path(self, manifest_path: impl core::convert::AsRef<std::path::Path>) -> Self
-pub const fn rustdoc_json::Builder::no_default_features(self, no_default_features: bool) -> Self
-pub fn rustdoc_json::Builder::package(self, package: impl core::convert::AsRef<str>) -> Self
-pub fn rustdoc_json::Builder::package_target(self, package_target: rustdoc_json::PackageTarget) -> Self
-pub const fn rustdoc_json::Builder::quiet(self, quiet: bool) -> Self
-pub const fn rustdoc_json::Builder::silent(self, silent: bool) -> Self
-pub fn rustdoc_json::Builder::target(self, target: alloc::string::String) -> Self
-pub fn rustdoc_json::Builder::target_dir(self, target_dir: impl core::convert::AsRef<std::path::Path>) -> Self
-pub fn rustdoc_json::Builder::toolchain(self, toolchain: impl core::convert::Into<alloc::string::String>) -> Self
+pub const fn rustdoc_json::Builder::color(self, rustdoc_json::Color) -> Self
+pub fn rustdoc_json::Builder::document_private_items(self, bool) -> Self
+pub fn rustdoc_json::Builder::env(self, impl core::convert::AsRef<std::ffi::os_str::OsStr>, impl core::convert::AsRef<std::ffi::os_str::OsStr>) -> Self
+pub fn rustdoc_json::Builder::features<I: core::iter::traits::collect::IntoIterator<Item = S>, S: core::convert::AsRef<str>>(self, I) -> Self
+pub fn rustdoc_json::Builder::manifest_path(self, impl core::convert::AsRef<std::path::Path>) -> Self
+pub const fn rustdoc_json::Builder::no_default_features(self, bool) -> Self
+pub fn rustdoc_json::Builder::package(self, impl core::convert::AsRef<str>) -> Self
+pub fn rustdoc_json::Builder::package_target(self, rustdoc_json::PackageTarget) -> Self
+pub const fn rustdoc_json::Builder::quiet(self, bool) -> Self
+pub const fn rustdoc_json::Builder::silent(self, bool) -> Self
+pub fn rustdoc_json::Builder::target(self, alloc::string::String) -> Self
+pub fn rustdoc_json::Builder::target_dir(self, impl core::convert::AsRef<std::path::Path>) -> Self
+pub fn rustdoc_json::Builder::toolchain(self, impl core::convert::Into<alloc::string::String>) -> Self
 impl core::clone::Clone for rustdoc_json::Builder
 pub fn rustdoc_json::Builder::clone(&self) -> rustdoc_json::Builder
 impl core::default::Default for rustdoc_json::Builder
 pub fn rustdoc_json::Builder::default() -> Self
 impl core::fmt::Debug for rustdoc_json::Builder
-pub fn rustdoc_json::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn rustdoc_json::Builder::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Freeze for rustdoc_json::Builder
 impl core::marker::Send for rustdoc_json::Builder
 impl core::marker::Sync for rustdoc_json::Builder
@@ -168,13 +168,13 @@ impl<T, U> core::convert::Into<U> for rustdoc_json::Builder where U: core::conve
 pub fn rustdoc_json::Builder::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for rustdoc_json::Builder where U: core::convert::Into<T>
 pub type rustdoc_json::Builder::Error = core::convert::Infallible
-pub fn rustdoc_json::Builder::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn rustdoc_json::Builder::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for rustdoc_json::Builder where U: core::convert::TryFrom<T>
 pub type rustdoc_json::Builder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn rustdoc_json::Builder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
 impl<T> alloc::borrow::ToOwned for rustdoc_json::Builder where T: core::clone::Clone
 pub type rustdoc_json::Builder::Owned = T
-pub fn rustdoc_json::Builder::clone_into(&self, target: &mut T)
+pub fn rustdoc_json::Builder::clone_into(&self, &mut T)
 pub fn rustdoc_json::Builder::to_owned(&self) -> T
 impl<T> core::any::Any for rustdoc_json::Builder where T: 'static + ?core::marker::Sized
 pub fn rustdoc_json::Builder::type_id(&self) -> core::any::TypeId
@@ -183,8 +183,8 @@ pub fn rustdoc_json::Builder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for rustdoc_json::Builder where T: ?core::marker::Sized
 pub fn rustdoc_json::Builder::borrow_mut(&mut self) -> &mut T
 impl<T> core::clone::CloneToUninit for rustdoc_json::Builder where T: core::clone::Clone
-pub unsafe fn rustdoc_json::Builder::clone_to_uninit(&self, dest: *mut u8)
+pub unsafe fn rustdoc_json::Builder::clone_to_uninit(&self, *mut u8)
 impl<T> core::convert::From<T> for rustdoc_json::Builder
-pub fn rustdoc_json::Builder::from(t: T) -> T
+pub fn rustdoc_json::Builder::from(T) -> T
 impl<T> tracing::instrument::Instrument for rustdoc_json::Builder
 impl<T> tracing::instrument::WithSubscriber for rustdoc_json::Builder

--- a/public-api/tests/snapshots/rustup-toolchain_public-api.txt
+++ b/public-api/tests/snapshots/rustup-toolchain_public-api.txt
@@ -4,13 +4,13 @@ pub rustup_toolchain::Error::IoError(std::io::error::Error)
 pub rustup_toolchain::Error::RustupToolchainInstallError
 pub rustup_toolchain::Error::StdSyncPoisonError
 impl core::convert::From<std::io::error::Error> for rustup_toolchain::Error
-pub fn rustup_toolchain::Error::from(source: std::io::error::Error) -> Self
+pub fn rustup_toolchain::Error::from(std::io::error::Error) -> Self
 impl core::error::Error for rustup_toolchain::Error
 pub fn rustup_toolchain::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for rustup_toolchain::Error
-pub fn rustup_toolchain::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn rustup_toolchain::Error::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for rustup_toolchain::Error
-pub fn rustup_toolchain::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn rustup_toolchain::Error::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Freeze for rustup_toolchain::Error
 impl core::marker::Send for rustup_toolchain::Error
 impl core::marker::Sync for rustup_toolchain::Error
@@ -22,7 +22,7 @@ impl<T, U> core::convert::Into<U> for rustup_toolchain::Error where U: core::con
 pub fn rustup_toolchain::Error::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for rustup_toolchain::Error where U: core::convert::Into<T>
 pub type rustup_toolchain::Error::Error = core::convert::Infallible
-pub fn rustup_toolchain::Error::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+pub fn rustup_toolchain::Error::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
 impl<T, U> core::convert::TryInto<U> for rustup_toolchain::Error where U: core::convert::TryFrom<T>
 pub type rustup_toolchain::Error::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn rustup_toolchain::Error::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
@@ -35,8 +35,8 @@ pub fn rustup_toolchain::Error::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for rustup_toolchain::Error where T: ?core::marker::Sized
 pub fn rustup_toolchain::Error::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for rustup_toolchain::Error
-pub fn rustup_toolchain::Error::from(t: T) -> T
-pub fn rustup_toolchain::ensure_installed(toolchain: &str) -> rustup_toolchain::Result<()>
-pub fn rustup_toolchain::install(toolchain: impl core::convert::AsRef<str>) -> rustup_toolchain::Result<()>
-pub fn rustup_toolchain::is_installed(toolchain: &str) -> rustup_toolchain::Result<bool>
+pub fn rustup_toolchain::Error::from(T) -> T
+pub fn rustup_toolchain::ensure_installed(&str) -> rustup_toolchain::Result<()>
+pub fn rustup_toolchain::install(impl core::convert::AsRef<str>) -> rustup_toolchain::Result<()>
+pub fn rustup_toolchain::is_installed(&str) -> rustup_toolchain::Result<bool>
 pub type rustup_toolchain::Result<T> = core::result::Result<T, rustup_toolchain::Error>

--- a/repo-tests/Cargo.toml
+++ b/repo-tests/Cargo.toml
@@ -7,5 +7,5 @@ license = "MIT"
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.51.0"
+version = "0.52.0"
 

--- a/rustdoc-json/Cargo.toml
+++ b/rustdoc-json/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "rustdoc-json"
-version = "0.9.9"
+version = "0.9.10"
 description = "Utilities for working with rustdoc JSON."
 homepage = "https://github.com/cargo-public-api/cargo-public-api/tree/main/rustdoc-json"
 documentation = "https://docs.rs/rustdoc-json"

--- a/scripts/release-helper/src/version_info.rs
+++ b/scripts/release-helper/src/version_info.rs
@@ -7,6 +7,10 @@ pub struct CargoPublicApiVersionInfo {
 
 pub static TABLE: &[CargoPublicApiVersionInfo] = &[
     CargoPublicApiVersionInfo {
+        cargo_public_api_version: "0.52.x",
+        min_nightly_rust_version: "nightly-2025-08-02",
+    },
+    CargoPublicApiVersionInfo {
         cargo_public_api_version: "0.51.x",
         min_nightly_rust_version: "nightly-2025-08-02",
     },


### PR DESCRIPTION
Stop including function parameter names by default in the output. This avoids issues where
renaming parameters shows up as API diffs. This is especially relevant for trait impls, where fn
parameter names are often `_`-prefixed.

To opt-in to the old behavior of including parameter names, use the new `--include
function-parameter-names` CLI option (or the `-v` / `--verbose` shorthand). Or `public_api::Builder::include_function_parameter_names(true)`.

For easier review, this PR is split in two commits. The second is just the noisy blessing of the changes in the first.

Closes https://github.com/cargo-public-api/cargo-public-api/issues/766.