### PR TITLE
Bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "public-api"
-version = "0.52.0"
+version = "0.52.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cargo-public-api/Cargo.toml
+++ b/cargo-public-api/Cargo.toml
@@ -44,7 +44,7 @@ version = "0.9.10"
 
 [dependencies.public-api]
 path = "../public-api"
-version = "0.52.0"
+version = "0.52.1"
 
 [dependencies.serde]
 version = "1.0.179"

--- a/public-api/CHANGELOG.md
+++ b/public-api/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `public-api` changelog
 
+## v0.52.1
+* Re-export `rustdoc-types` under the feature `experimental-feature-that-can-be-removed-in-a-patch-release_re-export-rustdoc-types`.
+
 ## v0.52.0
 * Stop including function parameter names by default in the output. This avoids issues where renaming parameters shows up as API diffs.  This is especially relevant for trait impls, where fn parameter names are often `_`-prefixed.
 

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "public-api"
-version = "0.52.0"
+version = "0.52.1"
 description = "List and diff the public API of Rust library crates. Relies on rustdoc JSON output from the nightly toolchain."
 homepage = "https://github.com/cargo-public-api/cargo-public-api/tree/main/public-api"
 documentation = "https://docs.rs/public-api"

--- a/repo-tests/Cargo.toml
+++ b/repo-tests/Cargo.toml
@@ -7,5 +7,5 @@ license = "MIT"
 
 [dev-dependencies.public-api]
 path = "../public-api"
-version = "0.52.0"
+version = "0.52.1"
 


### PR DESCRIPTION
Hopefully, I did this right (ref: https://github.com/cargo-public-api/cargo-public-api/pull/895#pullrequestreview-4386485322). I assume a patch release is okay(?).

Aside, in the following link, I think `lib` should be `src`: https://github.com/cargo-public-api/cargo-public-api/blob/cafae1356b2fccb7e9c2250fced0aa71d4281f99/docs/RELEASE.md?plain=1#L67