### PR TITLE
Fix `MINIMUM_NIGHTLY_RUST_VERSION` and add tests enforcing it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -913,6 +913,7 @@ dependencies = [
  "pretty_assertions",
  "rustdoc-json",
  "rustdoc-types",
+ "rustup-toolchain",
  "serde",
  "serde_json",
  "snapshot-testing",

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install the `cargo public-api` subcommand with a recent regular **stable** Rust 
 cargo +stable install cargo-public-api
 ```
 
-Ensure **nightly-2025-08-02** or later is installed (does not need to be the active toolchain) so `cargo public-api` can build rustdoc JSON for you:
+Ensure **nightly-2025-11-22** or later is installed (does not need to be the active toolchain) so `cargo public-api` can build rustdoc JSON for you:
 
 ```sh
 rustup install nightly --profile minimal
@@ -153,12 +153,12 @@ cargo public-api -sss
 
 | Version          | Understands the rustdoc JSON output of  |
 | ---------------- | --------------------------------------- |
-| 0.50.x — 0.52.x  | nightly-2025-08-02 —                    |
+| 0.52.x           | nightly-2025-11-22 —                    |
+| 0.50.x — 0.51.x  | nightly-2025-08-02 — nightly-2025-11-21 |
 | 0.49.x           | nightly-2025-07-17 — nightly-2025-08-01 |
 | 0.48.x           | nightly-2025-06-22 — nightly-2025-07-16 |
 | 0.47.x           | nightly-2025-03-24 — nightly-2025-06-21 |
 | 0.46.x           | nightly-2025-03-16 — nightly-2025-03-23 |
-| 0.45.x           | nightly-2025-03-14 — nightly-2025-03-15 |
 | earlier versions | see [here](https://github.com/cargo-public-api/cargo-public-api/blob/main/scripts/release-helper/src/version_info.rs) |
 
 # Contributing

--- a/cargo-public-api/tests/cargo-public-api-bin-tests.rs
+++ b/cargo-public-api/tests/cargo-public-api-bin-tests.rs
@@ -213,12 +213,7 @@ fn debug_logging() {
 /// * [`MINIMUM_NIGHTLY_RUST_VERSION`] is not set too high
 /// * `cargo pubic-api` suggests the nightly toolchain might be too old when a
 ///   too old nightly toolchain is used
-///
-/// Note: If there is no rustdoc JSON incompatibilities in the previous version,
-/// this test will fail. In that case, feel to add an `#[ignore]` in the
-/// meantime.
 #[test]
-#[ignore = "this test assumes rustdoc JSON incomaptibilities in the previous version but that is not the case right now"]
 fn one_day_before_minimum_nightly_rust_version() {
     test_unusable_toolchain(
         TestCmd::with_proxy_toolchain(&get_toolchain_one_day_before_minimal_toolchain())

--- a/public-api/Cargo.toml
+++ b/public-api/Cargo.toml
@@ -50,6 +50,10 @@ default-features = false
 path = "../rustdoc-json"
 version = "0.9.10"
 
+[dev-dependencies.rustup-toolchain]
+path = "../rustup-toolchain"
+version = "0.1.10"
+
 [dev-dependencies.predicates]
 version = "3.1.4"
 default-features = false

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -67,7 +67,7 @@ pub use public_item::PublicItem;
 /// The rustdoc JSON format is still changing, so every now and then we update
 /// this library to support the latest format. If you use this version of
 /// nightly or later, you should be fine.
-pub const MINIMUM_NIGHTLY_RUST_VERSION: &str = "nightly-2025-08-02";
+pub const MINIMUM_NIGHTLY_RUST_VERSION: &str = "nightly-2025-11-22";
 // End-marker for scripts/release-helper/src/bin/update-version-info/main.rs
 
 /// See [`Builder`] method docs for what each field means.

--- a/public-api/src/lib.rs
+++ b/public-api/src/lib.rs
@@ -312,3 +312,35 @@ fn deserialize_without_recursion_limit(rustdoc_json_str: &str) -> Result<rustdoc
     deserializer.disable_recursion_limit();
     Ok(serde::de::Deserialize::deserialize(&mut deserializer)?)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::MINIMUM_NIGHTLY_RUST_VERSION;
+
+    /// The toolchain named by [`MINIMUM_NIGHTLY_RUST_VERSION`] must produce
+    /// rustdoc JSON that this version of the library can parse.
+    #[test]
+    fn minimum_nightly_rust_version_produces_parsable_rustdoc_json() {
+        rustup_toolchain::install(MINIMUM_NIGHTLY_RUST_VERSION).unwrap();
+
+        let build_dir = tempfile::tempdir().unwrap();
+
+        let rustdoc_json = rustdoc_json::Builder::default()
+            .manifest_path(Path::new("../test-apis/comprehensive_api/Cargo.toml"))
+            .toolchain(MINIMUM_NIGHTLY_RUST_VERSION)
+            .target_dir(build_dir.path())
+            .quiet(true)
+            .build()
+            .unwrap();
+
+        if let Err(e) = crate::Builder::from_rustdoc_json(&rustdoc_json).build() {
+            panic!(
+                "rustdoc JSON built with `MINIMUM_NIGHTLY_RUST_VERSION` \
+                 (`{MINIMUM_NIGHTLY_RUST_VERSION}`) cannot be parsed by this version of \
+                 `public-api`: {e}"
+            );
+        }
+    }
+}

--- a/scripts/release-helper/src/version_info.rs
+++ b/scripts/release-helper/src/version_info.rs
@@ -8,7 +8,7 @@ pub struct CargoPublicApiVersionInfo {
 pub static TABLE: &[CargoPublicApiVersionInfo] = &[
     CargoPublicApiVersionInfo {
         cargo_public_api_version: "0.52.x",
-        min_nightly_rust_version: "nightly-2025-08-02",
+        min_nightly_rust_version: "nightly-2025-11-22",
     },
     CargoPublicApiVersionInfo {
         cargo_public_api_version: "0.51.x",


### PR DESCRIPTION
Running `cargo-public-api` v. 0.52.x as a library using the readme example fails because `MINIMUM_NIGHTLY_RUST_VERSION` seems to have fallen out of sync leading to an incompatible unparseable rustdoc json output. This PR updates the minimum nightly rust version to the correct minimum, and adds a test enforcing that the minimum nightly toolchain version from the constant can actually successfully parse the rustdoc json output