### PR TITLE
Rename `cargo-public-api --verbose` to `--debug-processing`

### DIFF
--- a/cargo-public-api/src/api_source.rs
+++ b/cargo-public-api/src/api_source.rs
@@ -168,7 +168,7 @@ pub fn builder_from_args(argst: &ArgsAndToolchain) -> rustdoc_json::Builder {
 fn public_api_from_rustdoc_json(path: impl AsRef<Path>, args: &Args) -> Result<PublicApi> {
     let json_path = path.as_ref();
 
-    if args.verbose {
+    if args.debug_processing {
         println!("Processing {json_path:?}");
     }
 
@@ -197,7 +197,7 @@ If the issue remains, please report at
             )
         })?;
 
-    if args.verbose {
+    if args.debug_processing {
         public_api.missing_item_ids().for_each(|i| {
             println!("NOTE: rustdoc JSON missing referenced item with ID \"{i}\"");
         });

--- a/cargo-public-api/src/main.rs
+++ b/cargo-public-api/src/main.rs
@@ -92,10 +92,9 @@ pub struct Args {
 
     /// Show detailed info about processing.
     ///
-    /// For debugging purposes. The output is not stable and can change across
-    /// patch versions.
+    /// Only intended for debugging this tool.
     #[arg(global = true, long, hide = true)]
-    verbose: bool,
+    debug_processing: bool,
 
     /// Show the hidden "sorting prefix" that makes items nicely grouped
     ///
@@ -614,7 +613,7 @@ fn git_checkout(args: &Args, commit: &str) -> Result<()> {
     git_utils::git_checkout(
         &args.git_root()?,
         commit,
-        !args.verbose,
+        !args.debug_processing,
         args.diff_args()
             .map(|diff_args| diff_args.force)
             .unwrap_or_default(),

--- a/cargo-public-api/src/published_crate.rs
+++ b/cargo-public-api/src/published_crate.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 pub fn build_rustdoc_json(version: Option<&str>, argst: &ArgsAndToolchain) -> Result<PathBuf> {
     let args = &argst.args;
     let package_name = package_name_from_args(args).ok_or_else(|| anyhow!("You must specify a package with either `-p package-name` or `--manifest-path path/to/Cargo.toml`"))?;
-    let crate_ = http_get_crate(&package_name, args.verbose)?;
+    let crate_ = http_get_crate(&package_name, args.debug_processing)?;
     let crate_version = get_crate_version(&crate_, version)?;
     let build_dir = build_dir(args, &crate_version);
     std::fs::create_dir_all(&build_dir)?;

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -1018,11 +1018,11 @@ fn list_public_items_from_json_file() {
 }
 
 #[test]
-fn verbose() {
+fn debug_processing() {
     let mut cmd = TestCmd::new();
     cmd.arg("--manifest-path");
     cmd.arg("../test-apis/lint_error/Cargo.toml");
-    cmd.arg("--verbose");
+    cmd.arg("--debug-processing");
     cmd.assert()
         .stdout(contains("Processing \""))
         .stdout(contains("rustdoc JSON missing referenced item"))


### PR DESCRIPTION
So we can later introduce `-v` / `--verbose` as a shorthand for

    --include function-parameter-names

For symmetry with `-s` / `--simplified` for `--omit ...`.

I can't imagine that anyone depends on the current `--verbose`.

See https://github.com/cargo-public-api/cargo-public-api/issues/766#issuecomment-4394246165.