### PR TITLE
ci: Do not run 'cargo audit' in Nightly CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,12 @@ permissions:
 
 on:
   workflow_call: # From .github/workflows/Release-*.yml, .github/workflows/Nightly.yml
+    inputs:
+      nightly-ci:
+        description: true if called from .github/workflows/Nightly.yml
+        type: boolean
+        default: false
+        required: false
   workflow_dispatch:
   pull_request:
   merge_group:
@@ -60,6 +66,8 @@ jobs:
       - run: lint_toolchain=1.95 ; rustup install $lint_toolchain --profile default && rustup default $lint_toolchain
       - run: cargo version --verbose # Make it easier to debug version-specific issues
       - run: ./scripts/lint.sh
+        env:
+          NIGHTLY_CI: ${{ inputs.nightly-ci }}
 
   cargo-test:
     strategy:

--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -19,6 +19,8 @@ jobs:
     permissions:
       contents: read # For actions/checkout in CI.yml
     uses: ./.github/workflows/CI.yml
+    with:
+      nightly-ci: true
 
   # Create an issue if Nightly CI fails unless there already is such an issue.
   create-issue-on-failure:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -26,11 +26,11 @@ cargo clippy \
 
 source ./scripts/utils.sh
 
-if if_command_exists_or_in_ci cargo-audit; then
+if if_command_exists_or_in_ci_but_not_nightly cargo-audit; then
     cargo audit --deny warnings
 fi
 
-if if_command_exists_or_in_ci cargo-deny; then
+if if_command_exists_or_in_ci_but_not_nightly cargo-deny; then
     cargo deny check
 fi
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -12,3 +12,17 @@ if_command_exists_or_in_ci() {
         return 1
     fi
 }
+
+# Tools like 'cargo audit' tend to give too many false positives for us. Don't
+# run them in Nightly CI to avoid annoying flakiness. Still run them for PRs and
+# releases however.
+if_command_exists_or_in_ci_but_not_nightly() {
+    command="$1"
+
+    if [ "${NIGHTLY_CI:-}" = "true" ]; then
+        echo "INFO: Not running \`$command\` because NIGHTLY_CI=true"
+        return 1
+    fi
+
+    if_command_exists_or_in_ci "$command"
+}


### PR DESCRIPTION
Because Nightly CI too often fails with "vulnerabilities" that are irrelevant for us. They are easy to fix if someone is making a PR anyway however, so let's keep enforcing for regular PRs (and releases).

Closes #904