### PR TITLE
Make renamed lib targets with `crate-type = ["rlib"]` work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `cargo-public-api` changelog
 
+## v0.51.1
+* Make renamed lib targets with `crate-type = ["rlib"]` work
+
 ## v0.51.0
 * Also include default trait methods in impls, even if not overridden, just like in rustdoc HTML.
 * Sort rendered attributes so rendering is determinstic and does not change with rustdoc JSON changes.

--- a/public-api/CHANGELOG.md
+++ b/public-api/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `public-api` changelog
 
+## v0.51.1
+* Make renamed lib targets with `crate-type = ["rlib"]` work
+
 ## v0.51.0
 * Also include default trait methods in impls, even if not overridden, just like in rustdoc HTML.
 

--- a/public-api/tests/public-api-lib-tests.rs
+++ b/public-api/tests/public-api-lib-tests.rs
@@ -302,6 +302,37 @@ pub mod a_mod {
     assert_eq!(Some("a_mod"), parent_item.name.as_deref());
 }
 
+#[test]
+fn renamed_rlib_library_target_name() {
+    let root = tempdir().unwrap();
+
+    write_file(
+        &root,
+        "Cargo.toml",
+        r#"[package]
+name = "thing"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "renamed_lib"
+crate-type = ["rlib"]
+path = "lib.rs"
+"#,
+    );
+    write_file(&root, "lib.rs", "pub fn example() {}\n");
+
+    let build_dir = tempdir().unwrap();
+    let json_path = rustdoc_json_path_for_crate(root.path(), &build_dir);
+
+    let api = public_api::Builder::from_rustdoc_json(json_path)
+        .build()
+        .unwrap()
+        .to_string();
+
+    assert!(api.contains("pub fn renamed_lib::example()"), "{api}");
+}
+
 struct LibWithJson {
     json_path: PathBuf,
 
@@ -309,15 +340,15 @@ struct LibWithJson {
     _root: TempDir,
 }
 
+fn write_file(root: &TempDir, file: &str, content: &str) {
+    fs::write(root.path().join(file), content).unwrap();
+}
+
 fn rustdoc_json_for_lib(lib: &str) -> LibWithJson {
     let root = tempdir().unwrap();
 
-    let write = |file: &str, content: &str| {
-        let file_path = root.path().join(file);
-        fs::write(file_path, content).unwrap();
-    };
-
-    write(
+    write_file(
+        &root,
         "Cargo.toml",
         "\
         [package]\n\
@@ -329,7 +360,7 @@ fn rustdoc_json_for_lib(lib: &str) -> LibWithJson {
         ",
     );
 
-    write("lib.rs", lib);
+    write_file(&root, "lib.rs", lib);
 
     LibWithJson {
         json_path: rustdoc_json_path_for_temp_crate(&root),

--- a/rustdoc-json/CHANGELOG.md
+++ b/rustdoc-json/CHANGELOG.md
@@ -1,5 +1,8 @@
 # rustdoc-json
 
+## v0.9.10
+* Make renamed lib targets with `crate-type = ["rlib"]` work
+
 ## v0.9.9
 * Bump deps. Most notably `cargo-manifest` from `0.19.x` to `0.20.x` and `toml` from `0.8.x` to `1.x.y`.
 

--- a/rustdoc-json/src/builder.rs
+++ b/rustdoc-json/src/builder.rs
@@ -246,12 +246,23 @@ fn library_name(
         .ok_or_else(|| BuildError::VirtualManifest(manifest_path.as_ref().to_owned()))?;
 
     for target in &package.targets {
-        if target.kind.contains(&TargetKind::Lib) {
+        if target.kind.iter().any(is_library_target_kind) {
             return Ok(target.name.to_owned());
         }
     }
 
     Ok(package.name.into_inner())
+}
+
+fn is_library_target_kind(target_kind: &TargetKind) -> bool {
+    matches!(
+        target_kind,
+        TargetKind::Lib
+            | TargetKind::RLib
+            | TargetKind::DyLib
+            | TargetKind::CDyLib
+            | TargetKind::StaticLib
+    )
 }
 
 /// Color configuration for the output of `cargo rustdoc`.


### PR DESCRIPTION
Closes #877