### PR TITLE
Re-export `rustdoc-types`

### DIFF
--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -13,6 +13,8 @@ repository = "https://github.com/cargo-public-api/cargo-public-api/tree/main/pub
 [features]
 default = ["snapshot-testing"]
 snapshot-testing = ["dep:snapshot-testing"]
+experimental-feature-that-can-be-removed-in-a-patch-release_re-export-rustdoc-types = [
+]
 
 [dependencies]
 hashbag = { version = "0.1.13", default-features = false }

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -34,6 +34,11 @@
 // deny in CI, only warn here
 #![warn(missing_docs)]
 
+#[cfg(
+    feature = "experimental-feature-that-can-be-removed-in-a-patch-release_re-export-rustdoc-types"
+)]
+pub use rustdoc_types;
+
 mod crate_wrapper;
 mod error;
 mod intermediate_public_item;


### PR DESCRIPTION
Re-export `rustdoc-types` under the feature `experimental-feature-that-can-be-removed-in-a-patch-release_re-export-rustdoc-types`.

Resolves #794.

Nits are welcome.